### PR TITLE
feat(api): server-rendered instrument HTML, no JavaScript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,16 @@ jobs:
         if: steps.probe.outputs.has_crates == 'true'
         run: cargo fmt --all --check
 
+      # `--offline` only succeeds if every crate is already in CARGO_HOME.
+      # A newly added dependency has never been downloaded on a runner, so
+      # gate 4 structurally rejected the FIRST dependency the workspace ever
+      # gained -- it passed until now only because there were none. Fetching
+      # with --locked first preserves the whole point of the gate (build the
+      # EXACT locked versions, resolve nothing) while letting it actually run.
+      - name: Gate 4a — fetch exactly what the lock names
+        if: steps.probe.outputs.has_crates == 'true'
+        run: cargo fetch --locked
+
       - name: Gate 4 — locked, offline
         if: steps.probe.outputs.has_crates == 'true'
         run: cargo build --workspace --locked --offline --all-targets

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,520 @@
 version = 4
 
 [[package]]
+name = "api"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "core",
+ "tokio",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "core"
 version = "0.1.0"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "http"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "serde"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.151"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # The intended final graph is in docs/01-architecture.md §1, in the order the
 # crates are built:
 #   core → store → vocab → indicators → engine → pull → api → web → cli
-members = ["crates/core"]
+members = ["crates/core", "crates/api"]
 
 [workspace.package]
 version      = "0.1.0"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name         = "api"
+version      = { workspace = true }
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+publish      = { workspace = true }
+description  = "HTTP surface. Server-rendered HTML; no JavaScript anywhere."
+
+# docs/01-architecture.md gives api `core`, `store` and `engine` as its
+# permitted dependencies. That is a MAXIMUM, not a requirement -- store and
+# engine do not exist yet, so today it depends on core alone and will gain the
+# others when they land.
+[dependencies]
+core   = { path = "../core", package = "core" }
+axum   = { workspace = true }
+tokio  = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -12,7 +12,14 @@ description  = "HTTP surface. Server-rendered HTML; no JavaScript anywhere."
 # engine do not exist yet, so today it depends on core alone and will gain the
 # others when they land.
 [dependencies]
-core   = { path = "../core", package = "core" }
+# A version is required alongside the path: deny.toml sets
+# wildcards = "deny", and a path dependency with no version IS a wildcard.
+# Relaxing the ban was rejected -- it protects registry crates too.
+# `package` is an explicit rename: the PACKAGE is `core` but its lib target
+# is `brutex_core` (a lib named `core` shadows the sysroot crate and breaks
+# rustdoc). This restores `use core::...` here while keeping the dependency
+# KEY as `core`, which is what gates 7 and 9 match on.
+core   = { path = "../core", package = "core", version = "0.1.0" }
 axum   = { workspace = true }
 tokio  = { workspace = true }
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1,0 +1,10 @@
+//! HTTP surface. Server-rendered HTML, no JavaScript anywhere.
+//!
+//! `docs/01-architecture.md` permits this crate `core`, `store` and `engine`.
+//! That is a maximum, not a requirement: `store` and `engine` do not exist
+//! yet, so today it depends on `core` alone and will gain the others when they
+//! land.
+
+#![forbid(unsafe_code)]
+
+pub mod render;

--- a/crates/api/src/render.rs
+++ b/crates/api/src/render.rs
@@ -1,0 +1,397 @@
+//! Turning instruments into HTML.
+//!
+//! # Why HTML is rendered on the server
+//!
+//! `CLAUDE.md` §2 allows `.rs`, `.toml`, `.md`, `.lock`, `.html`, `.css` and
+//! `.yml`. **`.js` is not on that list**, and CI gate 1 walks every tracked
+//! file — so a browser UI here cannot be a script framework.
+//!
+//! Two routes remain. WebAssembly is one, but `crates/web` is permitted
+//! exactly one dependency (`core`) and a wasm binary cannot touch the DOM
+//! without `wasm-bindgen`, so that route is blocked on a decision nobody has
+//! taken. Server-rendered HTML is the other, and it needs no decision at all:
+//! the server already holds the data and `core` already holds every display
+//! rule.
+//!
+//! # Why escaping is not optional
+//!
+//! Instrument symbols come from a vendor file. A vendor is not an attacker,
+//! but a vendor is also not a validator, and `<` in a symbol would break the
+//! page. [`Symbol`](core::symbol::Symbol) already refuses every byte outside
+//! `A-Z 0-9 - _ &`, so the dangerous characters cannot reach here — but `&`
+//! **can**, and an unescaped `&` produces malformed HTML. Escaping is applied
+//! anyway, because a rule that depends on a guarantee two crates away is a
+//! rule that breaks when that guarantee moves.
+//!
+//! # Cost
+//!
+//! Rendering is **O(rows on the page)**, never O(rows in the universe). A page
+//! shows what a person can read; the other 90,000 instruments cost nothing
+//! because they are never touched.
+
+use core::instrument::{InstrumentKey, Kind};
+use std::fmt::Write as _;
+
+/// The stylesheet, inlined so the page is a single response.
+///
+/// Kept here rather than in a `.css` file on purpose: one file means one
+/// request and no second route to serve, and the page is small enough that
+/// splitting it would be organisation for its own sake.
+const STYLE: &str = "\
+body{font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;margin:2rem;color:#111;background:#fff}\
+h1{font-size:1.1rem;margin:0 0 .25rem}\
+p.sub{color:#666;margin:0 0 1.25rem}\
+table{border-collapse:collapse;width:100%}\
+th,td{text-align:left;padding:.35rem .6rem;border-bottom:1px solid #e5e5e5;white-space:nowrap}\
+th{background:#fafafa;font-weight:600;border-bottom:2px solid #ddd}\
+td.num{text-align:right;font-variant-numeric:tabular-nums}\
+tr:hover td{background:#f6f9ff}\
+.tag{font-size:11px;padding:.1rem .4rem;border-radius:3px;background:#eef;color:#334}\
+.swept{background:#e6f7e6;color:#141}\
+footer{margin-top:1.5rem;color:#888;font-size:12px}";
+
+/// Escapes the five characters that change HTML meaning.
+///
+/// # Examples
+///
+/// ```
+/// # use api::render::escape;
+/// assert_eq!(escape("M&M"), "M&amp;M");
+/// assert_eq!(escape("NIFTY"), "NIFTY");
+/// ```
+#[must_use]
+pub fn escape(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for c in raw.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// One row of the instruments table.
+#[derive(Debug, Clone, Copy)]
+pub struct Row {
+    /// The canonical identity.
+    pub key: InstrumentKey,
+    /// Whether the primary broker's master listed it.
+    pub from_groww: bool,
+    /// Whether the secondary broker's master listed it.
+    pub from_dhan: bool,
+}
+
+/// Renders one row's kind, expiry and strike cells.
+fn kind_cells(kind: Kind) -> String {
+    match kind {
+        Kind::Index => "<td>Index</td><td>—</td><td class=\"num\">—</td>".to_owned(),
+        Kind::Equity => "<td>Equity</td><td>—</td><td class=\"num\">—</td>".to_owned(),
+        Kind::Future { expiry } => {
+            format!("<td>Future</td><td>{expiry}</td><td class=\"num\">—</td>")
+        }
+        Kind::Option {
+            expiry,
+            strike,
+            side,
+        } => {
+            // Strike is paisa; a human reads rupees. core owns the split so the
+            // browser and the server cannot disagree about it.
+            format!(
+                "<td>Option {}</td><td>{}</td><td class=\"num\">{}.{:02}</td>",
+                side.as_str(),
+                expiry,
+                strike.rupees_trunc(),
+                strike.paisa_part().abs()
+            )
+        }
+    }
+}
+
+/// Renders the vendor column, which is the visible proof of deduplication.
+///
+/// When both brokers list the same contract they resolve to one
+/// [`InstrumentKey`] and therefore one row — so seeing `groww · dhan` in a
+/// single row *is* the O(1) dedup, on screen.
+fn vendor_cell(row: &Row) -> String {
+    let mut tags = Vec::new();
+    if row.from_groww {
+        tags.push("<span class=\"tag\">groww</span>");
+    }
+    if row.from_dhan {
+        tags.push("<span class=\"tag\">dhan</span>");
+    }
+    format!("<td>{}</td>", tags.join(" "))
+}
+
+/// Renders a complete instruments page.
+///
+/// `total` is the size of the whole universe, `rows` is only what this page
+/// shows. Passing both keeps the page honest about the difference between what
+/// exists and what was rendered.
+#[must_use]
+pub fn instruments_page(title: &str, total: usize, rows: &[Row]) -> String {
+    let mut body = String::with_capacity(1024 + rows.len() * 256);
+    body.push_str("<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">");
+    body.push_str("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
+    body.push_str("<title>");
+    body.push_str(&escape(title));
+    body.push_str("</title><style>");
+    body.push_str(STYLE);
+    body.push_str("</style></head><body>");
+
+    body.push_str("<h1>");
+    body.push_str(&escape(title));
+    body.push_str("</h1>");
+    // Writing to a String is infallible, so the Result is deliberately
+    // discarded rather than unwrapped -- `unwrap_used` and `expect_used` are
+    // denied workspace-wide and neither belongs in a renderer.
+    let _ = write!(
+        body,
+        "<p class=\"sub\">{total} instruments total · showing {} · \
+         a green row is one of the two the engine sweeps</p>",
+        rows.len()
+    );
+
+    body.push_str(
+        "<table><thead><tr>\
+         <th>Canonical key</th><th>Vendors</th><th>Underlying</th>\
+         <th>Kind</th><th>Expiry</th><th>Strike</th>\
+         </tr></thead><tbody>",
+    );
+
+    for row in rows {
+        let swept = if row.key.is_sweepable() {
+            " class=\"swept\""
+        } else {
+            ""
+        };
+        let _ = write!(
+            body,
+            "<tr{}><td>{}</td>{}<td>{}</td>{}</tr>",
+            swept,
+            escape(&row.key.to_string()),
+            vendor_cell(row),
+            escape(row.key.underlying.as_str()),
+            kind_cells(row.key.kind),
+        );
+    }
+
+    body.push_str("</tbody></table>");
+    body.push_str(
+        "<footer>Rendered on the server. No JavaScript — \
+         CLAUDE.md section 2 does not permit it, and CI gate 1 enforces that.</footer>",
+    );
+    body.push_str("</body></html>");
+    body
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::indexing_slicing,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+mod tests {
+    use super::*;
+    use core::instrument::{Exchange, Expiry, OptionSide, Segment};
+    use core::price::Paisa;
+    use core::symbol::Symbol;
+
+    fn nifty() -> InstrumentKey {
+        InstrumentKey::index(Exchange::Nse, "NIFTY").expect("valid")
+    }
+
+    fn opt() -> InstrumentKey {
+        InstrumentKey {
+            exchange: Exchange::Nse,
+            segment: Segment::Fno,
+            underlying: Symbol::new("NIFTY").expect("valid"),
+            kind: Kind::Option {
+                expiry: Expiry::new(2026, 8, 4).expect("valid"),
+                strike: Paisa::from_raw(1_945_000),
+                side: OptionSide::Call,
+            },
+        }
+    }
+
+    #[test]
+    fn escapes_every_html_significant_character() {
+        assert_eq!(escape("a&b"), "a&amp;b");
+        assert_eq!(escape("a<b"), "a&lt;b");
+        assert_eq!(escape("a>b"), "a&gt;b");
+        assert_eq!(escape("a\"b"), "a&quot;b");
+        assert_eq!(escape("a'b"), "a&#39;b");
+        assert_eq!(escape("NIFTY"), "NIFTY", "ordinary text is untouched");
+        assert_eq!(escape(""), "");
+    }
+
+    #[test]
+    fn an_ampersand_symbol_cannot_break_the_page() {
+        // Symbol permits '&' -- M&M is a real NSE listing -- so this is the
+        // one dangerous character that genuinely reaches the renderer.
+        let key = InstrumentKey {
+            exchange: Exchange::Nse,
+            segment: Segment::Cash,
+            underlying: Symbol::new("M&M").expect("valid"),
+            kind: Kind::Equity,
+        };
+        let html = instruments_page(
+            "x",
+            1,
+            &[Row {
+                key,
+                from_groww: true,
+                from_dhan: false,
+            }],
+        );
+        assert!(html.contains("M&amp;M"), "the ampersand must be escaped");
+        assert!(
+            !html.contains("<td>M&M<"),
+            "a raw ampersand must never reach the output"
+        );
+    }
+
+    #[test]
+    fn a_swept_instrument_is_marked_and_others_are_not() {
+        let html = instruments_page(
+            "NSE",
+            2,
+            &[
+                Row {
+                    key: nifty(),
+                    from_groww: true,
+                    from_dhan: true,
+                },
+                Row {
+                    key: opt(),
+                    from_groww: true,
+                    from_dhan: false,
+                },
+            ],
+        );
+        assert_eq!(
+            html.matches("class=\"swept\"").count(),
+            1,
+            "exactly one of these two is swept"
+        );
+    }
+
+    #[test]
+    fn both_vendors_on_one_row_is_the_visible_dedup() {
+        let html = instruments_page(
+            "x",
+            1,
+            &[Row {
+                key: nifty(),
+                from_groww: true,
+                from_dhan: true,
+            }],
+        );
+        assert!(html.contains(">groww<"));
+        assert!(html.contains(">dhan<"));
+        assert_eq!(html.matches("<tr").count(), 2, "header plus ONE data row");
+    }
+
+    #[test]
+    fn a_single_vendor_row_shows_only_that_vendor() {
+        let only_dhan = instruments_page(
+            "x",
+            1,
+            &[Row {
+                key: nifty(),
+                from_groww: false,
+                from_dhan: true,
+            }],
+        );
+        assert!(only_dhan.contains(">dhan<"));
+        assert!(!only_dhan.contains(">groww<"));
+    }
+
+    #[test]
+    fn every_kind_renders_its_own_cells() {
+        assert!(kind_cells(Kind::Index).contains("Index"));
+        assert!(kind_cells(Kind::Equity).contains("Equity"));
+
+        let fut = kind_cells(Kind::Future {
+            expiry: Expiry::new(2026, 9, 29).expect("valid"),
+        });
+        assert!(fut.contains("Future") && fut.contains("2026-09-29"));
+
+        let call = kind_cells(Kind::Option {
+            expiry: Expiry::new(2026, 8, 4).expect("valid"),
+            strike: Paisa::from_raw(1_945_000),
+            side: OptionSide::Call,
+        });
+        assert!(call.contains("Option CE"), "side must be shown");
+        assert!(
+            call.contains("19450.00"),
+            "1,945,000 paisa reads as 19450.00 rupees, not as paisa"
+        );
+
+        let put = kind_cells(Kind::Option {
+            expiry: Expiry::new(2026, 8, 4).expect("valid"),
+            strike: Paisa::from_raw(2_700_050),
+            side: OptionSide::Put,
+        });
+        assert!(put.contains("Option PE"));
+        assert!(put.contains("27000.50"), "the paisa part must not be lost");
+    }
+
+    #[test]
+    fn the_page_states_the_true_total_not_the_rendered_count() {
+        // Rendering is O(rows shown). The page must not imply it looked at
+        // more than it did, nor hide how large the universe is.
+        let html = instruments_page(
+            "NSE FNO",
+            90_623,
+            &[Row {
+                key: nifty(),
+                from_groww: true,
+                from_dhan: true,
+            }],
+        );
+        assert!(html.contains("90623 instruments total"));
+        assert!(html.contains("showing 1"));
+    }
+
+    #[test]
+    fn an_empty_page_is_still_well_formed() {
+        let html = instruments_page("nothing here", 0, &[]);
+        assert!(html.starts_with("<!doctype html>"));
+        assert!(html.ends_with("</html>"));
+        assert!(html.contains("<tbody></tbody>"));
+        assert_eq!(html.matches("<tr").count(), 1, "header row only");
+    }
+
+    #[test]
+    fn the_page_contains_no_script_at_all() {
+        // CLAUDE.md section 2 does not permit JavaScript, and a renderer that
+        // emitted a <script> tag would smuggle it past gate 1, which only
+        // inspects tracked FILES.
+        let html = instruments_page(
+            "x",
+            1,
+            &[Row {
+                key: opt(),
+                from_groww: true,
+                from_dhan: true,
+            }],
+        );
+        for forbidden in ["<script", "javascript:", "onclick", "onload", "onerror"] {
+            assert!(!html.contains(forbidden), "{forbidden} must never appear");
+        }
+    }
+
+    #[test]
+    fn the_title_is_escaped_too() {
+        let html = instruments_page("<b>x</b>", 0, &[]);
+        assert!(html.contains("&lt;b&gt;x&lt;/b&gt;"));
+        assert!(!html.contains("<b>x</b>"));
+    }
+}


### PR DESCRIPTION
The crate that lets a person **look** at the data.

## Why server-rendered, not a frontend app

`CLAUDE.md` §2 allows `rs toml md lock html css yml`. **`.js` is not on that list** and gate 1 walks every tracked file.

WebAssembly is the only other route, and it's **blocked**: `crates/web` is permitted exactly one dependency (`core`), but a wasm binary can't touch the DOM without `wasm-bindgen`. That contradiction between `docs/01-architecture.md` §2 and gate 7 is real and still unresolved — **this crate sidesteps it rather than quietly relaxing the gate.**

## The vendor column IS the dedup, visible

When both brokers list the same contract they resolve to one `InstrumentKey` → **one row**. Seeing `groww · dhan` together in a single row is O(1) dedup on screen. Pinned by a test asserting **exactly one data row for two vendors**.

## Three things the tests pin

| Test | Why |
|---|---|
| No `<script`, `javascript:`, `onclick`, `onload`, `onerror` | Gate 1 inspects **files** — it cannot see a string built at runtime |
| `M&M` → `M&amp;M` | A real NSE listing. `Symbol` permits `&`, and unescaped it breaks the page |
| `2_700_050` → `27000.50` | Strike is paisa, humans read rupees — the paisa part must not vanish |

## Honest about cost

The page states the **true universe size** and the **rendered count** separately. Rendering is **O(rows on the page)**, never O(rows in the universe) — and the page shouldn't imply it looked at more than it did.

## Verified on 1.97.1

| Gate | Result |
|---|---|
| clippy `-D warnings` | CLEAN |
| tests | **66 + 2 doc-tests** |
| coverage | **1724/1724 regions · 117/117 fns · 965/965 lines — 100.00%** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)