### PR TITLE
docs: the lake is the source of F&O history (D-0021..D-0023)

### DIFF
--- a/docs/05-decisions.md
+++ b/docs/05-decisions.md
@@ -509,6 +509,100 @@ fabrication.
 
 ---
 
+## D-0021 · 2026-08-01 · The lake is the source of F&O history; neither broker is
+
+**Decision.** Expired option and future history comes from the **existing lake
+on local disk**. Vendor APIs backfill only what the lake is missing. No
+historical F&O data is purchased.
+
+**Measured, not assumed** — a full survey of `~/.brutex/lake/bars/NSE/FNO`:
+
+| | |
+|---|---|
+| Contract directories | **116,086** — 115,927 options, 159 futures |
+| NIFTY option contracts | **60,996**, expiring **2020-01-02 → 2026-08-25** |
+| BANKNIFTY options | 54,931 |
+| Underlyings | NIFTY and BANKNIFTY only — no single stocks |
+| On disk | **18 GB**, 196,954 parquet files, **zero empty directories** |
+| **Absent from BOTH live vendor masters** | **115,272 — 99.3%** |
+
+Both brokers purge on expiry: the earliest index-option expiry in either live
+master is **2026-08-04**, three days after this measurement. Relying on the
+masters alone would lose 99.3% of the history that is already owned.
+
+**Contract identity is preserved independently of the directory names.**
+`~/.brutex/lake/registry.duckdb` holds a `contracts` table of **169,530 rows**
+(`exch, underlying, expiry_date, contract_symbol, strike, side,
+candle_status`), spanning NIFTY 2020-01-02 → 2026-12-29. **No on-disk
+directory is unknown to the registry.**
+
+**Option bars already carry computed greeks** — `iv, delta, gamma, theta,
+vega, rho, spot_at_bar, t_years_used, rate_used, greeks_provenance_id` — 17
+columns in total. The tick vendor quoted for this data **excludes greeks
+explicitly**.
+
+**Rejected — buying historical F&O.** Two quotes exist, ₹1,15,050 and
+₹3,04,787, for a superset of data already on disk, minus the greeks.
+
+**Rejected — refetching from the brokers.** 116,086 contracts against a rate
+limit, to reproduce what is already local.
+
+**The one real gap.** The registry knows **~15,900 contracts, almost entirely
+expiry-year 2024**, that have no bars on disk. That — and only that — is what
+a vendor backfill is for.
+
+---
+
+## D-0022 · 2026-08-01 · The converter is a numeric boundary, not a copy
+
+**Decision.** The lake→store converter **converts**; it does not transfer
+bytes. Two transformations are mandatory and each is a correctness boundary:
+
+| Lake | Store |
+|---|---|
+| prices as `double` | **`i64` paisa** — `CLAUDE.md` §7 |
+| `timestamp` INT64 µs **UTC** | same, but IST is UTC + 19,800 s at every display |
+
+**Why this is recorded rather than assumed.** The lake stores option OHLC as
+IEEE doubles. `CLAUDE.md` §7 says prices are paisa integers and never a float.
+A converter written as a copy would carry doubles into a store whose entire
+addressing and comparison model assumes integers. The spot survey measured the
+maximum deviation of `x·100` from an integer at **9.3 × 10⁻¹⁰ paisa**, so the
+conversion is exact — but it must actually happen.
+
+**Rejected — widening the store record to hold a float.** D-0002 and D-0011
+fix the 56-byte stride permanently.
+
+---
+
+## D-0023 · 2026-08-01 · Verified vendor capability for expired contracts
+
+**Decision.** Recorded as verified external facts, with the route that
+verified each, because two earlier claims in this session were wrong and were
+corrected only by going to the live source.
+
+| Fact | Route | Lane |
+|---|---|---|
+| Groww `/v1/historical/{expiries,contracts,candles}` exist; FNO **"available from 2020"**; `year` accepts **"2020 - current year"**; `groww_symbol` is constructible as Exchange·Symbol·`DDMmmYY`·Strike·`CE/PE/FUT`; 1-minute window **30 days** | `curl` on `groww.in`, server-rendered, three URLs with three distinct hashes and 24 content markers | verified |
+| The Groww endpoint is live | `curl` → **`401 "Missing token in request."`** — not a 404 | verified |
+| Dhan `/v2/charts/rollingoption`: **45 days** per call, intervals `1/5/15/30/60`, strike enum `ATM, ATM+10, ATM-10`, **last 5 years rolling**, index **and** stock options, returns IV/OI/spot | **live browser** on `docs.dhanhq.co` | verified |
+| **Dhan cannot reach 2020-01.** Five years *rolling* puts the floor at ~2021-08 and moving | live browser | verified |
+| Dhan has **no expired-futures endpoint** | live browser | verified |
+| Rate limits, either vendor · Dhan Data-API pricing · any behaviour with a real token | — | **UNVERIFIED** |
+
+**The method matters, and is part of the decision.** Dhan's documentation is a
+JavaScript application: three different URLs return one byte-identical 33,884
+byte shell to `curl`, containing **zero** content markers. Reading it without a
+browser produced a mangled capture from which a **non-existent `ATM±3` rule**
+was reconstructed and reported as fact. Groww's documentation is
+server-rendered and `curl` receives it intact — but `groww.in` is blocked in
+both browsers by policy, so `curl` is the only route available there.
+
+**No vendor claim enters this repository without naming the route that
+produced it.**
+
+---
+
 ## How to add an entry
 
 Next free ID, today's date, the decision in one sentence, the alternative

--- a/docs/06-limits.md
+++ b/docs/06-limits.md
@@ -119,6 +119,30 @@ exactly the mistake the read-only-mapping decision was made to avoid.
 
 ---
 
+## 7b. What a green gate does not prove — measured 2026-08-01
+
+Four adversarial audits ran against a tree where **CI was green, 66 tests
+passed and coverage read 100.00%**. They found 11 CRITICAL and 17 HIGH
+defects. Two are worth keeping here permanently, because they are the shape of
+the mistake rather than an instance of it:
+
+| Defect | Why every gate stayed green |
+|---|---|
+| The decoder could not read **NIFTY**. `underlying_symbol` is empty on all 4,104 Groww cash/index rows, and the test fed a **different column** than the code reads. | Coverage proves lines ran. It cannot prove they ran on data shaped like reality. |
+| **All 200,460 Dhan rows were discarded** and reported as a routine `ForeignSegment` skip, because Dhan writes segments as single letters. | A mapping bug was indistinguishable from a legitimate refusal. |
+
+The rule both produce: **a test built from a hand-written fixture proves the
+code runs; only a test built from a real vendor row proves it is right.**
+
+Ten further findings shared one shape — a guard that silently turns a step into
+a no-op (`[ -d benches ]`, `[ -f crates/web/… ]`, status `—`, `|| true`, a
+non-member crate, a missing `[lints]`). Gate 8 is the live example: it probes
+for a **repository-root** `benches/`, but Cargo benches live at
+`crates/<name>/benches/`, so C-01..C-04 are unenforceable **in perpetuity**,
+not merely until benches are written.
+
+---
+
 ## 8. Open questions, carried forward
 
 | Question | Status |
@@ -127,6 +151,10 @@ exactly the mistake the read-only-mapping decision was made to avoid.
 | Secondary-vendor India VIX candle availability | undocumented — treat as a hard gate |
 | Primary-vendor per-second request cap | undocumented; the production ceiling is a chosen value, not a measured one |
 | ~~Whether a bar timestamp marks the open or the close of its minute~~ | **RESOLVED — open.** See §9. |
+
+| Rate limits for either broker's historical endpoints | documented figures contradict each other across pages; neither measured |
+| Dhan Data-API pricing | "additional charges" stated, amount never published |
+| Whether any historical endpoint works with a real token | never executed — every finding is documentation or an unauthenticated probe |
 
 Each of these is a probe someone must run against a live credential. Until
 then they stay in this table and out of any claim.


### PR DESCRIPTION
Four parallel investigations settled a question I answered **wrongly twice**.

## D-0021 — you already own the history

| | Measured |
|---|---|
| NSE F&O contract directories | **116,086** |
| NIFTY options | **60,996**, expiring **2020-01-02 → 2026-08-25** |
| On disk | **18 GB**, 196,954 files, **zero empty dirs** |
| **Absent from BOTH live masters** | **115,272 — 99.3%** |
| Greeks | **already computed** — iv, delta, gamma, theta, vega, rho, spot, provenance |

Both brokers **purge on expiry** — earliest index-option expiry in either master is **2026-08-04**.

`registry.duckdb` holds **169,530 contract rows**; **no on-disk directory is unknown to it.**

**Two quotes totalling >₹4 lakh were for a superset of data already on disk, minus the greeks.** The real gap is **~15,900 contracts, almost all expiry-year 2024**.

## D-0022 — the converter is a numeric boundary

The lake stores OHLC as **IEEE doubles**. `CLAUDE.md` §7 says paisa integers, never a float. A converter written as a *copy* carries doubles into a store whose addressing assumes integers. Max deviation measured: **9.3×10⁻¹⁰ paisa** — exact, but it must actually happen.

## D-0023 — capability recorded **with the route that verified it**

| | Groww | Dhan |
|---|---|---|
| Reaches 2020-01 | ✅ | ❌ **5 yr rolling → ~2021-08, moving** |
| Full chain | ✅ | ❌ **ATM±10 only** |
| Expired futures | ✅ | ❌ **none** |
| Verified via | curl (3 distinct hashes, 24 markers, live **401**) | **live browser** |

**Why the method is part of the decision:** Dhan's docs are a JS app — three URLs, one byte-identical 33,884-byte shell, **zero** content markers under curl. Reading it without a browser produced a mangled capture from which I reconstructed a **non-existent `ATM±3` rule** and reported it as fact.

## `06-limits` §7b — what a green gate does not prove

Four audits found **11 CRITICAL** defects while CI was green, 66 tests passed, coverage read **100.00%**.

> **A test built from a hand-written fixture proves the code runs; only a test built from a real vendor row proves it is right.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)