### PR TITLE
feat: NSE only, sweep two, store everything (D-0017, D-0018)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,12 @@ A brute-force backtesting engine for Indian spot indices. It sweeps
 combinations of boolean market conditions over historical 1-minute bars and
 ranks what survives.
 
-**Engine surface — exactly three instruments:**
-`NSE-NIFTY`, `NSE-BANKNIFTY`, `BSE-SENSEX`.
+**Engine surface — exactly two instruments, NSE only:**
+`NSE-NIFTY`, `NSE-BANKNIFTY`.
+
+BSE and MCX are not swept and not pulled. Narrowed from three
+instruments by D-0017. Existing BSE data already on disk is not deleted --
+append-only history applies to the store as well.
 
 `NSE-INDIAVIX` is **reference only**: it is stored and it is stamped onto
 observable trades, but it never enters the condition vocabulary, never enters
@@ -47,8 +51,8 @@ CI gate 1 enforces this by walking every tracked file. It is not advisory.
 1. **No invention.** Every claim about a vendor, an exchange, an instrument or
    a cost is traceable to a source recorded in `docs/00-charter.md`. If you are
    unsure, write `UNVERIFIED` and stop.
-2. **No silent scope change.** The engine surface in §1 does not widen without
-   a new entry in `docs/05-decisions.md`.
+2. **No silent scope change.** The engine surface in §1 does not widen OR
+   narrow without a new entry in `docs/05-decisions.md`.
 3. **Reproducibility.** Every run is identified by
    `blake3(mask ‖ direction ‖ instrument ‖ timeframe ‖ params ‖ data_digest ‖
    vocab_version ‖ commit)`. No computation without that identity recorded.

--- a/crates/core/src/instrument.rs
+++ b/crates/core/src/instrument.rs
@@ -20,8 +20,8 @@
 //!
 //! # Storable is not sweepable
 //!
-//! `docs/00-charter.md` §1 stores futures, options and single stocks but
-//! sweeps exactly three instruments. [`InstrumentKey::is_sweepable`] is the
+//! `docs/00-charter.md` §1 stores every NSE instrument but sweeps exactly
+//! two, both on NSE. See D-0017 and D-0018. [`InstrumentKey::is_sweepable`] is the
 //! one place that distinction is decided, so widening it is a visible edit
 //! rather than a caller passing a different string.
 
@@ -247,11 +247,8 @@ impl InstrumentKey {
     /// `docs/00-charter.md` §1. India VIX is deliberately absent: it is stored
     /// and stamped onto trades, but it never enters the condition vocabulary,
     /// ranking, or run identity.
-    pub const SWEPT: [(Exchange, &'static str); 3] = [
-        (Exchange::Nse, "NIFTY"),
-        (Exchange::Nse, "BANKNIFTY"),
-        (Exchange::Bse, "SENSEX"),
-    ];
+    pub const SWEPT: [(Exchange, &'static str); 2] =
+        [(Exchange::Nse, "NIFTY"), (Exchange::Nse, "BANKNIFTY")];
 
     /// Builds a spot index key.
     ///
@@ -415,19 +412,49 @@ mod tests {
     }
 
     #[test]
-    fn exactly_three_instruments_are_sweepable() {
+    fn exactly_two_nse_instruments_are_sweepable() {
         assert!(nifty().is_sweepable());
         assert!(
             InstrumentKey::index(Exchange::Nse, "BANKNIFTY")
                 .expect("valid")
                 .is_sweepable()
         );
+        assert_eq!(InstrumentKey::SWEPT.len(), 2);
         assert!(
-            InstrumentKey::index(Exchange::Bse, "SENSEX")
-                .expect("valid")
-                .is_sweepable()
+            InstrumentKey::SWEPT
+                .iter()
+                .all(|&(ex, _)| ex == Exchange::Nse),
+            "the swept set is NSE-only; see D-0017"
         );
-        assert_eq!(InstrumentKey::SWEPT.len(), 3);
+    }
+
+    #[test]
+    fn sensex_is_storable_but_no_longer_swept() {
+        // D-0017 narrowed the engine surface from three instruments to two.
+        // SENSEX bars already on disk are not deleted -- append-only history
+        // applies to the store too -- but the engine will not sweep them.
+        let sensex = InstrumentKey::index(Exchange::Bse, "SENSEX").expect("valid");
+        assert!(!sensex.is_sweepable());
+        assert_eq!(
+            sensex.require_sweepable(),
+            Err(InstrumentError::NotSweepable)
+        );
+    }
+
+    #[test]
+    fn an_nse_equity_is_storable_and_not_swept() {
+        // D-0018: every NSE instrument is STORED, and the sweep stays at the
+        // two indices until a two-instrument sweep earns the widening. This
+        // test is what would fail if someone widened the surface silently.
+        for s in ["RELIANCE", "HINDALCO", "TCS"] {
+            let eq = InstrumentKey {
+                exchange: Exchange::Nse,
+                segment: Segment::Cash,
+                underlying: Symbol::new(s).expect("valid"),
+                kind: Kind::Equity,
+            };
+            assert!(!eq.is_sweepable(), "{s} must not be swept yet");
+        }
     }
 
     #[test]

--- a/docs/00-charter.md
+++ b/docs/00-charter.md
@@ -7,13 +7,13 @@ because a prohibition survives a rewrite better than a goal does.
 
 ## 1. Scope lock
 
-**The engine sweeps exactly three instruments.**
+**The engine sweeps exactly two instruments, both on NSE.** Narrowed from
+three by D-0017: `BSE-SENSEX` is no longer swept and BSE is no longer pulled.
 
 | Symbol | Exchange | Segment |
 |---|---|---|
 | `NSE-NIFTY` | NSE | INDEX |
 | `NSE-BANKNIFTY` | NSE | INDEX |
-| `BSE-SENSEX` | BSE | INDEX |
 
 `NSE-INDIAVIX` is **reference only** — stored, stamped onto observable trades
 as `vix_at_entry` / `vix_at_exit`, and never in the condition vocabulary, the

--- a/docs/05-decisions.md
+++ b/docs/05-decisions.md
@@ -367,6 +367,80 @@ version before the toolchain itself turned out to be the constraint.
 
 ---
 
+## D-0017 · 2026-08-01 · NSE only; the swept surface narrows from three to two
+
+**Decision.** The engine sweeps **`NSE-NIFTY` and `NSE-BANKNIFTY`**. BSE and
+MCX are not pulled. `BSE-SENSEX` is no longer swept.
+
+**Rejected — keeping `BSE-SENSEX`.** It is the shortest series by a wide
+margin: the lake holds SENSEX from **2022-09-01** against 2020-01 for the two
+NSE indices. Any three-instrument result is therefore silently capped at the
+shortest history, and a window chosen to include SENSEX throws away 2 years 8
+months of NIFTY and BANKNIFTY data without saying so. Dropping it removes the
+cap rather than working around it.
+
+**Rejected — deleting BSE data already on disk.** Append-only history applies
+to the store, not only to condition bits. Existing SENSEX bars stay; the
+engine simply will not sweep them, and `is_sweepable` says so in one place.
+
+**Why this is a narrowing and still needs an entry.** Golden rule 2 previously
+said the surface "does not widen" without a ledger entry. That was a gap: a
+*narrowing* silently changes every historical comparison just as much, because
+a result set produced over three instruments is not comparable with one
+produced over two. The rule now reads "widen OR narrow", and this entry is the
+first use of it.
+
+---
+
+## D-0018 · 2026-08-01 · Store every NSE instrument; sweep two until one earns the widening
+
+**Decision.** `pull` fetches and stores **every NSE instrument** — 12,460 cash
+and 78,163 F&O rows in the vendor's own instrument master, 90,623 in total.
+The **sweep** stays at the two indices until a two-instrument sweep produces a
+profitable result.
+
+**Rejected — sweeping all NSE equities now.** Total sweep work is linear in
+symbols: 2 → ~750 is **375× the compute**, paid before anything has been shown
+to work. `docs/06-limits.md` §4 still records that a full production sweep has
+never been run. The same discipline as D-0015: build the capability, defer the
+spend.
+
+**Rejected — storing only the two indices.** Storage is cheap and re-pulling
+is not. With every NSE instrument on disk, widening the sweep later is one
+ledger entry and **zero re-pulling**. Pulling narrowly now would make the
+widening a multi-hour vendor-bound operation instead of a config change.
+
+**What widening will require, and is not solved today.** Indices never split;
+equities do. An unadjusted 1:5 split is a **fake 80% overnight crash**, and
+every condition fires on it — `gap_down_day`, `bar_bearish`,
+`close_below_ema200`, the whole bar-shape family. There is no corporate-action
+handling anywhere in this design, and the lake survey never looked for one
+because indices do not need it.
+
+The offsetting gain, recorded so it is not forgotten: equities carry **real
+traded volume**, so VWAP bits 52–53 stop abstaining. On the index surface they
+are permanently dead by construction.
+
+**Behaviour when a corporate action is met: refuse the window, loudly.** A
+suspected split or bonus — an unexplained overnight gap beyond a threshold —
+causes the sweep to **refuse that window and name the date**, rather than
+producing a result built on a fake crash. This follows
+`docs/00-charter.md` prohibition 6: degrade loudly and name the reason, or
+refuse; never silently.
+
+**Rejected — back-adjusting prices from a corporate-action feed.** It is what
+charting vendors do and it is the eventual right answer, but none of the four
+vendors has been *verified* to supply split and bonus records. Building on an
+unverified source would put a fabricated price into the store, which is worse
+than refusing. Upgrading later invalidates no stored bar, because raw prices
+are what is stored.
+
+**Rejected — sweeping raw prices and ignoring the problem.** Cheapest, and it
+contradicts prohibition 6 outright. A spurious signal that looks real is the
+failure mode this repository is organised against.
+
+---
+
 ## How to add an entry
 
 Next free ID, today's date, the decision in one sentence, the alternative


### PR DESCRIPTION
Two operator decisions, recorded before any code depends on them.

## D-0017 — swept surface narrows 3 → 2

`BSE-SENSEX` is no longer swept; BSE and MCX are no longer pulled.

**The reason is in the data:** the lake holds SENSEX only from **2022-09-01**, against 2020-01 for the two NSE indices. Every three-instrument result was silently capped at the shortest series — throwing away 2y8m of NIFTY/BANKNIFTY without saying so.

SENSEX bars already on disk are **not deleted**. Append-only history applies to the store, not just to condition bits.

**This exposed a gap in golden rule 2**, which said the surface "does not widen" without a ledger entry. A *narrowing* changes every historical comparison just as much. The rule now reads **"widen OR narrow"**.

## D-0018 — store all NSE, sweep two

Pull and store **all 90,623 NSE instruments** (12,460 cash + 78,163 F&O). Keep the sweep at NIFTY + BANKNIFTY until a two-instrument sweep turns a profit.

| | |
|---|---|
| Sweep 2 → ~750 symbols | **375× the compute** |
| Full production sweep run so far | **never** (`06-limits` §4) |
| Cost of storing wide now | ~nothing |
| Cost of widening later | one ledger entry, **zero re-pulling** |

## The hazard recorded now, not discovered later

**Indices never split. Equities do.** An unadjusted 1:5 split is a **fake 80% overnight crash**, and every condition fires on it — `gap_down_day`, `bar_bearish`, `close_below_ema200`, the whole bar-shape family.

**Decided behaviour: refuse the window and name the date**, per charter prohibition 6. Adjusting from a vendor feed was rejected *for now* — no vendor is **verified** to supply split/bonus records, and building on an unverified source would put a fabricated price in the store.

**The gain:** equities carry real volume, so **VWAP bits 52–53 stop abstaining**. On indices they're permanently dead.

## Verified on 1.97.1

| Gate | Result |
|---|---|
| clippy `-D warnings` | CLEAN |
| tests | **40 passed** + 1 doc-test |
| coverage | **942/942 regions · 78/78 fns · 547/547 lines — 100.00%** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)