### PR TITLE
feat(core,store,api): equity gate on ISIN identity, store hardening, filtered instrument page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,18 @@
 # Criterion output.
 /target/criterion
 
+# cargo-mutants output. Build output, and it writes `.json` — which CI gate 1b
+# confines to `.github/` and `crates/web/`.
+/mutants.out
+/mutants.out.old
+
+# Editor and agent scratch. `.claude/` holds `launch.json` and
+# `settings.local.json`, and `.json` is NOT in CLAUDE.md section 2's allowed
+# extension list at all — CI gate 1b confines `.json` to `.github/` and
+# `crates/web/`, so a single `git add -A` here would turn the build red. The
+# directory is local tooling, not source; it is ignored rather than deleted so
+# the tooling keeps working. See docs/05-decisions.md D-0028.
+/.claude/
+
 # macOS.
 .DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,6 +398,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "store"
+version = "0.1.0"
+dependencies = [
+ "core",
+]
+
+[[package]]
 name = "syn"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # The intended final graph is in docs/01-architecture.md §1, in the order the
 # crates are built:
 #   core → store → vocab → indicators → engine → pull → api → web → cli
-members = ["crates/core", "crates/api"]
+members = ["crates/core", "crates/store", "crates/api"]
 
 [workspace.package]
 version      = "0.1.0"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -15,11 +15,16 @@ description  = "HTTP surface. Server-rendered HTML; no JavaScript anywhere."
 # A version is required alongside the path: deny.toml sets
 # wildcards = "deny", and a path dependency with no version IS a wildcard.
 # Relaxing the ban was rejected -- it protects registry crates too.
-# `package` is an explicit rename: the PACKAGE is `core` but its lib target
-# is `brutex_core` (a lib named `core` shadows the sysroot crate and breaks
-# rustdoc). This restores `use core::...` here while keeping the dependency
-# KEY as `core`, which is what gates 7 and 9 match on.
-core   = { path = "../core", package = "core", version = "0.1.0" }
+#
+# The dependency KEY is `brutex_core` and the PACKAGE is `core`. Both halves
+# are load-bearing and the earlier comment here claimed the opposite of what
+# the line does, so: the package must stay named `core` because CI gates 7 and
+# 9 match on that name, and the key must NOT be `core` because a crate bound
+# to that name shadows the sysroot crate -- `#[tokio::main]` expands to
+# `core::future::...` and stops compiling, and rustdoc's generated doc-test
+# harness breaks the same way. Hence `crates/core` declares
+# `[lib] name = "brutex_core"` and this line renames the key to match.
+brutex_core = { path = "../core", package = "core", version = "0.1.0" }
 axum   = { workspace = true }
 tokio  = { workspace = true }
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -4,7 +4,17 @@
 //! That is a maximum, not a requirement: `store` and `engine` do not exist
 //! yet, so today it depends on `core` alone and will gain the others when they
 //! land.
+//!
+//! | Module | Owns |
+//! |---|---|
+//! | [`master`] | reading one vendor's instrument master off disk |
+//! | [`merge`] | one map from every vendor, and the ISIN cross-check on it |
+//! | [`render`] | turning instruments into HTML |
+//! | [`server`] | the routes, the process, and everything `main` would hold |
 
 #![forbid(unsafe_code)]
 
+pub mod master;
+pub mod merge;
 pub mod render;
+pub mod server;

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1,0 +1,22 @@
+//! The operator entry point for the HTTP surface.
+//!
+//! This file holds one call and nothing else, on purpose. A `main` cannot be
+//! entered by a unit test — `cargo test` builds the binary with its own
+//! harness and never runs it — so every line of logic left here is a line no
+//! test can reach. Everything therefore lives in [`api::server`], which is
+//! ordinary library code, and `tests/binary.rs` runs this binary once so that
+//! even this call is measured rather than assumed.
+//!
+//! Usage: `api [serve [ADDR] | report]`.
+
+/// Serves, or reports, and returns the exit code the operator's shell reads.
+///
+/// The shutdown signal is passed IN rather than installed inside the server,
+/// so that every arm of [`api::server::run`] is drivable from a test without a
+/// signal and without a hard kill. Ctrl-C is what an operator has; an
+/// already-resolved future is what a test has.
+#[tokio::main]
+async fn main() -> std::process::ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    std::process::ExitCode::from(api::server::run(&args, Box::pin(tokio::signal::ctrl_c())).await)
+}

--- a/crates/api/src/master.rs
+++ b/crates/api/src/master.rs
@@ -1,0 +1,593 @@
+//! Reading a vendor instrument master from disk.
+//!
+//! # Columns are found by NAME, never by position
+//!
+//! The primary broker publishes 19 columns and ships **21** — `internal_trading_symbol`
+//! and `is_intraday` are undocumented — and the documented *order* is wrong:
+//! the docs list `lot_size` before `expiry_date`, the file has
+//! `expiry_date,strike_price,lot_size`.
+//!
+//! A positional reader would therefore put a lot size where a strike belongs
+//! and never fail, because both are numbers. Every field here is located by
+//! header name, and a missing header is a refusal rather than a default.
+//!
+//! # Which names, though, is the vendor's business
+//!
+//! The name table itself lives in [`brutex_core::vendor`], reached through
+//! [`Vendor::master_columns`]. It was here, as a `match` on the vendor, and it
+//! could not stay: [`Vendor`] is `#[non_exhaustive]`, so a match on it in this
+//! crate requires a wildcard arm that no test can reach and the coverage gate
+//! can never satisfy. Moving the table to the crate that owns the enum makes
+//! that match exhaustive and provable, and it puts the column names beside the
+//! segment and instrument-type alphabets they belong with — one place to look
+//! when a vendor renames a column, rather than one per reader.
+
+use brutex_core::isin::Isin;
+use brutex_core::vendor::{Decoded, Listing, MasterRow, Skip, Vendor, decode_master_row};
+use std::collections::{BTreeMap, HashMap};
+
+/// What one master file produced.
+#[derive(Debug, Default)]
+pub struct Loaded {
+    /// Rows that decoded into an instrument this engine stores, each with the
+    /// vendor's ISIN beside its key.
+    pub kept: Vec<Listing>,
+    /// Rows declined, counted by reason.
+    pub skipped: HashMap<&'static str, usize>,
+    /// Every declined row that carried a parseable ISIN, and why it was
+    /// declined.
+    ///
+    /// This is what makes an **eligibility** disagreement visible. Before it
+    /// existed a declined row was dropped right here, so the merge could only
+    /// ever compare rows both vendors had already agreed to keep, and it
+    /// printed `0 conflicts` while the two masters disagreed about 62
+    /// instruments that carried the same ISIN in both files. See
+    /// [`crate::merge::Merged::eligibility`].
+    pub declined: Vec<(Isin, Skip)>,
+    /// Rows that could not be understood, with the line number and the reason.
+    ///
+    /// Held rather than dropped: a row we failed to parse is how an instrument
+    /// silently vanishes. [`Loaded::errors_by_reason`] is what actually puts
+    /// them on the page — for a long time this vector was allocated, formatted
+    /// and then read only for its `.len()`, so "104 unreadable" was the whole
+    /// of what an operator was ever told and the reason had to be grepped out
+    /// of the raw CSV by hand.
+    pub errors: Vec<(usize, String)>,
+    /// Every listing class this engine does not recognise, and how often.
+    ///
+    /// Separate from [`Loaded::skipped`] because the count alone does not name
+    /// the code, and the code is the entire diagnostic: "2,438 rows declined
+    /// under `EQX`" says an alphabet moved, while "2,438 not an equity
+    /// listing" says nothing at all. See
+    /// [`brutex_core::vendor::Skip::UnrecognisedListingClass`].
+    pub unrecognised: BTreeMap<String, usize>,
+}
+
+impl Loaded {
+    /// Total rows declined.
+    #[must_use]
+    pub fn skipped_total(&self) -> usize {
+        self.skipped.values().sum()
+    }
+
+    /// The decline reasons and their counts, ordered so a report is stable.
+    #[must_use]
+    pub fn skipped_by_reason(&self) -> Vec<(&'static str, usize)> {
+        let mut v: Vec<(&'static str, usize)> =
+            self.skipped.iter().map(|(&k, &n)| (k, n)).collect();
+        v.sort_unstable();
+        v
+    }
+
+    /// Each distinct parse failure, how many rows hit it, and the first line
+    /// that did.
+    ///
+    /// Grouped rather than listed row by row so the output is bounded without
+    /// being truncated: every *reason* is named, always, and the line number
+    /// is where to look. A bare total is what this replaces.
+    #[must_use]
+    pub fn errors_by_reason(&self) -> Vec<(&str, usize, usize)> {
+        let mut by: BTreeMap<&str, (usize, usize)> = BTreeMap::new();
+        for (line, reason) in &self.errors {
+            let e = by.entry(reason.as_str()).or_insert((0, *line));
+            e.0 += 1;
+            e.1 = e.1.min(*line);
+        }
+        by.into_iter()
+            .map(|(reason, (n, first))| (reason, n, first))
+            .collect()
+    }
+}
+
+/// Locates the columns this decoder needs, by name.
+#[derive(Debug, Clone, Copy)]
+struct Columns {
+    exchange: usize,
+    segment: usize,
+    underlying: usize,
+    trading_symbol: usize,
+    instrument_type: usize,
+    listing_class: usize,
+    isin: usize,
+    expiry: usize,
+    strike: usize,
+    option_side: Option<usize>,
+}
+
+impl Columns {
+    /// Finds each required column in the header row.
+    ///
+    /// # Errors
+    ///
+    /// The name of the first column that is absent. A missing column is a
+    /// refusal and never a default: a defaulted column reads an empty string
+    /// for every row, which the decoder would report as thousands of routine
+    /// skips rather than as the mapping bug it is.
+    fn locate(header: &str, vendor: Vendor) -> Result<Self, String> {
+        let idx: HashMap<&str, usize> = header
+            .trim_end()
+            .split(',')
+            .enumerate()
+            .map(|(i, name)| (name.trim(), i))
+            .collect();
+        let need = |n: &str| -> Result<usize, String> {
+            idx.get(n)
+                .copied()
+                .ok_or_else(|| format!("no column {n:?}"))
+        };
+        let names = vendor.master_columns();
+        Ok(Self {
+            exchange: need(names.exchange)?,
+            segment: need(names.segment)?,
+            underlying: need(names.underlying)?,
+            trading_symbol: need(names.trading_symbol)?,
+            instrument_type: need(names.instrument_type)?,
+            listing_class: need(names.listing_class)?,
+            isin: need(names.isin)?,
+            expiry: need(names.expiry)?,
+            strike: need(names.strike)?,
+            option_side: names.option_side.map(need).transpose()?,
+        })
+    }
+
+    /// The highest column index this decoder reads.
+    ///
+    /// A row with fewer fields than this cannot be decoded, and must not be
+    /// *guessed* at — see the shortfall check in [`load`].
+    fn widest(&self) -> usize {
+        // Folded from `exchange` rather than `max()`ed over everything,
+        // because `Iterator::max` returns an `Option` whose `None` arm cannot
+        // happen here — and a branch no test can enter is a branch nobody has
+        // checked. `option_side` chains in only for the vendor that has one.
+        [
+            self.segment,
+            self.underlying,
+            self.trading_symbol,
+            self.instrument_type,
+            self.listing_class,
+            self.isin,
+            self.expiry,
+            self.strike,
+        ]
+        .into_iter()
+        .chain(self.option_side)
+        .fold(self.exchange, usize::max)
+    }
+}
+
+/// Reads a vendor master and decodes every row.
+///
+/// # Errors
+///
+/// A message naming what was wrong with the file itself — unreadable, empty,
+/// or missing a required column.
+pub fn load(path: &std::path::Path, vendor: Vendor) -> Result<Loaded, String> {
+    let text = std::fs::read_to_string(path).map_err(|e| format!("{}: {e}", path.display()))?;
+    let mut lines = text.lines();
+    let header = lines.next().ok_or_else(|| "file is empty".to_owned())?;
+    let cols = Columns::locate(header, vendor)?;
+
+    let widest = cols.widest();
+    let mut out = Loaded::default();
+    for (n, line) in lines.enumerate() {
+        if line.is_empty() {
+            continue;
+        }
+        let f: Vec<&str> = line.split(',').collect();
+        // A ROW TOO SHORT TO HOLD THE COLUMNS IS AN ERROR, NOT A DEFAULT.
+        //
+        // Defaulting a missing field to `""` put the empty string into the
+        // listing class, where the gate read it as a series it does not
+        // recognise and declined a genuine share as routine business, with
+        // `0 unreadable` beside it. `Columns::locate` already refuses a
+        // missing HEADER for exactly this hazard; this is the same hazard one
+        // row at a time, and the real masters are uniform — every Dhan row has
+        // 33 fields and every Groww row has 21 — so a short row is an anomaly
+        // and never the normal case.
+        if f.len() <= widest {
+            out.errors.push((
+                n + 2,
+                format!(
+                    "row has {} field(s); the columns this vendor needs run to {}",
+                    f.len(),
+                    widest + 1
+                ),
+            ));
+            continue;
+        }
+        let get = |i: usize| -> &str { f.get(i).copied().unwrap_or("") };
+        let row = MasterRow {
+            exchange: get(cols.exchange),
+            segment: get(cols.segment),
+            underlying: get(cols.underlying),
+            trading_symbol: get(cols.trading_symbol),
+            instrument_type: get(cols.instrument_type),
+            listing_class: get(cols.listing_class),
+            isin: get(cols.isin),
+            expiry: get(cols.expiry),
+            strike_rupees: get(cols.strike),
+            option_side: cols.option_side.map_or("", get),
+        };
+        match decode_master_row(vendor, row) {
+            Ok(Decoded::Keep(l)) => out.kept.push(l),
+            // The reason text belongs to the Skip variant, in the crate that
+            // owns it. A `match` here would need a wildcard -- Skip is
+            // `#[non_exhaustive]` -- and a wildcard silently files every
+            // variant added later under whatever label it happens to name.
+            Ok(Decoded::Skipped(d)) => {
+                *out.skipped.entry(d.reason.reason()).or_insert(0) += 1;
+                if let Some(isin) = d.isin {
+                    out.declined.push((isin, d.reason));
+                }
+                // The COUNT says an alphabet moved; the CODE says which one.
+                if d.reason == Skip::UnrecognisedListingClass {
+                    *out.unrecognised
+                        .entry(row.listing_class.trim().to_owned())
+                        .or_insert(0) += 1;
+                }
+            }
+            Err(e) => out.errors.push((n + 2, e.to_string())),
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::indexing_slicing,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    fn tmp(name: &str, body: &str) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(format!("brutex-master-{name}.csv"));
+        let mut f = std::fs::File::create(&p).expect("create");
+        f.write_all(body.as_bytes()).expect("write");
+        p
+    }
+
+    #[test]
+    fn columns_are_found_by_name_not_position() {
+        // The columns are deliberately in a DIFFERENT order from the docs and
+        // carry two undocumented trailing fields, exactly like the real file.
+        let body = "is_intraday,segment,exchange,instrument_type,trading_symbol,series,\
+                    isin,expiry_date,strike_price,underlying_symbol,internal_trading_symbol\n\
+                    0,CASH,NSE,IDX,NIFTY,,NIFTY,,,,x\n";
+        let p = tmp("byname", body);
+        let got = load(&p, Vendor::Groww).expect("loads");
+        assert_eq!(got.kept.len(), 1);
+        assert_eq!(got.kept[0].key.underlying.as_str(), "NIFTY");
+        assert!(got.kept[0].key.is_sweepable());
+        assert_eq!(got.kept[0].isin, None, "an index has no ISIN");
+        assert!(got.errors.is_empty());
+    }
+
+    #[test]
+    fn a_missing_column_is_refused_and_named() {
+        let p = tmp("missing", "exchange,segment\nNSE,CASH\n");
+        let err = load(&p, Vendor::Groww).expect_err("must refuse");
+        // The FIRST missing column is named, whichever it is -- the point is
+        // that it refuses and says which, never that it defaults.
+        assert!(err.starts_with("no column"), "got {err}");
+        assert!(err.contains("underlying_symbol"), "got {err}");
+    }
+
+    #[test]
+    fn every_column_a_vendor_needs_is_required_and_named_when_absent() {
+        // One case per required column, built by REMOVING that column from an
+        // otherwise complete header. A column that could go missing without a
+        // refusal would be read as an empty string on every row, and the
+        // decoder would report that as thousands of routine skips rather than
+        // as the mapping bug it is.
+        for vendor in [Vendor::Groww, Vendor::Dhan] {
+            let c = vendor.master_columns();
+            let mut all = vec![
+                c.exchange,
+                c.segment,
+                c.underlying,
+                c.trading_symbol,
+                c.instrument_type,
+                c.listing_class,
+                c.isin,
+                c.expiry,
+                c.strike,
+            ];
+            all.extend(c.option_side);
+            // The complete header is accepted, or the cases below prove
+            // nothing about which column was missing.
+            let full = format!("{}\n", all.join(","));
+            assert!(
+                load(&tmp("full", &full), vendor).is_ok(),
+                "the complete header must load"
+            );
+            for missing in &all {
+                let header: Vec<&str> = all.iter().copied().filter(|n| n != missing).collect();
+                let body = format!("{}\n", header.join(","));
+                let err = load(&tmp("dropped", &body), vendor).expect_err("must refuse");
+                assert!(
+                    err.contains(missing),
+                    "dropping {missing} must name it, got {err}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_new_class_and_isin_columns_are_required_by_their_own_names() {
+        // Each vendor spells them differently, and a file missing either is a
+        // refusal that NAMES the column -- never a silent empty string, which
+        // the decoder would report as thousands of routine skips.
+        let groww = "exchange,segment,underlying_symbol,trading_symbol,instrument_type,\
+                     expiry_date,strike_price";
+        let err = load(&tmp("noseries", &format!("{groww},isin\n")), Vendor::Groww)
+            .expect_err("must refuse");
+        assert!(err.contains("\"series\""), "got {err}");
+        let err = load(&tmp("noisin", &format!("{groww},series\n")), Vendor::Groww)
+            .expect_err("must refuse");
+        assert!(err.contains("\"isin\""), "got {err}");
+
+        let dhan = "EXCH_ID,SEGMENT,UNDERLYING_SYMBOL,SYMBOL_NAME,INSTRUMENT,\
+                    SM_EXPIRY_DATE,STRIKE_PRICE,OPTION_TYPE";
+        let err = load(&tmp("noclass", &format!("{dhan},ISIN\n")), Vendor::Dhan)
+            .expect_err("must refuse");
+        assert!(err.contains("\"SERIES\""), "got {err}");
+        let err = load(
+            &tmp("nodhanisin", &format!("{dhan},SERIES\n")),
+            Vendor::Dhan,
+        )
+        .expect_err("must refuse");
+        assert!(err.contains("\"ISIN\""), "got {err}");
+        // The side column is Dhan's alone, and it is required there.
+        let err = load(
+            &tmp(
+                "noside",
+                "EXCH_ID,SEGMENT,UNDERLYING_SYMBOL,SYMBOL_NAME,INSTRUMENT,SM_EXPIRY_DATE,\
+                 STRIKE_PRICE,ISIN,SERIES\n",
+            ),
+            Vendor::Dhan,
+        )
+        .expect_err("must refuse");
+        assert!(err.contains("\"OPTION_TYPE\""), "got {err}");
+        // And a file WITHOUT `INSTRUMENT_TYPE` loads: it is the measurably
+        // wrong column, so it is neither read nor required. D-0025.
+        assert!(
+            load(
+                &tmp(
+                    "noinstrtype",
+                    "EXCH_ID,SEGMENT,UNDERLYING_SYMBOL,SYMBOL_NAME,INSTRUMENT,SM_EXPIRY_DATE,\
+                     STRIKE_PRICE,ISIN,SERIES,OPTION_TYPE\n",
+                ),
+                Vendor::Dhan,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn the_equity_gate_runs_on_a_real_file_and_the_bond_loses() {
+        // The CHOLAFIN pair, in the order the real Dhan master has them: the
+        // 7.5% NCD FIRST, the share second. Before the gate, insert-if-absent
+        // resolved the ticker to the bond. Both lines are verbatim, and the
+        // column the gate reads is SERIES -- `D1` for the NCD, `EQ` for the
+        // share -- not the INSTRUMENT_TYPE beside it.
+        let body = "EXCH_ID,SEGMENT,ISIN,INSTRUMENT,UNDERLYING_SYMBOL,SYMBOL_NAME,\
+                    INSTRUMENT_TYPE,SERIES,SM_EXPIRY_DATE,STRIKE_PRICE,OPTION_TYPE\n\
+                    NSE,E,INE121A08PJ0,EQUITY,CHOLAFIN,CHOLAMANDALAM IN & FIN CO,DEB,D1,,,\n\
+                    NSE,E,INE121A01024,EQUITY,CHOLAFIN,CHOLAMANDALAM IN & FIN CO,ES,EQ,,,\n";
+        let got = load(&tmp("cholafin", body), Vendor::Dhan).expect("loads");
+        assert_eq!(got.kept.len(), 1, "only the share survives");
+        assert_eq!(got.kept[0].key.underlying.as_str(), "CHOLAFIN");
+        assert_eq!(
+            got.kept[0].isin.map(|i| i.to_string()).as_deref(),
+            Some("INE121A01024"),
+            "and it is the SHARE, identified by its own ISIN"
+        );
+        assert_eq!(got.skipped.get("not an equity listing"), Some(&1));
+        assert!(got.errors.is_empty());
+        // The bond's ISIN survives the decline, so another vendor keeping the
+        // same paper can be recognised as a disagreement.
+        assert_eq!(got.declined.len(), 1);
+        assert_eq!(got.declined[0].0.as_str(), "INE121A08PJ0");
+        assert_eq!(got.declined[0].1, Skip::NotEquityListing);
+        assert!(got.unrecognised.is_empty(), "D1 is a series we know");
+    }
+
+    #[test]
+    fn an_unrecognised_series_is_recorded_under_the_code_itself() {
+        // A count under a shared label cannot distinguish "NSE minted a debt
+        // series" from "the vendor renamed the equity series". The CODE can.
+        let body = "EXCH_ID,SEGMENT,ISIN,INSTRUMENT,UNDERLYING_SYMBOL,SYMBOL_NAME,\
+                    INSTRUMENT_TYPE,SERIES,SM_EXPIRY_DATE,STRIKE_PRICE,OPTION_TYPE\n\
+                    NSE,E,INE002A01018,EQUITY,RELIANCE,RELIANCE INDUSTRIES,ES,  EQX  ,,,\n\
+                    NSE,E,INE121A01024,EQUITY,CHOLAFIN,CHOLA,ES,EQX,,,\n\
+                    NSE,E,INE775A08105,EQUITY,MOTHERSON,MOTHERSON NCD,DEB,D1,,,\n";
+        let got = load(&tmp("unrecognised", body), Vendor::Dhan).expect("loads");
+        assert_eq!(got.kept.len(), 0);
+        assert_eq!(got.skipped.get("unrecognised listing class"), Some(&2));
+        assert_eq!(got.skipped.get("not an equity listing"), Some(&1));
+        // Trimmed, so the padded and unpadded forms are ONE code and not two.
+        assert_eq!(got.unrecognised.get("EQX"), Some(&2));
+        assert_eq!(got.unrecognised.len(), 1);
+    }
+
+    #[test]
+    fn a_row_with_too_few_fields_is_unreadable_and_names_the_shortfall() {
+        // A defaulted field landed the empty string in the listing class,
+        // where the gate declined a genuine share as routine business with
+        // `0 unreadable` beside it. `Columns::locate` already refuses a
+        // missing HEADER for this hazard; this is the same hazard per row.
+        let body = "exchange,segment,underlying_symbol,trading_symbol,instrument_type,\
+                    series,isin,expiry_date,strike_price\n\
+                    NSE,CASH,,RELIANCE,EQ\n\
+                    NSE,CASH,,CHOLAFIN,EQ,EQ,INE121A01024,,\n";
+        let got = load(&tmp("shortrow", body), Vendor::Groww).expect("loads");
+        assert_eq!(got.kept.len(), 1, "only the intact row decodes");
+        assert_eq!(got.errors.len(), 1);
+        assert_eq!(got.errors[0].0, 2, "the line is named");
+        // Bound rather than called inside the failure message: a call there is
+        // a region that only runs when the assertion FAILS, so no passing test
+        // can ever cover it.
+        let reason = &got.errors[0].1;
+        assert!(
+            reason.contains("row has 5 field(s)") && reason.contains("run to 9"),
+            "got {reason}"
+        );
+        assert!(
+            got.skipped.is_empty(),
+            "a truncated share is not a routine decline: {:?}",
+            got.skipped
+        );
+    }
+
+    #[test]
+    fn unreadable_rows_are_grouped_by_reason_with_the_first_line_that_hit_it() {
+        // `errors` was allocated, formatted and read only for `.len()`, so an
+        // operator was told `104 unreadable` and nothing else. `NIFTY 100` is
+        // a real Dhan index ticker; a space is not a legal Symbol, and 104
+        // rows of the real master are exactly that shape.
+        let body = "exchange,segment,underlying_symbol,trading_symbol,instrument_type,\
+                    series,isin,expiry_date,strike_price\n\
+                    NSE,CASH,,NIFTY 100,IDX,,NIFTY,,\n\
+                    NSE,CASH\n\
+                    NSE,CASH,,NIFTY 200,IDX,,NIFTY,,\n";
+        let got = load(&tmp("grouped", body), Vendor::Groww).expect("loads");
+        let by = got.errors_by_reason();
+        assert_eq!(by.len(), 2, "two distinct reasons: {by:?}");
+        assert_eq!(
+            by,
+            vec![
+                ("malformed instrument identifier", 2, 2),
+                (
+                    "row has 2 field(s); the columns this vendor needs run to 9",
+                    1,
+                    3
+                ),
+            ],
+            "every reason named, with its count and the FIRST line it hit"
+        );
+        assert!(
+            Loaded::default().errors_by_reason().is_empty(),
+            "and nothing to say when nothing failed"
+        );
+    }
+
+    #[test]
+    fn an_unreadable_or_empty_file_is_refused() {
+        let missing = std::env::temp_dir().join("brutex-does-not-exist.csv");
+        assert!(load(&missing, Vendor::Groww).is_err());
+        let p = tmp("empty", "");
+        assert!(
+            load(&p, Vendor::Groww)
+                .expect_err("empty")
+                .contains("empty")
+        );
+    }
+
+    #[test]
+    fn skips_are_counted_by_reason_and_errors_keep_their_line_number() {
+        let body = "exchange,segment,underlying_symbol,trading_symbol,instrument_type,\
+                    series,isin,expiry_date,strike_price\n\
+                    BSE,CASH,,SENSEX,IDX,,,,\n\
+                    NSE,COMMODITY,GOLD,GOLD,FUT,,,2026-08-05,\n\
+                    NSE,FNO,031NSETEST,X,FUT,,,2036-11-27,\n\
+                    NSE,CASH,,SOMEBOND,EQ,N2,INE002A01018,,\n\
+                    NSE,CASH,,SOMESME,EQ,SM,INE002A01018,,\n\
+                    NSE,FNO,NIFTY,X,ZZ,,,2026-08-04,1\n";
+        let p = tmp("skips", body);
+        let got = load(&p, Vendor::Groww).expect("loads");
+        assert_eq!(got.kept.len(), 0);
+        assert_eq!(got.skipped.get("foreign exchange"), Some(&1));
+        assert_eq!(got.skipped.get("segment not stored"), Some(&1));
+        assert_eq!(got.skipped.get("exchange test instrument"), Some(&1));
+        assert_eq!(got.skipped.get("not an equity listing"), Some(&1));
+        assert_eq!(got.skipped.get("SME board"), Some(&1));
+        assert_eq!(got.skipped_total(), 5);
+        assert_eq!(
+            got.skipped_by_reason(),
+            vec![
+                ("SME board", 1),
+                ("exchange test instrument", 1),
+                ("foreign exchange", 1),
+                ("not an equity listing", 1),
+                ("segment not stored", 1),
+            ],
+            "a report needs a stable order, not a hash order"
+        );
+        assert_eq!(got.errors.len(), 1, "the ZZ type is unreadable");
+        assert_eq!(got.errors[0].0, 7, "line numbers count the header");
+    }
+
+    #[test]
+    fn a_short_row_is_an_error_and_never_an_index_panic() {
+        let body = "exchange,segment,underlying_symbol,trading_symbol,instrument_type,\
+                    series,isin,expiry_date,strike_price\n\
+                    NSE,CASH\n";
+        let p = tmp("short", body);
+        let got = load(&p, Vendor::Groww).expect("loads");
+        // Too short to hold the columns -> an error naming the shortfall,
+        // never an index panic and never a defaulted empty field.
+        assert_eq!(got.errors.len(), 1);
+        assert!(got.kept.is_empty() && got.skipped.is_empty());
+    }
+
+    #[test]
+    fn dhan_columns_use_their_own_names() {
+        let body = "EXCH_ID,SEGMENT,SECURITY_ID,ISIN,INSTRUMENT,UNDERLYING_SYMBOL,\
+                    SYMBOL_NAME,SERIES,SM_EXPIRY_DATE,STRIKE_PRICE,OPTION_TYPE\n\
+                    NSE,I,13,NA,INDEX,NIFTY,NIFTY,NA,0001-01-01,,\n\
+                    NSE,D,1,,OPTIDX,NIFTY,NIFTY,,2026-08-04,19450.00000,CE\n";
+        let p = tmp("dhan", body);
+        let got = load(&p, Vendor::Dhan).expect("loads");
+        // The INDEX row is kept. The OPTION row is a LIVE contract and is
+        // skipped by design -- backtests run on expired contracts from the
+        // historical endpoints and the lake, never on the live chain.
+        assert_eq!(got.kept.len(), 1, "only the index is stored");
+        assert!(got.errors.is_empty());
+        assert!(
+            got.kept[0].key.is_sweepable(),
+            "NIFTY from Dhan is sweepable"
+        );
+        assert_eq!(
+            got.kept[0].isin, None,
+            "`NA` in the ISIN column is not an ISIN"
+        );
+        assert_eq!(got.skipped_total(), 1, "the live option was declined");
+    }
+
+    #[test]
+    fn blank_lines_are_ignored() {
+        let body = "exchange,segment,underlying_symbol,trading_symbol,instrument_type,\
+                    series,isin,expiry_date,strike_price\n\
+                    \n\
+                    NSE,CASH,,NIFTY,IDX,,NIFTY,,\n\
+                    \n";
+        let p = tmp("blank", body);
+        let got = load(&p, Vendor::Groww).expect("loads");
+        assert_eq!(got.kept.len(), 1);
+        assert_eq!(got.errors.len(), 0);
+    }
+}

--- a/crates/api/src/merge.rs
+++ b/crates/api/src/merge.rs
@@ -1,0 +1,731 @@
+//! Merging every vendor's master into one map, and cross-checking it.
+//!
+//! # What the merge is
+//!
+//! Two vendors naming the same contract produce the same
+//! [`brutex_core::instrument::InstrumentKey`], so they collide
+//! by design and that collision **is** the deduplication —
+//! `docs/05-decisions.md` D-0015. This module is where the collision happens
+//! and where the two vendors are made to agree about what collided.
+//!
+//! # The cross-check, and why the ISIN is not simply part of the key
+//!
+//! The ISIN is the one field a broker does not mint: it comes from a national
+//! numbering agency, so both masters carry the same string for the same paper.
+//! That makes it the ideal check on a merge — and a catastrophic key
+//! component. As a field of the key, a vendor disagreement would produce two
+//! different keys, the map would hold the instrument twice, and nobody would
+//! ever learn there was a disagreement. Beside the key, the same disagreement
+//! is one loud line naming the key and both ISINs. See [`brutex_core::isin`].
+//!
+//! # Two kinds of disagreement, and only one of them used to be looked for
+//!
+//! A merge that compares the ISINs of rows **both vendors kept** cannot see
+//! the disagreement that actually existed in this data: one vendor calling a
+//! security an equity while the other called it a bond. Those rows never
+//! reached the merge at all — the reader counted them and dropped them — so
+//! the report printed `0 isin conflicts` while the two masters disagreed about
+//! the eligibility of 62 instruments, every one of which carried the **same
+//! ISIN in both files**. The check had the key it needed and never looked.
+//!
+//! So there are two, and they are counted separately because they mean
+//! different things:
+//!
+//! | | What disagreed | Held in |
+//! |---|---|---|
+//! | Identity | one key, two different ISINs | [`Merged::conflicts`] |
+//! | Eligibility | one ISIN, kept by one vendor and declined by another | [`Merged::eligibility`] |
+//!
+//! Under D-0025 both are **zero** on the real masters — the gate reads one
+//! exchange-issued series code from both vendors, so their verdicts agree on
+//! 4,080 of 4,080 shared ISINs. That is the point: the checks are what make
+//! the zero worth anything.
+//!
+//! # What a disagreement does
+//!
+//! It **refuses**, and the refusal is a returned value rather than a log line:
+//! [`Merged::verdict`] is [`Verdict::Disputed`], the caller's exit code is
+//! non-zero and `/health` stops returning 200. D-0026. Earlier text here
+//! claimed a non-empty conflicts vector "is a refusal to believe the merge",
+//! and cited D-0020 for it, while the code printed a line, kept the
+//! instrument, and exited 0 — the "primary vendor wins, log the difference"
+//! shape D-0020 exists to reject. Naming a thing a refusal does not make it
+//! one.
+//!
+//! # The suffix, and why it is confirmed rather than normalised
+//!
+//! Groww leaks `internal_trading_symbol` into `trading_symbol` on exactly 209
+//! of the 4,080 ISINs the two masters share — `BLUECHIP-BE`, `CBAZAAR-ST`,
+//! `HDFCLIQUID-EQ`, `LOWVOL-EQ` — and the rule is exact with zero residual:
+//! `groww.trading_symbol == dhan.UNDERLYING_SYMBOL + "-" + series`. It would
+//! be very easy, and wrong, to strip a trailing `-XX` everywhere:
+//! `BAJAJ-AUTO`, `NAM-INDIA` and `M&M` are real tickers, and
+//! `crates/core/src/symbol.rs` argues at length that blind normalisation
+//! manufactures the collision it exists to prevent.
+//!
+//! So the strip needs **two** independent agreements before it is applied: the
+//! trailing segment must be the row's own series (decided in
+//! [`brutex_core::vendor`], which is where the series is), and some vendor
+//! must have asserted the stripped identity under the **same ISIN** (decided
+//! here, which is where both vendors are). Neither alone is enough, and where
+//! they do not both hold the symbol is left exactly as the vendor wrote it.
+
+use brutex_core::instrument::InstrumentKey;
+use brutex_core::isin::Isin;
+use brutex_core::universe::{self, Universe};
+use brutex_core::vendor::{Listing, Skip, Vendor, VendorSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+/// One instrument, after every vendor has had its say.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Entry {
+    /// Which vendors listed it. Seeing two here is the deduplication, on
+    /// screen.
+    pub vendors: VendorSet,
+    /// The ISIN, and the vendor that gave it. `None` for an index, which has
+    /// no ISIN at all.
+    pub isin: Option<(Vendor, Isin)>,
+    /// A **different** ISIN a later vendor gave for the same key.
+    ///
+    /// Both are kept. Picking one would be choosing a winner without evidence,
+    /// and dropping the row would hide the disagreement entirely.
+    pub conflict: Option<(Vendor, Isin)>,
+    /// Which of the engine's universes this instrument is in.
+    pub universe: Universe,
+}
+
+/// One vendor's whole contribution to the merge.
+///
+/// Both halves are needed: what a vendor **kept** builds the map, and what it
+/// **declined** is the only way another vendor's keep can be recognised as a
+/// disagreement rather than as a row nobody mentioned.
+#[derive(Debug)]
+pub struct Source {
+    /// Whose rows these are.
+    pub vendor: Vendor,
+    /// The instruments this vendor listed.
+    pub kept: Vec<Listing>,
+    /// The ISINs this vendor declined, and why.
+    pub declined: Vec<(Isin, Skip)>,
+}
+
+/// Whether the merged universe may be believed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Every vendor that spoke agreed. The normal state.
+    Clean,
+    /// At least one cross-vendor disagreement survived the merge.
+    ///
+    /// The instruments are still in the map and still on the page — dropping
+    /// them would hide the disagreement, which is the failure `CLAUDE.md` §4
+    /// forbids — but the *universe as a whole* is refused: a caller that turns
+    /// this into an exit code must not return success. D-0026.
+    Disputed,
+}
+
+/// The merged universe, and everything that disagreed while it was built.
+#[derive(Debug, Default)]
+pub struct Merged {
+    /// One entry per distinct instrument.
+    pub by_key: HashMap<InstrumentKey, Entry>,
+    /// One line per key two vendors gave different ISINs for, naming the key
+    /// and both ISINs. Empty is the normal state.
+    pub conflicts: Vec<String>,
+    /// One line per ISIN one vendor kept and another declined, naming the
+    /// ISIN, both vendors and the decline reason.
+    ///
+    /// Separate from [`Merged::conflicts`] because it is a different
+    /// disagreement: not "which paper is this" but "is this paper an equity at
+    /// all". Folding the two together would let a count of one hide the other.
+    pub eligibility: Vec<String>,
+}
+
+impl Merged {
+    /// The number of distinct instruments.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_key.len()
+    }
+
+    /// Whether nothing merged at all.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_key.is_empty()
+    }
+
+    /// Whether this universe may be believed.
+    #[must_use]
+    pub fn verdict(&self) -> Verdict {
+        if self.conflicts.is_empty() && self.eligibility.is_empty() {
+            Verdict::Clean
+        } else {
+            Verdict::Disputed
+        }
+    }
+
+    /// How many members of each universe the merge resolved, and how many of
+    /// those two vendors both named.
+    ///
+    /// The second number is the one that means something. An instrument named
+    /// by one vendor rests entirely on that vendor's gate; an instrument named
+    /// by both has been cross-checked. Reporting only the first would let two
+    /// vendors' worth of confidence and one vendor's worth look identical.
+    #[must_use]
+    pub fn universe_census(&self) -> Vec<(&'static str, usize, usize)> {
+        let mut out = Vec::new();
+        for (name, bit) in [
+            ("F&O underlyings", Universe::FNO),
+            ("NIFTY Total Market", Universe::TOTAL_MARKET),
+        ] {
+            let members = self.by_key.iter().filter(|(_, e)| e.universe.contains(bit));
+            let mut present = 0;
+            let mut both = 0;
+            for (_, e) in members {
+                present += 1;
+                if Vendor::ALL.iter().all(|v| e.vendors.contains(*v)) {
+                    both += 1;
+                }
+            }
+            out.push((name, present, both));
+        }
+        out
+    }
+
+    /// Universe members only one vendor named, by universe and key.
+    ///
+    /// An index carries no ISIN, so nothing cross-checks its identity at all —
+    /// and the two masters spell most index names differently. This is where
+    /// that shows up instead of being invisible: `MIDCPNIFTY` and `NIFTYNXT50`
+    /// are F&O underlyings Dhan names and Groww calls `NIFTYMIDSELECT` and
+    /// `NIFTYJR`. `docs/06-limits.md` §12.
+    #[must_use]
+    pub fn single_vendor_members(&self) -> Vec<String> {
+        let mut out: Vec<String> = self
+            .by_key
+            .iter()
+            .filter(|(_, e)| {
+                !e.universe.is_none() && !Vendor::ALL.iter().all(|v| e.vendors.contains(*v))
+            })
+            .map(|(k, e)| {
+                let who: Vec<&str> = Vendor::ALL
+                    .iter()
+                    .filter(|v| e.vendors.contains(**v))
+                    .map(|v| v.as_str())
+                    .collect();
+                format!("{k} ({})", who.join(" "))
+            })
+            .collect();
+        out.sort_unstable();
+        out
+    }
+}
+
+/// Merges every vendor's kept listings into one map, and cross-checks it.
+///
+/// Two passes, because the confirmation a strip needs may come from a vendor
+/// that has not been read yet. The first pass records every identity any
+/// vendor asserted; the second resolves each listing against it. Both are
+/// O(1) per listing — a hash probe on fixed-width `Copy` keys, never a scan.
+/// The eligibility check is a third probe against a map built once, so it is
+/// O(1) per declined row too.
+#[must_use]
+pub fn merge(sources: &[Source]) -> Merged {
+    // Pass 1. Every (identity, ISIN) pair anybody asserted. A row can never
+    // confirm ITSELF: it asserts its raw key, and the candidate it offers is
+    // by construction a different symbol.
+    let mut asserted: HashSet<(InstrumentKey, Isin)> = HashSet::new();
+    // And every ISIN each vendor KEPT, which is what a decline is checked
+    // against. `BTreeMap` rather than `HashMap` so the conflict lines come out
+    // in a stable order and two runs produce byte-identical output.
+    let mut kept_isins: BTreeMap<Isin, Vec<Vendor>> = BTreeMap::new();
+    for s in sources {
+        for l in &s.kept {
+            if let Some(i) = l.isin {
+                asserted.insert((l.key, i));
+                kept_isins.entry(i).or_default().push(s.vendor);
+            }
+        }
+    }
+
+    let mut out = Merged::default();
+    for s in sources {
+        let vendor = s.vendor;
+        for l in &s.kept {
+            let key = resolve(l, &asserted);
+            let e = out.by_key.entry(key).or_default();
+            e.vendors = e.vendors.with(vendor);
+            e.universe = universe::of_instrument(&key);
+            match (e.isin, l.isin) {
+                // Nothing on record yet: take what this vendor said, whether
+                // that is an ISIN or the honest absence of one.
+                (None, given) => e.isin = given.map(|i| (vendor, i)),
+                // Two vendors, two different ISINs, one key. Name both.
+                (Some((first_vendor, first)), Some(given)) if first != given => {
+                    e.conflict = Some((vendor, given));
+                    out.conflicts.push(format!(
+                        "{key}: {} says {first}, {} says {given}",
+                        first_vendor.as_str(),
+                        vendor.as_str()
+                    ));
+                }
+                // Agreement, or a vendor with nothing to add.
+                _ => {}
+            }
+        }
+    }
+
+    // THE ELIGIBILITY CHECK. One vendor declined this ISIN; did another keep
+    // it? Sorted by ISIN, so the output does not depend on map iteration
+    // order. This is what used to be structurally impossible: the declined
+    // rows were dropped before the merge ever saw them.
+    let mut disputes: BTreeMap<Isin, Vec<String>> = BTreeMap::new();
+    for s in sources {
+        for &(isin, reason) in &s.declined {
+            // Only a decline that judges the PAPER can contradict a keep. A
+            // decline for the venue cannot: `RELIANCE` is `INE002A01018` on
+            // both NSE and BSE, so one vendor declining the BSE row while the
+            // other keeps the NSE row is two correct decisions, not a
+            // disagreement — and counting it as one produced 3,000 false
+            // conflicts on the real masters.
+            if !reason.judges_the_paper() {
+                continue;
+            }
+            let Some(keepers) = kept_isins.get(&isin) else {
+                continue;
+            };
+            for keeper in keepers {
+                // A vendor listing the same ISIN twice — once kept, once
+                // declined — is a row shape neither master has, but it would
+                // be a statement about ONE vendor and not a cross-vendor
+                // disagreement, so it is not one.
+                if *keeper != s.vendor {
+                    disputes.entry(isin).or_default().push(format!(
+                        "{isin}: {} kept it, {} declined it as {}",
+                        keeper.as_str(),
+                        s.vendor.as_str(),
+                        reason.reason()
+                    ));
+                }
+            }
+        }
+    }
+    out.eligibility = disputes.into_values().flatten().collect();
+    out
+}
+
+/// The identity to file a listing under.
+///
+/// The candidate key from the decoder is adopted **only** when some vendor has
+/// asserted that identity under this row's own ISIN. Without that confirmation
+/// the vendor's symbol stands, suffix and all: an unmerged row is a visible
+/// duplicate, while a wrongly merged one is two instruments silently becoming
+/// one.
+fn resolve(l: &Listing, asserted: &HashSet<(InstrumentKey, Isin)>) -> InstrumentKey {
+    match (l.unsuffixed, l.isin) {
+        (Some(candidate), Some(isin)) if asserted.contains(&(candidate, isin)) => candidate,
+        _ => l.key,
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::indexing_slicing,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+mod tests {
+    use super::*;
+    use brutex_core::instrument::{Exchange, Kind, Segment};
+    use brutex_core::symbol::Symbol;
+
+    fn key(sym: &str, kind: Kind) -> InstrumentKey {
+        InstrumentKey {
+            exchange: Exchange::Nse,
+            segment: if kind == Kind::Index {
+                Segment::Index
+            } else {
+                Segment::Cash
+            },
+            underlying: Symbol::new(sym).expect("valid"),
+            kind,
+        }
+    }
+
+    fn equity(sym: &str, isin: &str) -> Listing {
+        Listing {
+            key: key(sym, Kind::Equity),
+            isin: Some(Isin::new(isin).expect("valid")),
+            unsuffixed: None,
+        }
+    }
+
+    fn index(sym: &str) -> Listing {
+        Listing {
+            key: key(sym, Kind::Index),
+            isin: None,
+            unsuffixed: None,
+        }
+    }
+
+    /// One vendor that declined nothing, which is what most tests need.
+    fn from(vendor: Vendor, kept: Vec<Listing>) -> Source {
+        Source {
+            vendor,
+            kept,
+            declined: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn one_instrument_named_by_both_vendors_is_one_entry_with_two_tags() {
+        let m = merge(&[
+            from(Vendor::Groww, vec![equity("RELIANCE", "INE002A01018")]),
+            from(Vendor::Dhan, vec![equity("RELIANCE", "INE002A01018")]),
+        ]);
+        assert_eq!(m.len(), 1, "the collision IS the deduplication");
+        assert!(!m.is_empty());
+        let e = m.by_key[&key("RELIANCE", Kind::Equity)];
+        assert!(e.vendors.contains(Vendor::Groww));
+        assert!(e.vendors.contains(Vendor::Dhan));
+        assert_eq!(e.conflict, None);
+        assert!(m.conflicts.is_empty(), "agreement is silent");
+        assert!(m.eligibility.is_empty());
+        assert_eq!(m.verdict(), Verdict::Clean, "agreement is believable");
+        assert!(
+            e.universe.contains(Universe::FNO) && e.universe.contains(Universe::TOTAL_MARKET),
+            "the merge stamps the universe it resolved into"
+        );
+    }
+
+    #[test]
+    fn a_cross_vendor_isin_conflict_is_reported_and_neither_side_is_dropped() {
+        // The whole reason the ISIN is beside the key rather than in it: as a
+        // key field this would be two entries and no one would ever know.
+        let m = merge(&[
+            from(Vendor::Groww, vec![equity("CHOLAFIN", "INE121A01024")]),
+            from(Vendor::Dhan, vec![equity("CHOLAFIN", "INE121A08PJ0")]),
+        ]);
+        assert_eq!(m.len(), 1, "one key, not two");
+        assert_eq!(m.conflicts.len(), 1);
+        let line = &m.conflicts[0];
+        assert!(line.contains("NSE-CHOLAFIN"), "the key is named: {line}");
+        assert!(
+            line.contains("INE121A01024"),
+            "both ISINs are named: {line}"
+        );
+        assert!(
+            line.contains("INE121A08PJ0"),
+            "both ISINs are named: {line}"
+        );
+        assert!(line.contains("groww") && line.contains("dhan"), "{line}");
+
+        let e = m.by_key[&key("CHOLAFIN", Kind::Equity)];
+        assert_eq!(
+            e.isin.map(|(_, i)| i.to_string()).as_deref(),
+            Some("INE121A01024"),
+            "the first ISIN is kept"
+        );
+        assert_eq!(
+            e.conflict.map(|(_, i)| i.to_string()).as_deref(),
+            Some("INE121A08PJ0"),
+            "and so is the second -- neither is dropped, neither wins"
+        );
+        assert!(e.vendors.contains(Vendor::Groww) && e.vendors.contains(Vendor::Dhan));
+        assert_eq!(
+            m.verdict(),
+            Verdict::Disputed,
+            "a named disagreement REFUSES the universe; it is not a log line"
+        );
+    }
+
+    #[test]
+    fn one_vendor_keeping_what_another_declined_is_a_named_disagreement() {
+        // THE CHECK THAT WAS STRUCTURALLY IMPOSSIBLE. Every declined row was
+        // dropped at the reader, so a disagreement about ELIGIBILITY -- the
+        // disagreement that actually existed -- produced no conflict, no note
+        // and no count, and the report read `0 isin conflicts` while the two
+        // masters disagreed about 62 instruments carrying the SAME ISIN in
+        // both files.
+        //
+        // INF090I01VS3 is one of them: a Franklin fund plan Dhan filed as an
+        // `ETF` and Groww declined as series `MF`.
+        let disputed = Isin::new("INF090I01VS3").expect("valid");
+        let m = merge(&[
+            from(Vendor::Dhan, vec![equity("FISTIPD3GP", "INF090I01VS3")]),
+            Source {
+                vendor: Vendor::Groww,
+                kept: Vec::new(),
+                declined: vec![(disputed, Skip::NotEquityListing)],
+            },
+        ]);
+        assert!(
+            m.conflicts.is_empty(),
+            "the ISINs agree; the verdicts do not"
+        );
+        assert_eq!(m.eligibility.len(), 1);
+        let line = &m.eligibility[0];
+        assert!(line.contains("INF090I01VS3"), "{line}");
+        assert!(line.contains("dhan kept it"), "{line}");
+        assert!(line.contains("groww declined it"), "{line}");
+        assert!(line.contains("not an equity listing"), "{line}");
+        assert_eq!(m.verdict(), Verdict::Disputed);
+        // The instrument stays in the map. Dropping it would hide the
+        // disagreement, which is the failure the check exists to prevent.
+        assert_eq!(m.len(), 1);
+    }
+
+    #[test]
+    fn a_decline_about_the_venue_is_not_a_disagreement_about_the_paper() {
+        // RELIANCE is INE002A01018 on NSE and on BSE. One vendor declining the
+        // BSE row for being BSE while the other keeps the NSE row is two
+        // CORRECT decisions about two different rows -- and counting it as a
+        // conflict produced 3,000 false lines on the real masters, which is a
+        // check nobody reads twice.
+        let reliance = Isin::new("INE002A01018").expect("valid");
+        for venue in [
+            Skip::ForeignExchange,
+            Skip::ForeignSegment,
+            Skip::LiveContract,
+            Skip::TestInstrument,
+        ] {
+            let m = merge(&[
+                from(Vendor::Dhan, vec![equity("RELIANCE", "INE002A01018")]),
+                Source {
+                    vendor: Vendor::Groww,
+                    kept: vec![equity("RELIANCE", "INE002A01018")],
+                    declined: vec![(reliance, venue)],
+                },
+            ]);
+            // Bound rather than called inside the failure message: a call
+            // there is a region only a FAILING assertion runs.
+            let what = venue.reason();
+            assert!(
+                m.eligibility.is_empty(),
+                "{what} judges the venue, not the paper"
+            );
+            assert_eq!(m.verdict(), Verdict::Clean);
+        }
+        // The three that DO judge the paper are the three that can conflict.
+        for paper in [
+            Skip::NotEquityListing,
+            Skip::SmeBoard,
+            Skip::UnrecognisedListingClass,
+        ] {
+            let m = merge(&[
+                from(Vendor::Dhan, vec![equity("RELIANCE", "INE002A01018")]),
+                Source {
+                    vendor: Vendor::Groww,
+                    kept: Vec::new(),
+                    declined: vec![(reliance, paper)],
+                },
+            ]);
+            let what = paper.reason();
+            assert_eq!(m.eligibility.len(), 1, "{what} judges the paper");
+        }
+    }
+
+    #[test]
+    fn a_decline_nobody_else_kept_is_not_a_disagreement() {
+        // A master is mostly declines. Only a decline that some OTHER vendor
+        // contradicts is news, or every bond in the file would be a conflict.
+        let m = merge(&[
+            from(Vendor::Dhan, vec![equity("RELIANCE", "INE002A01018")]),
+            Source {
+                vendor: Vendor::Groww,
+                kept: vec![equity("RELIANCE", "INE002A01018")],
+                declined: vec![
+                    (
+                        Isin::new("INE121A08PJ0").expect("valid"),
+                        Skip::NotEquityListing,
+                    ),
+                    (
+                        Isin::new("IN1520250086").expect("valid"),
+                        Skip::NotEquityListing,
+                    ),
+                ],
+            },
+        ]);
+        assert!(
+            m.eligibility.is_empty(),
+            "nobody kept those, so nobody disagrees"
+        );
+        assert_eq!(m.verdict(), Verdict::Clean);
+
+        // And one vendor declining what IT ALSO kept is a statement about one
+        // vendor, not a cross-vendor disagreement.
+        let m = merge(&[Source {
+            vendor: Vendor::Groww,
+            kept: vec![equity("RELIANCE", "INE002A01018")],
+            declined: vec![(Isin::new("INE002A01018").expect("valid"), Skip::SmeBoard)],
+        }]);
+        assert!(m.eligibility.is_empty());
+        assert_eq!(m.verdict(), Verdict::Clean);
+    }
+
+    #[test]
+    fn the_census_separates_what_two_vendors_confirmed_from_what_one_asserted() {
+        // 211 of the 213 F&O underlyings are named by both masters; MIDCPNIFTY
+        // and NIFTYNXT50 are Dhan's spellings for indices Groww calls
+        // NIFTYMIDSELECT and NIFTYJR, and an index carries no ISIN, so nothing
+        // cross-checks them at all. Reporting only "213 present" would make
+        // one vendor's word look like two vendors' agreement.
+        let m = merge(&[
+            from(
+                Vendor::Groww,
+                vec![
+                    index("NIFTY"),
+                    index("NIFTYJR"),
+                    equity("RELIANCE", "INE002A01018"),
+                ],
+            ),
+            from(
+                Vendor::Dhan,
+                vec![
+                    index("NIFTY"),
+                    index("NIFTYNXT50"),
+                    equity("RELIANCE", "INE002A01018"),
+                ],
+            ),
+        ]);
+        let census = m.universe_census();
+        assert_eq!(
+            census,
+            vec![
+                // NIFTY, NIFTYNXT50 and RELIANCE are F&O underlyings; only
+                // NIFTY and RELIANCE are named by both. NIFTYJR is in neither
+                // list under that spelling, which is exactly the finding.
+                ("F&O underlyings", 3, 2),
+                ("NIFTY Total Market", 1, 1),
+            ]
+        );
+        // BOTH spellings surface, because both are indices named by one vendor
+        // only and an index has no ISIN to reconcile them with. Naming them is
+        // the whole substitute for a cross-check that cannot exist.
+        let single = m.single_vendor_members();
+        assert_eq!(
+            single,
+            vec![
+                "NSE-NIFTYJR (groww)".to_owned(),
+                "NSE-NIFTYNXT50 (dhan)".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn a_suffixed_symbol_merges_only_when_the_isin_confirms_it() {
+        // Groww says BLUECHIP-BE, Dhan says BLUECHIP, and the ISIN says they
+        // are one instrument.
+        let suffixed = Listing {
+            key: key("BLUECHIP-BE", Kind::Equity),
+            isin: Some(Isin::new("INE657B01025").expect("valid")),
+            unsuffixed: Some(key("BLUECHIP", Kind::Equity)),
+        };
+        let m = merge(&[
+            from(Vendor::Groww, vec![suffixed]),
+            from(Vendor::Dhan, vec![equity("BLUECHIP", "INE657B01025")]),
+        ]);
+        assert_eq!(m.len(), 1, "confirmed, so they merge");
+        let e = m.by_key[&key("BLUECHIP", Kind::Equity)];
+        assert!(e.vendors.contains(Vendor::Groww) && e.vendors.contains(Vendor::Dhan));
+        assert!(m.conflicts.is_empty());
+        assert_eq!(m.verdict(), Verdict::Clean);
+    }
+
+    #[test]
+    fn an_unconfirmed_suffix_is_left_exactly_as_the_vendor_wrote_it() {
+        // Same shape, but no vendor asserts BLUECHIP under that ISIN. An
+        // unmerged row is a visible duplicate; a wrongly merged one is two
+        // instruments silently becoming one.
+        let suffixed = Listing {
+            key: key("BLUECHIP-BE", Kind::Equity),
+            isin: Some(Isin::new("INE657B01025").expect("valid")),
+            unsuffixed: Some(key("BLUECHIP", Kind::Equity)),
+        };
+        let m = merge(&[from(Vendor::Groww, vec![suffixed])]);
+        assert_eq!(m.len(), 1);
+        assert!(m.by_key.contains_key(&key("BLUECHIP-BE", Kind::Equity)));
+
+        // And a candidate confirmed under a DIFFERENT ISIN is not confirmed at
+        // all -- this is the case that separates "same ticker" from "same
+        // paper", and it must not merge.
+        let m = merge(&[
+            from(Vendor::Groww, vec![suffixed]),
+            from(Vendor::Dhan, vec![equity("BLUECHIP", "INE002A01018")]),
+        ]);
+        assert_eq!(m.len(), 2, "different ISIN, so different instruments");
+        assert!(m.conflicts.is_empty(), "they never met, so nothing clashed");
+    }
+
+    #[test]
+    fn an_index_carries_no_isin_and_still_merges_on_identity() {
+        let m = merge(&[
+            from(Vendor::Groww, vec![index("NIFTY")]),
+            from(Vendor::Dhan, vec![index("NIFTY")]),
+        ]);
+        assert_eq!(m.len(), 1);
+        let e = m.by_key[&key("NIFTY", Kind::Index)];
+        assert_eq!(e.isin, None, "no sentinel ISIN is invented for NIFTY");
+        assert!(e.vendors.contains(Vendor::Groww) && e.vendors.contains(Vendor::Dhan));
+        assert!(m.conflicts.is_empty());
+        assert!(e.universe.contains(Universe::INDEX));
+        assert!(
+            m.single_vendor_members().is_empty(),
+            "both vendors spell NIFTY the same way, so nothing rests on one"
+        );
+    }
+
+    #[test]
+    fn a_vendor_with_nothing_to_add_neither_overwrites_nor_conflicts() {
+        // One vendor knows the ISIN, the other does not carry one. That is not
+        // a disagreement, and the known value must survive it.
+        let bare = Listing {
+            key: key("RELIANCE", Kind::Equity),
+            isin: None,
+            unsuffixed: None,
+        };
+        let m = merge(&[
+            from(Vendor::Groww, vec![equity("RELIANCE", "INE002A01018")]),
+            from(Vendor::Dhan, vec![bare]),
+        ]);
+        let e = m.by_key[&key("RELIANCE", Kind::Equity)];
+        assert_eq!(
+            e.isin.map(|(v, _)| v),
+            Some(Vendor::Groww),
+            "the vendor that knew it is recorded"
+        );
+        assert_eq!(e.conflict, None);
+        assert!(m.conflicts.is_empty());
+
+        // And in the other order, the entry starts empty and is filled later.
+        let m = merge(&[
+            from(Vendor::Dhan, vec![bare]),
+            from(Vendor::Groww, vec![equity("RELIANCE", "INE002A01018")]),
+        ]);
+        assert_eq!(
+            m.by_key[&key("RELIANCE", Kind::Equity)]
+                .isin
+                .map(|(v, _)| v),
+            Some(Vendor::Groww)
+        );
+    }
+
+    #[test]
+    fn merging_nothing_produces_nothing_rather_than_a_default_row() {
+        let m = merge(&[]);
+        assert!(m.is_empty());
+        assert_eq!(m.len(), 0);
+        assert!(m.conflicts.is_empty());
+        assert!(m.eligibility.is_empty());
+        assert_eq!(
+            m.verdict(),
+            Verdict::Clean,
+            "nothing said, nothing disputed"
+        );
+        assert_eq!(
+            m.universe_census(),
+            vec![("F&O underlyings", 0, 0), ("NIFTY Total Market", 0, 0)]
+        );
+        assert!(m.single_vendor_members().is_empty());
+    }
+}

--- a/crates/api/src/render.rs
+++ b/crates/api/src/render.rs
@@ -17,7 +17,7 @@
 //!
 //! Instrument symbols come from a vendor file. A vendor is not an attacker,
 //! but a vendor is also not a validator, and `<` in a symbol would break the
-//! page. [`Symbol`](core::symbol::Symbol) already refuses every byte outside
+//! page. [`brutex_core::symbol::Symbol`] already refuses every byte outside
 //! `A-Z 0-9 - _ &`, so the dangerous characters cannot reach here — but `&`
 //! **can**, and an unescaped `&` produces malformed HTML. Escaping is applied
 //! anyway, because a rule that depends on a guarantee two crates away is a
@@ -29,7 +29,10 @@
 //! shows what a person can read; the other 90,000 instruments cost nothing
 //! because they are never touched.
 
-use core::instrument::{InstrumentKey, Kind};
+use brutex_core::instrument::{InstrumentKey, Kind};
+use brutex_core::isin::Isin;
+use brutex_core::universe::Universe;
+use brutex_core::vendor::{Vendor, VendorSet};
 use std::fmt::Write as _;
 
 /// The stylesheet, inlined so the page is a single response.
@@ -37,18 +40,103 @@ use std::fmt::Write as _;
 /// Kept here rather than in a `.css` file on purpose: one file means one
 /// request and no second route to serve, and the page is small enough that
 /// splitting it would be organisation for its own sake.
+/// The whole stylesheet, inlined.
+///
+/// # Why every effect here is CSS and none of it is script
+///
+/// `.js` is not an allowed tracked extension (CLAUDE.md §2), so the page has
+/// no scripting available to it at all. That turns out to cost nothing: the
+/// animations below run on the compositor thread, which is strictly faster
+/// than a script-driven equivalent and cannot block, throw, or leak. A page
+/// that renders correctly with scripting disabled is also a page that cannot
+/// break in a browser we never tested.
+///
+/// `prefers-reduced-motion` disables every animation in one rule, and
+/// `prefers-color-scheme` supplies the dark palette, so both are honoured
+/// without a preference toggle to store.
 const STYLE: &str = "\
-body{font:14px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;margin:2rem;color:#111;background:#fff}\
-h1{font-size:1.1rem;margin:0 0 .25rem}\
-p.sub{color:#666;margin:0 0 1.25rem}\
-table{border-collapse:collapse;width:100%}\
-th,td{text-align:left;padding:.35rem .6rem;border-bottom:1px solid #e5e5e5;white-space:nowrap}\
-th{background:#fafafa;font-weight:600;border-bottom:2px solid #ddd}\
+*{box-sizing:border-box;margin:0;padding:0}\
+:root{--bg:#f5f7fb;--panel:#fff;--ink:#0a0f1e;--dim:#5a6478;--line:#e4e9f3;\
+--acc:#4f46e5;--acc2:#0ea5e9;--ok:#059669;--warn:#d97706;--bad:#dc2626;\
+--sh:0 1px 2px rgba(16,24,40,.05),0 10px 30px rgba(16,24,40,.07)}\
+@media(prefers-color-scheme:dark){:root{--bg:#060911;--panel:#0e1524;--ink:#e9efff;--dim:#8f9db6;\
+--line:#1b2540;--acc:#818cf8;--acc2:#38bdf8;--sh:0 1px 2px rgba(0,0,0,.5),0 12px 36px rgba(0,0,0,.55)}}\
+body{background:var(--bg);color:var(--ink);\
+font:15px/1.55 ui-sans-serif,-apple-system,Segoe UI,Inter,system-ui,sans-serif;\
+-webkit-font-smoothing:antialiased;padding:0 0 64px}\
+h1{font-size:clamp(22px,3.4vw,31px);letter-spacing:-1.1px;font-weight:830;line-height:1.12;\
+margin:0 auto;max-width:1180px;padding:34px 20px 6px;animation:rise .6s cubic-bezier(.2,.8,.2,1) both}\
+@keyframes rise{from{opacity:0;transform:translateY(12px)}}\
+p.sub{color:var(--dim);font-size:14px;margin:0 auto 18px;max-width:1180px;padding:0 20px;\
+animation:rise .6s .06s cubic-bezier(.2,.8,.2,1) both}\
+form{margin:0 auto 16px;max-width:1180px;padding:0 20px;display:flex;gap:9px;align-items:center;flex-wrap:wrap}\
+input[type=text]{font:inherit;padding:10px 14px;border:1px solid var(--line);border-radius:11px;\
+min-width:min(24rem,100%);background:var(--panel);color:var(--ink);box-shadow:var(--sh);\
+transition:border-color .2s,box-shadow .2s}\
+input[type=text]:focus{outline:0;border-color:var(--acc);box-shadow:0 0 0 4px color-mix(in srgb,var(--acc) 18%,transparent)}\
+button{font:inherit;font-weight:700;padding:10px 20px;border:0;border-radius:11px;cursor:pointer;\
+background:linear-gradient(135deg,var(--acc),var(--acc2));color:#fff;\
+box-shadow:0 5px 16px color-mix(in srgb,var(--acc) 34%,transparent);transition:transform .2s,box-shadow .2s}\
+button:hover{transform:translateY(-2px);box-shadow:0 9px 24px color-mix(in srgb,var(--acc) 42%,transparent)}\
+form a{color:var(--dim);font-size:13px;text-decoration:none}\
+form a:hover{color:var(--acc)}\
+ul.notes{margin:0 auto 16px;max-width:1180px;padding:14px 18px 14px 34px;list-style:none;\
+background:var(--panel);border:1px solid var(--line);border-radius:13px;box-shadow:var(--sh);\
+color:var(--dim);font-size:13.5px}\
+ul.notes li{margin:3px 0;position:relative}\
+ul.notes li:before{content:'';position:absolute;left:-16px;top:8px;width:6px;height:6px;\
+border-radius:50%;background:var(--dim)}\
+ul.notes li.loud{color:var(--bad);font-weight:750}\
+ul.notes li.loud:before{background:var(--bad);animation:blip 1.6s infinite}\
+@keyframes blip{50%{opacity:.25}}\
+table{border-collapse:collapse;width:100%;font-size:13.5px;\
+margin:0 auto;background:var(--panel)}\
+thead th{position:sticky;top:0;z-index:2;text-align:left;padding:12px 15px;background:var(--panel);\
+font-size:10.5px;letter-spacing:.85px;text-transform:uppercase;color:var(--dim);font-weight:780;\
+border-bottom:1px solid var(--line);white-space:nowrap}\
+td{padding:11px 15px;border-bottom:1px solid var(--line);white-space:nowrap}\
 td.num{text-align:right;font-variant-numeric:tabular-nums}\
-tr:hover td{background:#f6f9ff}\
-.tag{font-size:11px;padding:.1rem .4rem;border-radius:3px;background:#eef;color:#334}\
-.swept{background:#e6f7e6;color:#141}\
-footer{margin-top:1.5rem;color:#888;font-size:12px}";
+tbody tr{animation:rowin .4s both;transition:background .15s}\
+@keyframes rowin{from{opacity:0;transform:translateY(5px)}}\
+tbody tr:hover td{background:color-mix(in srgb,var(--acc) 7%,transparent)}\
+.tag{display:inline-block;font-size:10px;font-weight:820;letter-spacing:.5px;padding:3px 8px;\
+border-radius:6px;margin-right:5px;background:color-mix(in srgb,var(--acc) 14%,transparent);color:var(--acc)}\
+.swept{background:color-mix(in srgb,var(--ok) 16%,transparent);color:var(--ok)}\
+td.clash{background:color-mix(in srgb,var(--bad) 12%,transparent);color:var(--bad);font-weight:750}\
+thead th a{color:inherit;text-decoration:none;display:block}\
+thead th a:hover{color:var(--acc)}\
+.filters{margin:0 auto;max-width:1180px;padding:0 20px}\
+.filters input{position:absolute;opacity:0;pointer-events:none}\
+.pills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 14px}\
+.pills label{cursor:pointer;user-select:none;padding:9px 16px;border-radius:99px;font-weight:650;\
+font-size:13.5px;border:1px solid var(--line);background:var(--panel);color:var(--dim);\
+transition:all .22s cubic-bezier(.2,.8,.2,1)}\
+.pills label:hover{transform:translateY(-2px);border-color:var(--acc);color:var(--ink)}\
+.pills label b{font-variant-numeric:tabular-nums;opacity:.65;margin-left:7px;font-weight:700}\
+#f-all:checked~.pills label[for=f-all],\
+#f-fno:checked~.pills label[for=f-fno],\
+#f-ntm:checked~.pills label[for=f-ntm],\
+#f-idx:checked~.pills label[for=f-idx]\
+{background:linear-gradient(135deg,var(--acc),var(--acc2));border-color:transparent;color:#fff;\
+box-shadow:0 6px 18px color-mix(in srgb,var(--acc) 34%,transparent);transform:translateY(-1px)}\
+#f-fno:checked~table tbody tr:not(.u-fno),\
+#f-ntm:checked~table tbody tr:not(.u-ntm),\
+#f-idx:checked~table tbody tr:not(.u-idx){display:none}\
+footer{margin:22px auto 0;max-width:1180px;padding:0 20px;color:var(--dim);font-size:12.5px;line-height:1.9}\
+@media(prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}";
+
+/// Words that make a note a failure rather than a tally.
+///
+/// A conflict line that renders in the same grey as a row count is a line
+/// nobody reads. These are the notes an operator has to see even when the page
+/// is full of ordinary numbers.
+const LOUD: [&str; 5] = [
+    "UNAVAILABLE",
+    "CONFLICT",
+    "UNREADABLE",
+    "UNRECOGNISED",
+    "UNCHECKED",
+];
 
 /// Escapes the five characters that change HTML meaning.
 ///
@@ -80,10 +168,42 @@ pub fn escape(raw: &str) -> String {
 pub struct Row {
     /// The canonical identity.
     pub key: InstrumentKey,
-    /// Whether the primary broker's master listed it.
-    pub from_groww: bool,
-    /// Whether the secondary broker's master listed it.
-    pub from_dhan: bool,
+    /// Which vendors listed it.
+    ///
+    /// A set rather than one `bool` per vendor: a `bool` per vendor forces
+    /// this crate to `match` on [`Vendor`], which is `#[non_exhaustive]`, and
+    /// that match needs a wildcard arm no test can ever reach.
+    pub vendors: VendorSet,
+    /// The ISIN the vendors agreed on, if they carry one.
+    pub isin: Option<Isin>,
+    /// A second, different ISIN for the same identity. Rendered loudly:
+    /// a disagreement the operator cannot see is a disagreement that decides
+    /// the run on its own.
+    pub conflict: Option<Isin>,
+    /// Which of the engine's lists this instrument is in.
+    pub universe: Universe,
+}
+
+/// Renders the universe cell.
+///
+/// On the page rather than only in a count, because the reason 1,117 SME
+/// shares are declined is that neither list contains one — and a claim that
+/// load-bearing should be visible against every row it governs.
+fn universe_cell(u: Universe) -> String {
+    let mut tags = Vec::new();
+    for (bit, label) in [
+        (Universe::INDEX, "index"),
+        (Universe::FNO, "F&amp;O"),
+        (Universe::TOTAL_MARKET, "total mkt"),
+    ] {
+        if u.contains(bit) {
+            tags.push(format!("<span class=\"tag\">{label}</span>"));
+        }
+    }
+    if tags.is_empty() {
+        return "<td>—</td>".to_owned();
+    }
+    format!("<td>{}</td>", tags.join(" "))
 }
 
 /// Renders one row's kind, expiry and strike cells.
@@ -119,13 +239,73 @@ fn kind_cells(kind: Kind) -> String {
 /// single row *is* the O(1) dedup, on screen.
 fn vendor_cell(row: &Row) -> String {
     let mut tags = Vec::new();
-    if row.from_groww {
-        tags.push("<span class=\"tag\">groww</span>");
-    }
-    if row.from_dhan {
-        tags.push("<span class=\"tag\">dhan</span>");
+    for v in Vendor::ALL {
+        if row.vendors.contains(v) {
+            tags.push(format!("<span class=\"tag\">{}</span>", escape(v.as_str())));
+        }
     }
     format!("<td>{}</td>", tags.join(" "))
+}
+
+/// Renders the ISIN cell — the cross-check, and any disagreement about it.
+///
+/// A conflicting pair is rendered in the row rather than only counted in a
+/// summary, because `docs/05-decisions.md` D-0020 requires a vendor
+/// disagreement to NAME what disagreed. A count says a problem exists; this
+/// says which instrument has it.
+fn isin_cell(row: &Row) -> String {
+    match (row.isin, row.conflict) {
+        (None, _) => "<td>—</td>".to_owned(),
+        (Some(i), None) => format!("<td>{}</td>", escape(i.as_str())),
+        (Some(i), Some(other)) => format!(
+            "<td class=\"clash\">{} ≠ {}</td>",
+            escape(i.as_str()),
+            escape(other.as_str())
+        ),
+    }
+}
+
+/// The universe filter — four radio inputs, four labels, one CSS rule.
+///
+/// Extracted from [`instruments_page`] because that function is at clippy's
+/// 100-line ceiling; the split is a lint, not a design.
+fn filter_pills(rows: &[Row]) -> String {
+    let mut out = String::with_capacity(512);
+    // THE UNIVERSE FILTER — four radio inputs and one CSS rule.
+    //
+    // No script, and none is wanted: `#f-fno:checked ~ table tbody tr:not(.u-fno)
+    // {display:none}` is resolved by the browser's selector engine in native
+    // code. It is faster than any handler could be, it cannot throw, and it
+    // needs no round trip — filtering is instant and the server is not touched.
+    //
+    // The inputs precede the table because a sibling combinator only reaches
+    // FORWARD; that ordering is load-bearing, not cosmetic.
+    //
+    // Counts are of the whole universe, not of this page, so a filter never
+    // implies the 200 rendered rows are all there are.
+    let (n_fno, n_ntm, n_idx) = rows.iter().fold((0, 0, 0), |(f, t, i), r| {
+        (
+            f + usize::from(r.universe.contains(Universe::FNO)),
+            t + usize::from(r.universe.contains(Universe::TOTAL_MARKET)),
+            i + usize::from(r.universe.contains(Universe::INDEX)),
+        )
+    });
+    let _ = write!(
+        out,
+        "<section class=\"filters\">\
+         <input type=\"radio\" name=\"u\" id=\"f-all\" checked>\
+         <input type=\"radio\" name=\"u\" id=\"f-fno\">\
+         <input type=\"radio\" name=\"u\" id=\"f-ntm\">\
+         <input type=\"radio\" name=\"u\" id=\"f-idx\">\
+         <div class=\"pills\">\
+         <label for=\"f-all\">All<b>{}</b></label>\
+         <label for=\"f-fno\">F&amp;O<b>{n_fno}</b></label>\
+         <label for=\"f-ntm\">NIFTY Total Market<b>{n_ntm}</b></label>\
+         <label for=\"f-idx\">Indices<b>{n_idx}</b></label>\
+         </div>",
+        rows.len()
+    );
+    out
 }
 
 /// Renders a complete instruments page.
@@ -133,8 +313,22 @@ fn vendor_cell(row: &Row) -> String {
 /// `total` is the size of the whole universe, `rows` is only what this page
 /// shows. Passing both keeps the page honest about the difference between what
 /// exists and what was rendered.
+///
+/// `notes` is rendered on **every** page, filtered or not. It carries
+/// `UNAVAILABLE` and every conflict line, and it used to be folded into the
+/// title only when no query had been typed — so searching, which is the only
+/// way to reach most of the universe, silently dropped the one thing the page
+/// existed to say.
 #[must_use]
-pub fn instruments_page(title: &str, total: usize, rows: &[Row]) -> String {
+pub fn instruments_page(
+    title: &str,
+    total: usize,
+    rows: &[Row],
+    query: &str,
+    sort: &str,
+    all: bool,
+    notes: &[String],
+) -> String {
     let mut body = String::with_capacity(1024 + rows.len() * 256);
     body.push_str("<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">");
     body.push_str("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
@@ -143,6 +337,25 @@ pub fn instruments_page(title: &str, total: usize, rows: &[Row]) -> String {
     body.push_str("</title><style>");
     body.push_str(STYLE);
     body.push_str("</style></head><body>");
+
+    // A search form. Method GET so the query lives in the URL and a result is
+    // linkable and reloadable -- no JavaScript, no client state.
+    let _ = write!(
+        body,
+        "<form method=\"get\" action=\"/instruments\">\
+         <input type=\"text\" name=\"q\" placeholder=\"NIFTY, BANKNIFTY, RELIANCE…\" \
+         value=\"{}\" autofocus>\
+         <button type=\"submit\">Search</button>\
+         <a href=\"/instruments\">clear</a>\
+         <a href=\"/instruments?all={}\">{}</a></form>",
+        escape(query),
+        u8::from(!all),
+        if all {
+            "show tracked only (NIFTY Total Market + indices)"
+        } else {
+            "show every NSE listing"
+        }
+    );
 
     body.push_str("<h1>");
     body.push_str(&escape(title));
@@ -157,31 +370,75 @@ pub fn instruments_page(title: &str, total: usize, rows: &[Row]) -> String {
         rows.len()
     );
 
-    body.push_str(
-        "<table><thead><tr>\
-         <th>Canonical key</th><th>Vendors</th><th>Underlying</th>\
-         <th>Kind</th><th>Expiry</th><th>Strike</th>\
-         </tr></thead><tbody>",
-    );
-
-    for row in rows {
-        let swept = if row.key.is_sweepable() {
-            " class=\"swept\""
+    // THE NOTES, ON EVERY PAGE. Not folded into the title, and not conditional
+    // on the query being empty.
+    body.push_str("<ul class=\"notes\">");
+    for note in notes {
+        let loud = if LOUD.iter().any(|w| note.contains(w)) {
+            " class=\"loud\""
         } else {
             ""
         };
+        let _ = write!(body, "<li{loud}>{}</li>", escape(note));
+    }
+    body.push_str("</ul>");
+
+    body.push_str(&filter_pills(rows));
+
+    // SORTABLE HEADERS. Links, not script: the order is part of the URL, so a
+    // sorted view is linkable, reloadable and back-buttonable, and the server
+    // decides it once from data already in memory. The query is carried through
+    // so sorting does not silently clear a search.
+    let q = escape(query);
+    let sort_link = |col: &str, label: &str| -> String {
+        let mark = if sort == col { " ▾" } else { "" };
+        format!("<th><a href=\"/instruments?q={q}&amp;sort={col}\">{label}{mark}</a></th>")
+    };
+    body.push_str("<table><thead><tr>");
+    for (col, label) in [
+        ("key", "Canonical key"),
+        ("vendors", "Vendors"),
+        ("symbol", "Underlying"),
+        ("isin", "ISIN"),
+        ("universe", "Universe"),
+        ("kind", "Kind"),
+    ] {
+        body.push_str(&sort_link(col, label));
+    }
+    body.push_str("<th>Expiry</th><th>Strike</th></tr></thead><tbody>");
+
+    for row in rows {
+        // Classes carry BOTH facts: whether the engine sweeps it (colour) and
+        // which lists it is in (what the filter selects on). One attribute,
+        // because a second would need a wrapper element per row.
+        let mut classes = String::new();
+        if row.key.is_sweepable() {
+            classes.push_str("swept ");
+        }
+        for (bit, name) in [
+            (Universe::FNO, "u-fno"),
+            (Universe::TOTAL_MARKET, "u-ntm"),
+            (Universe::INDEX, "u-idx"),
+        ] {
+            if row.universe.contains(bit) {
+                classes.push_str(name);
+                classes.push(' ');
+            }
+        }
         let _ = write!(
             body,
-            "<tr{}><td>{}</td>{}<td>{}</td>{}</tr>",
-            swept,
+            "<tr class=\"{}\"><td>{}</td>{}<td>{}</td>{}{}{}</tr>",
+            classes.trim_end(),
             escape(&row.key.to_string()),
             vendor_cell(row),
             escape(row.key.underlying.as_str()),
+            isin_cell(row),
+            universe_cell(row.universe),
             kind_cells(row.key.kind),
         );
     }
 
-    body.push_str("</tbody></table>");
+    body.push_str("</tbody></table></section>");
     body.push_str(
         "<footer>Rendered on the server. No JavaScript — \
          CLAUDE.md section 2 does not permit it, and CI gate 1 enforces that.</footer>",
@@ -199,9 +456,9 @@ pub fn instruments_page(title: &str, total: usize, rows: &[Row]) -> String {
 )]
 mod tests {
     use super::*;
-    use core::instrument::{Exchange, Expiry, OptionSide, Segment};
-    use core::price::Paisa;
-    use core::symbol::Symbol;
+    use brutex_core::instrument::{Exchange, Expiry, OptionSide, Segment};
+    use brutex_core::price::Paisa;
+    use brutex_core::symbol::Symbol;
 
     fn nifty() -> InstrumentKey {
         InstrumentKey::index(Exchange::Nse, "NIFTY").expect("valid")
@@ -218,6 +475,26 @@ mod tests {
                 side: OptionSide::Call,
             },
         }
+    }
+
+    /// A row listed by exactly the given vendors, with no ISIN.
+    fn row(key: InstrumentKey, vendors: &[Vendor]) -> Row {
+        let mut set = VendorSet::EMPTY;
+        for &v in vendors {
+            set = set.with(v);
+        }
+        Row {
+            key,
+            vendors: set,
+            isin: None,
+            conflict: None,
+            universe: brutex_core::universe::of_instrument(&key),
+        }
+    }
+
+    /// A page with no notes, for the tests that are about rows.
+    fn page(title: &str, total: usize, rows: &[Row], query: &str) -> String {
+        instruments_page(title, total, rows, query, "", false, &[])
     }
 
     #[test]
@@ -241,15 +518,7 @@ mod tests {
             underlying: Symbol::new("M&M").expect("valid"),
             kind: Kind::Equity,
         };
-        let html = instruments_page(
-            "x",
-            1,
-            &[Row {
-                key,
-                from_groww: true,
-                from_dhan: false,
-            }],
-        );
+        let html = page("x", 1, &[row(key, &[Vendor::Groww])], "");
         assert!(html.contains("M&amp;M"), "the ampersand must be escaped");
         assert!(
             !html.contains("<td>M&M<"),
@@ -259,24 +528,25 @@ mod tests {
 
     #[test]
     fn a_swept_instrument_is_marked_and_others_are_not() {
-        let html = instruments_page(
+        let html = page(
             "NSE",
             2,
             &[
-                Row {
-                    key: nifty(),
-                    from_groww: true,
-                    from_dhan: true,
-                },
-                Row {
-                    key: opt(),
-                    from_groww: true,
-                    from_dhan: false,
-                },
+                row(nifty(), &[Vendor::Groww, Vendor::Dhan]),
+                row(opt(), &[Vendor::Groww]),
             ],
+            "",
         );
+        // Counted on the CLASS, not on the whole attribute: a row's class list
+        // now also carries which universes it is in, so `class="swept"` as a
+        // literal would match only a swept row that is in no universe at all —
+        // a test that passes by accident and stops testing the thing it names.
+        // `class="swept` — the opening of a ROW's class list, with no closing
+        // quote, because the list now also carries the universes the row is in.
+        // Matching the whole attribute would find only a swept row in no
+        // universe; matching bare `swept` would also find the stylesheet rule.
         assert_eq!(
-            html.matches("class=\"swept\"").count(),
+            html.matches("class=\"swept").count(),
             1,
             "exactly one of these two is swept"
         );
@@ -284,15 +554,7 @@ mod tests {
 
     #[test]
     fn both_vendors_on_one_row_is_the_visible_dedup() {
-        let html = instruments_page(
-            "x",
-            1,
-            &[Row {
-                key: nifty(),
-                from_groww: true,
-                from_dhan: true,
-            }],
-        );
+        let html = page("x", 1, &[row(nifty(), &[Vendor::Groww, Vendor::Dhan])], "");
         assert!(html.contains(">groww<"));
         assert!(html.contains(">dhan<"));
         assert_eq!(html.matches("<tr").count(), 2, "header plus ONE data row");
@@ -300,17 +562,41 @@ mod tests {
 
     #[test]
     fn a_single_vendor_row_shows_only_that_vendor() {
-        let only_dhan = instruments_page(
-            "x",
-            1,
-            &[Row {
-                key: nifty(),
-                from_groww: false,
-                from_dhan: true,
-            }],
-        );
+        let only_dhan = page("x", 1, &[row(nifty(), &[Vendor::Dhan])], "");
         assert!(only_dhan.contains(">dhan<"));
         assert!(!only_dhan.contains(">groww<"));
+        let neither = page("x", 1, &[row(nifty(), &[])], "");
+        assert!(!neither.contains(">dhan<"));
+        assert!(!neither.contains(">groww<"));
+    }
+
+    #[test]
+    fn the_isin_cell_shows_the_cross_check_and_shouts_about_a_clash() {
+        let share = Isin::new("INE121A01024").expect("valid");
+        let bond = Isin::new("INE121A08PJ0").expect("valid");
+
+        // No ISIN at all -- an index -- is a dash, never a fabricated value.
+        assert_eq!(isin_cell(&row(nifty(), &[Vendor::Groww])), "<td>—</td>");
+
+        let agreed = Row {
+            isin: Some(share),
+            ..row(nifty(), &[Vendor::Groww])
+        };
+        assert_eq!(isin_cell(&agreed), "<td>INE121A01024</td>");
+
+        // A disagreement names BOTH values in the row itself. D-0020: a
+        // refusal names what disagreed; a count would not.
+        let clash = Row {
+            isin: Some(share),
+            conflict: Some(bond),
+            ..row(nifty(), &[Vendor::Groww, Vendor::Dhan])
+        };
+        let cell = isin_cell(&clash);
+        assert!(cell.contains("INE121A01024") && cell.contains("INE121A08PJ0"));
+        assert!(cell.contains("clash"), "and it is visibly marked: {cell}");
+
+        let html = page("x", 1, &[clash], "");
+        assert!(html.contains("INE121A08PJ0"), "it reaches the page");
     }
 
     #[test]
@@ -347,14 +633,11 @@ mod tests {
     fn the_page_states_the_true_total_not_the_rendered_count() {
         // Rendering is O(rows shown). The page must not imply it looked at
         // more than it did, nor hide how large the universe is.
-        let html = instruments_page(
+        let html = page(
             "NSE FNO",
             90_623,
-            &[Row {
-                key: nifty(),
-                from_groww: true,
-                from_dhan: true,
-            }],
+            &[row(nifty(), &[Vendor::Groww, Vendor::Dhan])],
+            "",
         );
         assert!(html.contains("90623 instruments total"));
         assert!(html.contains("showing 1"));
@@ -362,7 +645,7 @@ mod tests {
 
     #[test]
     fn an_empty_page_is_still_well_formed() {
-        let html = instruments_page("nothing here", 0, &[]);
+        let html = page("nothing here", 0, &[], "");
         assert!(html.starts_with("<!doctype html>"));
         assert!(html.ends_with("</html>"));
         assert!(html.contains("<tbody></tbody>"));
@@ -374,15 +657,7 @@ mod tests {
         // CLAUDE.md section 2 does not permit JavaScript, and a renderer that
         // emitted a <script> tag would smuggle it past gate 1, which only
         // inspects tracked FILES.
-        let html = instruments_page(
-            "x",
-            1,
-            &[Row {
-                key: opt(),
-                from_groww: true,
-                from_dhan: true,
-            }],
-        );
+        let html = page("x", 1, &[row(opt(), &[Vendor::Groww, Vendor::Dhan])], "");
         for forbidden in ["<script", "javascript:", "onclick", "onload", "onerror"] {
             assert!(!html.contains(forbidden), "{forbidden} must never appear");
         }
@@ -390,8 +665,64 @@ mod tests {
 
     #[test]
     fn the_title_is_escaped_too() {
-        let html = instruments_page("<b>x</b>", 0, &[]);
+        let html = page("<b>x</b>", 0, &[], "");
         assert!(html.contains("&lt;b&gt;x&lt;/b&gt;"));
         assert!(!html.contains("<b>x</b>"));
+    }
+
+    #[test]
+    fn the_notes_render_on_a_filtered_page_and_a_failure_is_marked_loud() {
+        // The banner is not conditional on the query. It carries UNAVAILABLE
+        // and every conflict line, and folding it into the title of the
+        // UNFILTERED page only is what made searching hide it.
+        let notes = vec![
+            "groww: 2 kept, 3 declined, 0 unreadable".to_owned(),
+            "dhan: UNAVAILABLE — no such file".to_owned(),
+            "ISIN CONFLICT · NSE-CHOLAFIN: groww says A, dhan says B".to_owned(),
+        ];
+        let html = instruments_page(
+            "search",
+            1,
+            &[row(nifty(), &[Vendor::Groww])],
+            "NIFTY",
+            "",
+            false,
+            &notes,
+        );
+        for note in &notes {
+            assert!(html.contains(&escape(note)), "{note} must be on the page");
+        }
+        assert_eq!(
+            html.matches("class=\"loud\"").count(),
+            2,
+            "the tally is quiet; UNAVAILABLE and the conflict are not"
+        );
+        // And a note is escaped like everything else.
+        let html = instruments_page("t", 0, &[], "", "", false, &["<b>x</b>".to_owned()]);
+        assert!(html.contains("&lt;b&gt;x&lt;/b&gt;"));
+        assert!(!html.contains("<li><b>"));
+    }
+
+    #[test]
+    fn the_universe_cell_names_every_list_an_instrument_is_in() {
+        // NIFTY is an index AND the underlying of its own options; RELIANCE is
+        // an F&O underlying AND a Total Market constituent; an option is in
+        // nothing at all.
+        let n = universe_cell(brutex_core::universe::of_instrument(&nifty()));
+        assert!(n.contains("index") && n.contains("F&amp;O"));
+        assert!(!n.contains("total mkt"), "an index is not a share");
+
+        let reliance = InstrumentKey {
+            exchange: Exchange::Nse,
+            segment: Segment::Cash,
+            underlying: Symbol::new("RELIANCE").expect("valid"),
+            kind: Kind::Equity,
+        };
+        let r = universe_cell(brutex_core::universe::of_instrument(&reliance));
+        assert!(r.contains("F&amp;O") && r.contains("total mkt"));
+
+        assert_eq!(universe_cell(Universe::NONE), "<td>—</td>");
+        // Never a raw ampersand, even in a hardcoded label.
+        assert!(!r.contains("F&O<"));
     }
 }

--- a/crates/api/src/render.rs
+++ b/crates/api/src/render.rs
@@ -80,15 +80,23 @@ box-shadow:0 5px 16px color-mix(in srgb,var(--acc) 34%,transparent);transition:t
 button:hover{transform:translateY(-2px);box-shadow:0 9px 24px color-mix(in srgb,var(--acc) 42%,transparent)}\
 form a{color:var(--dim);font-size:13px;text-decoration:none}\
 form a:hover{color:var(--acc)}\
-ul.notes{margin:0 auto 16px;max-width:1180px;padding:14px 18px 14px 34px;list-style:none;\
-background:var(--panel);border:1px solid var(--line);border-radius:13px;box-shadow:var(--sh);\
-color:var(--dim);font-size:13.5px}\
-ul.notes li{margin:3px 0;position:relative}\
-ul.notes li:before{content:'';position:absolute;left:-16px;top:8px;width:6px;height:6px;\
+details.notes{margin:0 auto 16px;max-width:1180px;background:var(--panel);\
+border:1px solid var(--line);border-radius:13px;box-shadow:var(--sh);\
+color:var(--dim);font-size:13px;overflow:hidden}\
+details.notes summary{cursor:pointer;padding:11px 18px;font-weight:650;list-style:none;\
+user-select:none;transition:background .18s}\
+details.notes summary::-webkit-details-marker{display:none}\
+details.notes summary:before{content:'▸ ';font-weight:800;color:var(--acc)}\
+details.notes[open] summary:before{content:'▾ '}\
+details.notes summary:hover{background:color-mix(in srgb,var(--acc) 6%,transparent)}\
+details.notes summary b{color:var(--bad);font-variant-numeric:tabular-nums}\
+details.notes ul{list-style:none;padding:2px 18px 14px 34px;margin:0;\
+border-top:1px solid var(--line)}\
+details.notes li{margin:5px 0;position:relative;line-height:1.5}\
+details.notes li:before{content:'';position:absolute;left:-16px;top:7px;width:6px;height:6px;\
 border-radius:50%;background:var(--dim)}\
-ul.notes li.loud{color:var(--bad);font-weight:750}\
-ul.notes li.loud:before{background:var(--bad);animation:blip 1.6s infinite}\
-@keyframes blip{50%{opacity:.25}}\
+details.notes li.loud{color:var(--bad);font-weight:700}\
+details.notes li.loud:before{background:var(--bad)}\
 table{border-collapse:collapse;width:100%;font-size:13.5px;\
 margin:0 auto;background:var(--panel)}\
 thead th{position:sticky;top:0;z-index:2;text-align:left;padding:12px 15px;background:var(--panel);\
@@ -115,6 +123,12 @@ transition:all .22s cubic-bezier(.2,.8,.2,1)}\
 .pills a b{font-variant-numeric:tabular-nums;opacity:.65;margin-left:7px;font-weight:700}\
 .pills a.on{background:linear-gradient(135deg,var(--acc),var(--acc2));border-color:transparent;color:#fff;\
 box-shadow:0 6px 18px color-mix(in srgb,var(--acc) 34%,transparent);transform:translateY(-1px)}\
+.pager{display:flex;gap:12px;align-items:center;justify-content:center;margin:16px auto 0;\
+max-width:1180px;padding:0 20px;font-size:13.5px}\
+.pager a{color:var(--acc);text-decoration:none;font-weight:700;padding:8px 16px;border-radius:10px;\
+border:1px solid var(--line);background:var(--panel);transition:all .2s}\
+.pager a:hover{background:linear-gradient(135deg,var(--acc),var(--acc2));color:#fff;border-color:transparent}\
+.pager span{color:var(--dim);font-variant-numeric:tabular-nums}\
 footer{margin:22px auto 0;max-width:1180px;padding:0 20px;color:var(--dim);font-size:12.5px;line-height:1.9}\
 @media(prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}";
 
@@ -154,6 +168,50 @@ pub fn escape(raw: &str) -> String {
         }
     }
     out
+}
+
+impl View<'_> {
+    /// The query string every link on the page shares, with optional overrides.
+    ///
+    /// # Why one builder
+    ///
+    /// Each link used to compose its own. The sort headers carried only the
+    /// search, so clicking a column dropped the universe filter; the pills
+    /// carried only the filter, so clicking one dropped the sort. The table
+    /// reordered *and* changed which rows it was ordering, which reads as the
+    /// data having moved under you.
+    ///
+    /// One builder makes forgetting a parameter impossible: a new parameter is
+    /// added here and every link gains it at once.
+    ///
+    /// `None` keeps the current value; `Some` overrides it. Sorting and
+    /// filtering pass `Some(0)` for the page deliberately — page 3 of an ISIN
+    /// ordering is not page 3 of a symbol ordering, so keeping the number would
+    /// land the operator somewhere arbitrary.
+    #[must_use]
+    pub fn link_params(
+        &self,
+        sort: Option<&str>,
+        active: Option<&str>,
+        page: Option<usize>,
+    ) -> String {
+        let mut out = String::with_capacity(64);
+        let _ = write!(
+            out,
+            "q={}&amp;sort={}&amp;u={}",
+            escape(self.query),
+            escape(sort.unwrap_or(self.sort)),
+            escape(active.unwrap_or(self.active)),
+        );
+        if self.all {
+            out.push_str("&amp;all=1");
+        }
+        let page = page.unwrap_or(self.page);
+        if page > 0 {
+            let _ = write!(out, "&amp;page={page}");
+        }
+        out
+    }
 }
 
 /// One row of the instruments table.
@@ -262,7 +320,8 @@ fn isin_cell(row: &Row) -> String {
 ///
 /// Extracted from [`instruments_page`] because that function is at clippy's
 /// 100-line ceiling; the split is a lint, not a design.
-fn filter_pills(counts: UniverseCounts, query: &str, active: &str, all: bool) -> String {
+fn filter_pills(view: &View<'_>) -> String {
+    let counts = view.counts;
     let mut out = String::with_capacity(512);
     // THE PILLS ARE LINKS, NOT A CSS TOGGLE.
     //
@@ -277,11 +336,16 @@ fn filter_pills(counts: UniverseCounts, query: &str, active: &str, all: bool) ->
     //
     // `all` is carried through, so widening to every NSE listing and then
     // filtering by universe compose instead of cancelling.
-    let q = escape(query);
-    let suffix = if all { "&amp;all=1" } else { "" };
     let pill = |slug: &str, label: &str, n: usize| -> String {
-        let on = if active == slug { " class=\"on\"" } else { "" };
-        format!("<a href=\"/instruments?q={q}&amp;u={slug}{suffix}\"{on}>{label}<b>{n}</b></a>")
+        let on = if view.active == slug {
+            " class=\"on\""
+        } else {
+            ""
+        };
+        format!(
+            "<a href=\"/instruments?{}\"{on}>{label}<b>{n}</b></a>",
+            view.link_params(None, Some(slug), Some(0))
+        )
     };
     let _ = write!(
         out,
@@ -315,16 +379,46 @@ pub struct UniverseCounts {
 ///
 /// Split out of [`instruments_page`] to stay under clippy's 100-line ceiling.
 /// The split is a lint, not a design.
-fn table(rows: &[Row], query: &str, sort: &str) -> String {
+fn table(rows: &[Row], view: &View<'_>) -> String {
     let mut body = String::with_capacity(256 + rows.len() * 256);
     // SORTABLE HEADERS. Links, not script: the order is part of the URL, so a
     // sorted view is linkable, reloadable and back-buttonable, and the server
-    // decides it once from data already in memory. The query is carried through
-    // so sorting does not silently clear a search.
-    let q = escape(query);
+    // decides it once from data already in memory.
+    //
+    // The link carries EVERY other parameter. It used to carry only the search,
+    // so clicking a column header silently dropped the universe filter and the
+    // page — the table reordered AND changed which rows it was ordering, which
+    // reads as the data having moved.
+    //
+    // Paging resets to page 1 deliberately: page 3 of an ISIN ordering is not
+    // page 3 of a symbol ordering, and keeping the number would land the
+    // operator somewhere arbitrary.
+    // ASCENDING AND DESCENDING. Clicking the column you are already sorted by
+    // REVERSES it; clicking a different column starts that one ascending.
+    //
+    // The direction is a `-` prefix on the column name, so it needs no second
+    // parameter and an old one-way link still means exactly what it did.
+    let sort = view.sort;
     let sort_link = |col: &str, label: &str| -> String {
-        let mark = if sort == col { " ▾" } else { "" };
-        format!("<th><a href=\"/instruments?q={q}&amp;sort={col}\">{label}{mark}</a></th>")
+        let (active, descending) = match sort.strip_prefix('-') {
+            Some(base) => (base == col, true),
+            None => (sort == col, false),
+        };
+        // Already on this column ascending -> offer descending, and vice versa.
+        let next = if active && !descending {
+            format!("-{col}")
+        } else {
+            col.to_owned()
+        };
+        let mark = match (active, descending) {
+            (true, false) => " ▲",
+            (true, true) => " ▼",
+            _ => "",
+        };
+        format!(
+            "<th><a href=\"/instruments?{}\">{label}{mark}</a></th>",
+            view.link_params(Some(&next), None, Some(0))
+        )
     };
     body.push_str("<table><thead><tr>");
     for (col, label) in [
@@ -397,6 +491,10 @@ pub struct View<'a> {
     pub counts: UniverseCounts,
     /// Which universe pill is selected.
     pub active: &'a str,
+    /// Which page of rows this is, zero-based.
+    pub page: usize,
+    /// The highest page number that has rows.
+    pub last_page: usize,
     /// Every line an operator has to be told.
     pub notes: &'a [String],
 }
@@ -414,16 +512,19 @@ pub struct View<'a> {
 /// existed to say.
 #[must_use]
 pub fn instruments_page(view: &View<'_>) -> String {
+    // `sort`, `counts` and `active` are not bound here: they are read through
+    // `view` by `table`, `filter_pills` and `View::link_params`, which is the
+    // point of routing every link through one builder.
     let View {
         title,
         total,
         rows,
         query,
-        sort,
         all,
-        counts,
-        active,
+        page,
+        last_page,
         notes,
+        ..
     } = *view;
     let mut body = String::with_capacity(1024 + rows.len() * 256);
     body.push_str("<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">");
@@ -468,7 +569,27 @@ pub fn instruments_page(view: &View<'_>) -> String {
 
     // THE NOTES, ON EVERY PAGE. Not folded into the title, and not conditional
     // on the query being empty.
-    body.push_str("<ul class=\"notes\">");
+    // THE NOTES, COLLAPSED BY DEFAULT.
+    //
+    // They were an always-open panel. With 31 index names in one red line it
+    // filled the screen above the table and read as wallpaper rather than as a
+    // warning — the opposite of the point. A `<details>` element collapses it
+    // with no script at all, and the summary line still states the counts and
+    // how many lines are loud, so nothing is hidden, only folded.
+    //
+    // It opens automatically when something IS loud, because a warning nobody
+    // is told about is a warning nobody reads.
+    let loud_count = notes
+        .iter()
+        .filter(|n| LOUD.iter().any(|w| n.contains(w)))
+        .count();
+    let open = if loud_count > 0 { " open" } else { "" };
+    let _ = write!(
+        body,
+        "<details class=\"notes\"{open}><summary>{} note{} · <b>{loud_count}</b> needing attention</summary><ul>",
+        notes.len(),
+        if notes.len() == 1 { "" } else { "s" },
+    );
     for note in notes {
         let loud = if LOUD.iter().any(|w| note.contains(w)) {
             " class=\"loud\""
@@ -477,11 +598,38 @@ pub fn instruments_page(view: &View<'_>) -> String {
         };
         let _ = write!(body, "<li{loud}>{}</li>", escape(note));
     }
-    body.push_str("</ul>");
+    body.push_str("</ul></details>");
 
-    body.push_str(&filter_pills(counts, query, active, all));
+    body.push_str(&filter_pills(view));
 
-    body.push_str(&table(rows, query, sort));
+    body.push_str(&table(rows, view));
+
+    // PAGING LINKS. Without them the row cap is a wall: the page rendered 200
+    // of 785 and scrolling could not reveal what was never sent. Links rather
+    // than script, so a page is bookmarkable and the browser's back button
+    // works. Every other parameter rides along, so paging does not silently
+    // clear a search, a sort or a filter.
+    if last_page > 0 {
+        let carry = view.link_params(None, None, Some(0));
+        let carry = carry.trim_end_matches("&amp;page=0").to_owned();
+        body.push_str("<nav class=\"pager\">");
+        if page > 0 {
+            let _ = write!(
+                body,
+                "<a href=\"/instruments?{carry}&amp;page={}\">&larr; previous</a>",
+                page - 1
+            );
+        }
+        let _ = write!(body, "<span>page {} of {}</span>", page + 1, last_page + 1);
+        if page < last_page {
+            let _ = write!(
+                body,
+                "<a href=\"/instruments?{carry}&amp;page={}\">next &rarr;</a>",
+                page + 1
+            );
+        }
+        body.push_str("</nav>");
+    }
     body.push_str("</tbody></table></section>");
     body.push_str(
         "<footer>Rendered on the server. No JavaScript — \
@@ -547,8 +695,115 @@ mod tests {
             all: false,
             counts: UniverseCounts::default(),
             active: "",
+            page: 0,
+            last_page: 0,
             notes: &[],
         })
+    }
+
+    #[test]
+    fn one_link_builder_carries_every_parameter_and_overrides_only_what_it_is_told() {
+        // This is the function that fixed the bug where sorting dropped the
+        // universe filter and filtering dropped the sort. It is tested directly
+        // because every link on the page goes through it, so a defect here is a
+        // defect in all of them at once.
+        let v = View {
+            title: "t",
+            total: 0,
+            rows: &[],
+            query: "M&M",
+            sort: "isin",
+            all: true,
+            counts: UniverseCounts::default(),
+            active: "ntm",
+            page: 3,
+            last_page: 9,
+            notes: &[],
+        };
+
+        // No overrides: the current state, verbatim. The ampersand in the
+        // search is escaped, because a symbol really can contain one.
+        let keep = v.link_params(None, None, None);
+        assert!(keep.contains("q=M&amp;M"), "the search is escaped: {keep}");
+        assert!(keep.contains("sort=isin"));
+        assert!(keep.contains("u=ntm"));
+        assert!(keep.contains("&amp;all=1"));
+        assert!(keep.contains("&amp;page=3"), "the page rides along: {keep}");
+
+        // Overriding the sort keeps the filter — the exact bug this replaced.
+        let sorted = v.link_params(Some("kind"), None, Some(0));
+        assert!(sorted.contains("sort=kind"));
+        assert!(sorted.contains("u=ntm"), "sorting must not drop the filter");
+        assert!(!sorted.contains("page="), "a new order starts at page one");
+
+        // Overriding the filter keeps the sort — the same bug, other direction.
+        let filtered = v.link_params(None, Some("idx"), Some(0));
+        assert!(filtered.contains("u=idx"));
+        assert!(
+            filtered.contains("sort=isin"),
+            "filtering must not drop the sort"
+        );
+
+        // Not widened: no all flag anywhere in the link.
+        let narrow = View { all: false, ..v };
+        assert!(!narrow.link_params(None, None, None).contains("all=1"));
+    }
+
+    #[test]
+    fn the_pager_leads_both_ways_and_carries_every_other_parameter() {
+        let r = [row(nifty(), &[Vendor::Groww])];
+        let view = |page: usize, last_page: usize, all: bool| View {
+            title: "t",
+            total: 785,
+            rows: &r,
+            query: "NIF",
+            sort: "isin",
+            all,
+            counts: UniverseCounts::default(),
+            active: "ntm",
+            page,
+            last_page,
+            notes: &[],
+        };
+
+        // A single page shows no pager: navigation that leads nowhere is worse
+        // than none at all.
+        assert!(!instruments_page(&view(0, 0, false)).contains("class=\"pager\""));
+
+        // First page: next only, no previous to nowhere.
+        let first = instruments_page(&view(0, 3, false));
+        assert!(first.contains("next"));
+        assert!(!first.contains("previous"));
+        assert!(first.contains("page 1 of 4"));
+
+        // Middle: both directions.
+        let mid = instruments_page(&view(1, 3, false));
+        assert!(mid.contains("previous") && mid.contains("next"));
+        assert!(mid.contains("page 2 of 4"));
+
+        // Last page: previous only.
+        let last = instruments_page(&view(3, 3, false));
+        assert!(last.contains("previous"));
+        assert!(!last.contains("next"));
+        assert!(last.contains("page 4 of 4"));
+
+        // EVERY other parameter rides along. Paging that silently cleared the
+        // search, the sort or the filter would look like the data changed.
+        assert!(mid.contains("q=NIF"), "the search is carried");
+        assert!(mid.contains("sort=isin"), "the sort is carried");
+        assert!(mid.contains("u=ntm"), "the universe filter is carried");
+        // Scoped to the pager's own carry (`&amp;all=1`), not a bare `all=1`:
+        // the escape-hatch link beside the search box is `?all=1` and is
+        // present on every un-widened page, so a bare match would always hit.
+        assert!(
+            !mid.contains("&amp;all=1"),
+            "not widened, so the pager carries no all flag"
+        );
+
+        // And when widened, the flag rides along too, so paging through every
+        // NSE listing does not silently snap back to the tracked universe.
+        let wide = instruments_page(&view(1, 3, true));
+        assert!(wide.contains("all=1"), "the widened view is carried");
     }
 
     #[test]
@@ -743,6 +998,8 @@ mod tests {
             all: false,
             counts: UniverseCounts::default(),
             active: "",
+            page: 0,
+            last_page: 0,
             notes: &notes,
         });
         for note in &notes {
@@ -763,6 +1020,8 @@ mod tests {
             all: false,
             counts: UniverseCounts::default(),
             active: "",
+            page: 0,
+            last_page: 0,
             notes: &["<b>x</b>".to_owned()],
         });
         assert!(html.contains("&lt;b&gt;x&lt;/b&gt;"));

--- a/crates/api/src/render.rs
+++ b/crates/api/src/render.rs
@@ -108,20 +108,13 @@ thead th a:hover{color:var(--acc)}\
 .filters{margin:0 auto;max-width:1180px;padding:0 20px}\
 .filters input{position:absolute;opacity:0;pointer-events:none}\
 .pills{display:flex;flex-wrap:wrap;gap:8px;margin:0 0 14px}\
-.pills label{cursor:pointer;user-select:none;padding:9px 16px;border-radius:99px;font-weight:650;\
+.pills a{cursor:pointer;user-select:none;text-decoration:none;display:inline-block;padding:9px 16px;border-radius:99px;font-weight:650;\
 font-size:13.5px;border:1px solid var(--line);background:var(--panel);color:var(--dim);\
 transition:all .22s cubic-bezier(.2,.8,.2,1)}\
-.pills label:hover{transform:translateY(-2px);border-color:var(--acc);color:var(--ink)}\
-.pills label b{font-variant-numeric:tabular-nums;opacity:.65;margin-left:7px;font-weight:700}\
-#f-all:checked~.pills label[for=f-all],\
-#f-fno:checked~.pills label[for=f-fno],\
-#f-ntm:checked~.pills label[for=f-ntm],\
-#f-idx:checked~.pills label[for=f-idx]\
-{background:linear-gradient(135deg,var(--acc),var(--acc2));border-color:transparent;color:#fff;\
+.pills a:hover{transform:translateY(-2px);border-color:var(--acc);color:var(--ink)}\
+.pills a b{font-variant-numeric:tabular-nums;opacity:.65;margin-left:7px;font-weight:700}\
+.pills a.on{background:linear-gradient(135deg,var(--acc),var(--acc2));border-color:transparent;color:#fff;\
 box-shadow:0 6px 18px color-mix(in srgb,var(--acc) 34%,transparent);transform:translateY(-1px)}\
-#f-fno:checked~table tbody tr:not(.u-fno),\
-#f-ntm:checked~table tbody tr:not(.u-ntm),\
-#f-idx:checked~table tbody tr:not(.u-idx){display:none}\
 footer{margin:22px auto 0;max-width:1180px;padding:0 20px;color:var(--dim);font-size:12.5px;line-height:1.9}\
 @media(prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}";
 
@@ -269,43 +262,143 @@ fn isin_cell(row: &Row) -> String {
 ///
 /// Extracted from [`instruments_page`] because that function is at clippy's
 /// 100-line ceiling; the split is a lint, not a design.
-fn filter_pills(rows: &[Row]) -> String {
+fn filter_pills(counts: UniverseCounts, query: &str, active: &str, all: bool) -> String {
     let mut out = String::with_capacity(512);
-    // THE UNIVERSE FILTER — four radio inputs and one CSS rule.
+    // THE PILLS ARE LINKS, NOT A CSS TOGGLE.
     //
-    // No script, and none is wanted: `#f-fno:checked ~ table tbody tr:not(.u-fno)
-    // {display:none}` is resolved by the browser's selector engine in native
-    // code. It is faster than any handler could be, it cannot throw, and it
-    // needs no round trip — filtering is instant and the server is not touched.
+    // They were a `:checked ~` rule, which filtered without a round trip. But a
+    // CSS rule can only hide rows the browser already HAS, and a page carries
+    // 200 of 785 — so "F&O" showed 52 when the answer was 208, instantly and
+    // authoritatively wrong. The count and the rows behind it disagreed.
     //
-    // The inputs precede the table because a sibling combinator only reaches
-    // FORWARD; that ordering is load-bearing, not cosmetic.
+    // As links, the server selects from the whole set and the number on the
+    // pill is the population behind it. The round trip costs 0.6 ms on
+    // loopback, below anything a person perceives, so correctness is free here.
     //
-    // Counts are of the whole universe, not of this page, so a filter never
-    // implies the 200 rendered rows are all there are.
-    let (n_fno, n_ntm, n_idx) = rows.iter().fold((0, 0, 0), |(f, t, i), r| {
-        (
-            f + usize::from(r.universe.contains(Universe::FNO)),
-            t + usize::from(r.universe.contains(Universe::TOTAL_MARKET)),
-            i + usize::from(r.universe.contains(Universe::INDEX)),
-        )
-    });
+    // `all` is carried through, so widening to every NSE listing and then
+    // filtering by universe compose instead of cancelling.
+    let q = escape(query);
+    let suffix = if all { "&amp;all=1" } else { "" };
+    let pill = |slug: &str, label: &str, n: usize| -> String {
+        let on = if active == slug { " class=\"on\"" } else { "" };
+        format!("<a href=\"/instruments?q={q}&amp;u={slug}{suffix}\"{on}>{label}<b>{n}</b></a>")
+    };
     let _ = write!(
         out,
-        "<section class=\"filters\">\
-         <input type=\"radio\" name=\"u\" id=\"f-all\" checked>\
-         <input type=\"radio\" name=\"u\" id=\"f-fno\">\
-         <input type=\"radio\" name=\"u\" id=\"f-ntm\">\
-         <input type=\"radio\" name=\"u\" id=\"f-idx\">\
-         <div class=\"pills\">\
-         <label for=\"f-all\">All<b>{}</b></label>\
-         <label for=\"f-fno\">F&amp;O<b>{n_fno}</b></label>\
-         <label for=\"f-ntm\">NIFTY Total Market<b>{n_ntm}</b></label>\
-         <label for=\"f-idx\">Indices<b>{n_idx}</b></label>\
-         </div>",
-        rows.len()
+        "<section class=\"filters\"><div class=\"pills\">{}{}{}{}</div>",
+        pill("", "All", counts.all),
+        pill("fno", "F&amp;O", counts.fno),
+        pill("ntm", "NIFTY Total Market", counts.ntm),
+        pill("idx", "Indices", counts.index),
     );
     out
+}
+
+/// How many instruments each universe holds, over the WHOLE tracked set.
+///
+/// Counted by the caller from the merged map, never from the rendered page: a
+/// pill whose number counts only the 200 rows on screen says 52 when the answer
+/// is 208, and looks authoritative doing it.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UniverseCounts {
+    /// Every tracked instrument.
+    pub all: usize,
+    /// F&O underlyings.
+    pub fno: usize,
+    /// NIFTY Total Market constituents.
+    pub ntm: usize,
+    /// Index series.
+    pub index: usize,
+}
+
+/// The sortable table: header links, then one row per instrument.
+///
+/// Split out of [`instruments_page`] to stay under clippy's 100-line ceiling.
+/// The split is a lint, not a design.
+fn table(rows: &[Row], query: &str, sort: &str) -> String {
+    let mut body = String::with_capacity(256 + rows.len() * 256);
+    // SORTABLE HEADERS. Links, not script: the order is part of the URL, so a
+    // sorted view is linkable, reloadable and back-buttonable, and the server
+    // decides it once from data already in memory. The query is carried through
+    // so sorting does not silently clear a search.
+    let q = escape(query);
+    let sort_link = |col: &str, label: &str| -> String {
+        let mark = if sort == col { " ▾" } else { "" };
+        format!("<th><a href=\"/instruments?q={q}&amp;sort={col}\">{label}{mark}</a></th>")
+    };
+    body.push_str("<table><thead><tr>");
+    for (col, label) in [
+        ("key", "Canonical key"),
+        ("vendors", "Vendors"),
+        ("symbol", "Underlying"),
+        ("isin", "ISIN"),
+        ("universe", "Universe"),
+        ("kind", "Kind"),
+    ] {
+        body.push_str(&sort_link(col, label));
+    }
+    body.push_str("<th>Expiry</th><th>Strike</th></tr></thead><tbody>");
+
+    for row in rows {
+        // Classes carry BOTH facts: whether the engine sweeps it (colour) and
+        // which lists it is in (what the filter selects on). One attribute,
+        // because a second would need a wrapper element per row.
+        let mut classes = String::new();
+        if row.key.is_sweepable() {
+            classes.push_str("swept ");
+        }
+        for (bit, name) in [
+            (Universe::FNO, "u-fno"),
+            (Universe::TOTAL_MARKET, "u-ntm"),
+            (Universe::INDEX, "u-idx"),
+        ] {
+            if row.universe.contains(bit) {
+                classes.push_str(name);
+                classes.push(' ');
+            }
+        }
+        let _ = write!(
+            body,
+            "<tr class=\"{}\"><td>{}</td>{}<td>{}</td>{}{}{}</tr>",
+            classes.trim_end(),
+            escape(&row.key.to_string()),
+            vendor_cell(row),
+            escape(row.key.underlying.as_str()),
+            isin_cell(row),
+            universe_cell(row.universe),
+            kind_cells(row.key.kind),
+        );
+    }
+
+    body
+}
+
+/// Everything one rendering of the instruments page needs.
+///
+/// A struct rather than nine parameters: clippy caps a function at seven,
+/// and more to the point a positional list of four `&str` invites a caller to
+/// swap `sort` and `active` with no type error and no test failure -- the page
+/// would simply sort by a filter name and filter by a column name.
+#[derive(Debug, Clone, Copy)]
+pub struct View<'a> {
+    /// The page title.
+    pub title: &'a str,
+    /// The denominator the title's count means.
+    pub total: usize,
+    /// The rows to render, already filtered and sorted.
+    pub rows: &'a [Row],
+    /// What was typed in the search box.
+    pub query: &'a str,
+    /// Which column the rows are ordered by.
+    pub sort: &'a str,
+    /// Whether the universe filter is lifted.
+    pub all: bool,
+    /// Universe sizes, over the whole tracked set.
+    pub counts: UniverseCounts,
+    /// Which universe pill is selected.
+    pub active: &'a str,
+    /// Every line an operator has to be told.
+    pub notes: &'a [String],
 }
 
 /// Renders a complete instruments page.
@@ -320,15 +413,18 @@ fn filter_pills(rows: &[Row]) -> String {
 /// way to reach most of the universe, silently dropped the one thing the page
 /// existed to say.
 #[must_use]
-pub fn instruments_page(
-    title: &str,
-    total: usize,
-    rows: &[Row],
-    query: &str,
-    sort: &str,
-    all: bool,
-    notes: &[String],
-) -> String {
+pub fn instruments_page(view: &View<'_>) -> String {
+    let View {
+        title,
+        total,
+        rows,
+        query,
+        sort,
+        all,
+        counts,
+        active,
+        notes,
+    } = *view;
     let mut body = String::with_capacity(1024 + rows.len() * 256);
     body.push_str("<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">");
     body.push_str("<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">");
@@ -383,61 +479,9 @@ pub fn instruments_page(
     }
     body.push_str("</ul>");
 
-    body.push_str(&filter_pills(rows));
+    body.push_str(&filter_pills(counts, query, active, all));
 
-    // SORTABLE HEADERS. Links, not script: the order is part of the URL, so a
-    // sorted view is linkable, reloadable and back-buttonable, and the server
-    // decides it once from data already in memory. The query is carried through
-    // so sorting does not silently clear a search.
-    let q = escape(query);
-    let sort_link = |col: &str, label: &str| -> String {
-        let mark = if sort == col { " ▾" } else { "" };
-        format!("<th><a href=\"/instruments?q={q}&amp;sort={col}\">{label}{mark}</a></th>")
-    };
-    body.push_str("<table><thead><tr>");
-    for (col, label) in [
-        ("key", "Canonical key"),
-        ("vendors", "Vendors"),
-        ("symbol", "Underlying"),
-        ("isin", "ISIN"),
-        ("universe", "Universe"),
-        ("kind", "Kind"),
-    ] {
-        body.push_str(&sort_link(col, label));
-    }
-    body.push_str("<th>Expiry</th><th>Strike</th></tr></thead><tbody>");
-
-    for row in rows {
-        // Classes carry BOTH facts: whether the engine sweeps it (colour) and
-        // which lists it is in (what the filter selects on). One attribute,
-        // because a second would need a wrapper element per row.
-        let mut classes = String::new();
-        if row.key.is_sweepable() {
-            classes.push_str("swept ");
-        }
-        for (bit, name) in [
-            (Universe::FNO, "u-fno"),
-            (Universe::TOTAL_MARKET, "u-ntm"),
-            (Universe::INDEX, "u-idx"),
-        ] {
-            if row.universe.contains(bit) {
-                classes.push_str(name);
-                classes.push(' ');
-            }
-        }
-        let _ = write!(
-            body,
-            "<tr class=\"{}\"><td>{}</td>{}<td>{}</td>{}{}{}</tr>",
-            classes.trim_end(),
-            escape(&row.key.to_string()),
-            vendor_cell(row),
-            escape(row.key.underlying.as_str()),
-            isin_cell(row),
-            universe_cell(row.universe),
-            kind_cells(row.key.kind),
-        );
-    }
-
+    body.push_str(&table(rows, query, sort));
     body.push_str("</tbody></table></section>");
     body.push_str(
         "<footer>Rendered on the server. No JavaScript — \
@@ -494,7 +538,17 @@ mod tests {
 
     /// A page with no notes, for the tests that are about rows.
     fn page(title: &str, total: usize, rows: &[Row], query: &str) -> String {
-        instruments_page(title, total, rows, query, "", false, &[])
+        instruments_page(&View {
+            title,
+            total,
+            rows,
+            query,
+            sort: "",
+            all: false,
+            counts: UniverseCounts::default(),
+            active: "",
+            notes: &[],
+        })
     }
 
     #[test]
@@ -680,15 +734,17 @@ mod tests {
             "dhan: UNAVAILABLE — no such file".to_owned(),
             "ISIN CONFLICT · NSE-CHOLAFIN: groww says A, dhan says B".to_owned(),
         ];
-        let html = instruments_page(
-            "search",
-            1,
-            &[row(nifty(), &[Vendor::Groww])],
-            "NIFTY",
-            "",
-            false,
-            &notes,
-        );
+        let html = instruments_page(&View {
+            title: "search",
+            total: 1,
+            rows: &[row(nifty(), &[Vendor::Groww])],
+            query: "NIFTY",
+            sort: "",
+            all: false,
+            counts: UniverseCounts::default(),
+            active: "",
+            notes: &notes,
+        });
         for note in &notes {
             assert!(html.contains(&escape(note)), "{note} must be on the page");
         }
@@ -698,7 +754,17 @@ mod tests {
             "the tally is quiet; UNAVAILABLE and the conflict are not"
         );
         // And a note is escaped like everything else.
-        let html = instruments_page("t", 0, &[], "", "", false, &["<b>x</b>".to_owned()]);
+        let html = instruments_page(&View {
+            title: "t",
+            total: 0,
+            rows: &[],
+            query: "",
+            sort: "",
+            all: false,
+            counts: UniverseCounts::default(),
+            active: "",
+            notes: &["<b>x</b>".to_owned()],
+        });
         assert!(html.contains("&lt;b&gt;x&lt;/b&gt;"));
         assert!(!html.contains("<li><b>"));
     }

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -304,6 +304,17 @@ pub fn param(raw: &str, name: &str) -> String {
     String::new()
 }
 
+/// The zero-based page number a query string asks for.
+///
+/// Anything unparseable is page one. This is the one parameter that is
+/// defaulted rather than refused, and it is defensible only because a page
+/// number selects a VIEW: it can never change what the data says, so a mangled
+/// bookmark should land on the first page rather than on an error.
+#[must_use]
+pub fn page_number(raw: &str) -> usize {
+    param(raw, "page").parse().unwrap_or(0)
+}
+
 /// Decodes `+` and `%XX` escapes.
 fn percent_decode(s: &str) -> String {
     let b = s.as_bytes();
@@ -364,7 +375,7 @@ fn hex_digit(c: u8) -> Option<u8> {
 /// are now a banner the page always carries, whatever was typed.
 #[must_use]
 pub fn instruments_html(dir: &Path, query: &str) -> String {
-    instruments_html_from(&universe(dir), query, "", false, "")
+    instruments_html_from(&universe(dir), query, "", false, "", 0)
 }
 
 /// The instruments page, rendered from a universe that is **already loaded**.
@@ -391,6 +402,7 @@ pub fn instruments_html_from(
     sort: &str,
     all: bool,
     universe_filter: &str,
+    page: usize,
 ) -> String {
     let needle = query.to_uppercase();
 
@@ -462,7 +474,14 @@ pub fn instruments_html_from(
     // equal ISINs still have one fixed order, and the page is byte-identical
     // between reloads. A HashMap's iteration order is not, which is why this
     // cannot be left to insertion.
-    match sort {
+    // A leading `-` means descending. Sorting the key list ascending and then
+    // reversing keeps ONE ordering rule per column instead of two, so ascending
+    // and descending can never disagree about how ties break.
+    let (column, descending) = match sort.strip_prefix('-') {
+        Some(base) => (base, true),
+        None => (sort, false),
+    };
+    match column {
         "symbol" => keys.sort_unstable_by_key(|(k, _)| (k.underlying, *k)),
         "isin" => keys.sort_unstable_by_key(|(k, e)| (e.isin.map(|(_, i)| i), *k)),
         "universe" => keys.sort_unstable_by_key(|(k, e)| (e.universe.bits(), *k)),
@@ -472,9 +491,25 @@ pub fn instruments_html_from(
         // column is NOT an error -- a stale bookmark should still render.
         _ => keys.sort_unstable_by_key(|(k, _)| (!k.is_sweepable(), *k)),
     }
+    if descending {
+        keys.reverse();
+    }
 
+    // PAGING, so nothing is unreachable.
+    //
+    // The cap alone rendered 200 of 785 and offered no way to the rest —
+    // scrolling cannot reveal rows that were never sent, and the page said
+    // "showing 200" as though that were the whole answer. A bound with no
+    // navigation past it is the same class of defect as a filter with no
+    // escape hatch.
+    //
+    // The offset is clamped to the last page rather than refused: `?page=999`
+    // is a stale bookmark, not an attack, and it should land somewhere real.
+    let last_page = matched.saturating_sub(1) / PAGE_ROWS;
+    let page = page.min(last_page);
     let rows: Vec<render::Row> = keys
         .into_iter()
+        .skip(page * PAGE_ROWS)
         .take(PAGE_ROWS)
         .map(|(key, e)| render::Row {
             key,
@@ -510,6 +545,8 @@ pub fn instruments_html_from(
         all,
         counts,
         active: universe_filter,
+        page,
+        last_page,
         notes: &read.notes,
     })
 }
@@ -524,7 +561,8 @@ async fn page(
     let sort = param(raw, "sort");
     let all = param(raw, "all") == "1";
     let u = param(raw, "u");
-    axum::response::Html(instruments_html_from(&read, &typed, &sort, all, &u))
+    let page = page_number(raw);
+    axum::response::Html(instruments_html_from(&read, &typed, &sort, all, &u, page))
 }
 
 /// The health endpoint.
@@ -957,6 +995,196 @@ mod tests {
         let html = instruments_html(&dir, "");
         assert!(html.contains("ISIN CONFLICT"), "the page says so too");
         assert!(html.contains("clash"), "and the row is marked");
+    }
+
+    #[test]
+    fn a_page_number_that_is_not_a_number_is_page_one() {
+        // `?page=abc` is a mangled bookmark or a hand-typed URL. It must render
+        // the first page, not fail and not 500 -- but note this is the ONE
+        // place a bad parameter is quietly defaulted rather than refused, and
+        // it is defensible only because a page number selects a VIEW and can
+        // never change what the data says.
+        assert_eq!(page_number("page=abc"), 0);
+        assert_eq!(page_number("page="), 0);
+        assert_eq!(page_number("page=-1"), 0);
+        assert_eq!(page_number("page=2"), 2);
+        assert_eq!(page_number(""), 0);
+    }
+
+    #[test]
+    fn the_escape_hatch_reaches_a_listing_the_tracked_universe_excludes() {
+        // RAJESHEXPO is a real-shaped equity row that is in neither NIFTY Total
+        // Market nor the index series, so it is the only kind of instrument the
+        // tracked filter actually removes. Without a row like this the filter
+        // can never be observed doing anything, and `all` can never be observed
+        // undoing it.
+        let dir = masters(
+            "hatchreach",
+            Some(&format!(
+                "{GROWW_HEAD}\
+                 NSE,CASH,,RAJESHEXPO,EQ,EQ,INE343B01030,,\n"
+            )),
+            Some(&format!(
+                "{DHAN_HEAD}\
+                 NSE,E,INE343B01030,EQUITY,RAJESHEXPO,RAJESH EXPORTS,ES,EQ,,,\n"
+            )),
+        );
+        let read = universe(&dir);
+
+        // Tracked view: the gate accepted it as a share, and the universe
+        // filter still excludes it — those are different questions.
+        let tracked = instruments_html_from(&read, "", "", false, "", 0);
+        assert!(
+            !tracked.contains("NSE-RAJESHEXPO"),
+            "not in NIFTY Total Market, so not tracked"
+        );
+        assert!(tracked.contains("0 instruments total"));
+
+        // The escape hatch reaches it. This is the whole reason the hatch
+        // exists: an instrument the filter hides must still be inspectable.
+        let every = instruments_html_from(&read, "", "", true, "", 0);
+        assert!(
+            every.contains("NSE-RAJESHEXPO"),
+            "?all=1 reaches every listing"
+        );
+        assert!(every.contains("1 instruments total"));
+    }
+
+    #[test]
+    fn a_leading_minus_reverses_the_order_without_a_second_comparator() {
+        // Ascending and descending share ONE ordering rule per column: the
+        // keys are sorted ascending and then reversed. Two comparators is how
+        // ties silently break differently in each direction.
+        let read = universe(&agreeing("desc"));
+        let up = instruments_html_from(&read, "", "symbol", false, "", 0);
+        let down = instruments_html_from(&read, "", "-symbol", false, "", 0);
+
+        let first = |html: &str| -> String {
+            html.split("<tr class=")
+                .nth(1)
+                .and_then(|r| r.split("<td>").nth(1))
+                .and_then(|c| c.split("</td>").next())
+                .unwrap_or_default()
+                .to_owned()
+        };
+        assert_ne!(first(&up), first(&down), "the two orders differ");
+        assert!(up.contains("NSE-NIFTY") && up.contains("NSE-RELIANCE"));
+        assert!(down.contains("NSE-NIFTY") && down.contains("NSE-RELIANCE"));
+
+        // An unknown column reverses the DEFAULT order rather than erroring.
+        let stale = instruments_html_from(&read, "", "-no-such-column", false, "", 0);
+        assert!(stale.contains("NSE-NIFTY") && stale.contains("NSE-RELIANCE"));
+    }
+
+    #[test]
+    fn every_row_is_reachable_by_paging_and_a_stale_page_clamps() {
+        // The cap alone was a wall: 200 of 785 rendered and nothing led to the
+        // rest. Scrolling cannot reveal rows that were never sent.
+        let read = universe(&agreeing("paging"));
+
+        // This fixture is smaller than one page, so there is no pager at all --
+        // navigation that leads nowhere is worse than none.
+        let one = instruments_html_from(&read, "", "", false, "", 0);
+        assert!(
+            !one.contains("class=\"pager\""),
+            "no pager for a single page"
+        );
+        assert!(one.contains("NSE-NIFTY") && one.contains("NSE-RELIANCE"));
+
+        // A page beyond the end CLAMPS to the last page rather than rendering
+        // an empty table: `?page=999` is a stale bookmark, not an attack, and
+        // it should land somewhere real.
+        let past = instruments_html_from(&read, "", "", false, "", 999);
+        assert!(
+            past.contains("NSE-NIFTY") && past.contains("NSE-RELIANCE"),
+            "an out-of-range page clamps to the last one, it does not empty out"
+        );
+        assert_eq!(past, one, "clamping lands exactly on the last page");
+    }
+
+    #[test]
+    fn every_sort_column_orders_and_none_of_them_errors() {
+        // Each arm of the sort match is a separate closure; an arm no test
+        // enters is an arm that can be wrong forever. RELIANCE is in NIFTY
+        // Total Market and NIFTY is an index, so the two rows differ on every
+        // column the page can order by.
+        let read = universe(&agreeing("sortcols"));
+        for column in ["key", "symbol", "isin", "universe", "kind", "vendors", ""] {
+            let html = instruments_html_from(&read, "", column, false, "", 0);
+            assert!(
+                html.contains("NSE-NIFTY") && html.contains("NSE-RELIANCE"),
+                "sort={column:?} lost a row"
+            );
+            // Every named column has a header link. The empty column is the
+            // default order and names no column, so it is checked separately
+            // rather than through a short-circuit whose right side never runs.
+            if !column.is_empty() {
+                assert!(
+                    html.contains(&format!("sort={column}")),
+                    "sort={column:?} has no header link"
+                );
+            }
+        }
+        // An unrecognised column is the DEFAULT order, not an error and not an
+        // empty page: a stale bookmark should still render.
+        let stale = instruments_html_from(&read, "", "no-such-column", false, "", 0);
+        assert!(stale.contains("NSE-NIFTY") && stale.contains("NSE-RELIANCE"));
+    }
+
+    #[test]
+    fn the_universe_pill_selects_from_the_whole_set_not_from_the_page() {
+        let read = universe(&agreeing("pills"));
+
+        // Counts are of the tracked set. Both rows are tracked: NIFTY is an
+        // index, RELIANCE is a Total Market constituent.
+        let all = instruments_html_from(&read, "", "", false, "", 0);
+        assert!(all.contains("2 instruments total"));
+
+        // Indices selects the index and drops the equity.
+        let idx = instruments_html_from(&read, "", "", false, "idx", 0);
+        assert!(idx.contains("NSE-NIFTY"), "the index survives");
+        assert!(!idx.contains("NSE-RELIANCE"), "the equity is filtered out");
+
+        // Total Market selects the equity and drops the index.
+        let ntm = instruments_html_from(&read, "", "", false, "ntm", 0);
+        assert!(ntm.contains("NSE-RELIANCE"));
+        assert!(!ntm.contains("NSE-NIFTY"));
+
+        // F&O selects BOTH, because both are F&O underlyings.
+        //
+        // `universe::of_instrument` gives an index `INDEX ∪ of_equity(symbol)`,
+        // so NIFTY carries INDEX **and** FNO — it is an index *and* the
+        // underlying of its options. The universes deliberately overlap; a
+        // filter treating them as disjoint would drop NIFTY from the F&O view,
+        // which is the one instrument that most needs to be there.
+        let fno = instruments_html_from(&read, "", "", false, "fno", 0);
+        assert!(
+            fno.contains("NSE-RELIANCE"),
+            "RELIANCE is an F&O underlying"
+        );
+        assert!(
+            fno.contains("NSE-NIFTY"),
+            "NIFTY is INDEX and FNO both — see universe::of_instrument"
+        );
+
+        // An unrecognised value selects EVERYTHING, so a stale bookmark renders
+        // the page rather than an empty one.
+        let stale = instruments_html_from(&read, "", "", false, "no-such-universe", 0);
+        assert!(stale.contains("NSE-NIFTY") && stale.contains("NSE-RELIANCE"));
+    }
+
+    #[test]
+    fn the_escape_hatch_says_which_direction_it_goes() {
+        let read = universe(&agreeing("hatch"));
+        // Default: the link offers to widen.
+        let tracked = instruments_html_from(&read, "", "", false, "", 0);
+        assert!(tracked.contains("show every NSE listing"));
+        assert!(tracked.contains("all=1"));
+        // Widened: the SAME link offers to narrow again. Without this arm the
+        // page can be widened and never returned from.
+        let every = instruments_html_from(&read, "", "", true, "", 0);
+        assert!(every.contains("show tracked only"));
+        assert!(every.contains("all=0"));
     }
 
     #[test]

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -1,0 +1,1199 @@
+//! The operator's window onto the store, and the process that serves it.
+//!
+//! Everything the binary does lives here rather than in `main.rs`, so that
+//! every branch of it is reachable from a test. `main.rs` holds one call and
+//! nothing else — a line of logic in a `main` is a line no unit test can enter,
+//! and `docs/04-invariants.md` X-06 does not exempt binaries.
+//!
+//! # What the page is for
+//!
+//! It shows what decoded, what was declined and — crucially — what could not
+//! be read at all. A refused row is the thing that hides an instrument, so it
+//! is on the page rather than in a log. Since the equity gate landed it also
+//! shows every ISIN two vendors disagree about, because a disagreement nobody
+//! sees decides the run on its own.
+
+use crate::{master, merge, render};
+use brutex_core::universe::Universe;
+use brutex_core::vendor::Vendor;
+use std::fmt::Write as _;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+/// The default listen address when none is given.
+///
+/// Loopback, not `0.0.0.0`: this page is an operator's window onto a local
+/// store, and a default that listens on every interface is a decision nobody
+/// took.
+pub const DEFAULT_ADDR: SocketAddr =
+    SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 8080);
+
+/// The most rows one page renders.
+///
+/// A page shows what a person can read; the rest cost nothing because they are
+/// never touched, which is what keeps rendering O(rows shown).
+const PAGE_ROWS: usize = 200;
+
+/// The signal that stops the server.
+///
+/// A boxed future rather than a type parameter, deliberately. A generic
+/// `serve` is a *different function* for every caller — one for the binary's
+/// ctrl-C, one for each test's ready future — and coverage is accounted per
+/// instantiation, so the binary's copy would be permanently short of the arms
+/// only a test exercises. One allocation per process buys one function with
+/// one set of counters. The same reasoning applies to the argument list below.
+pub type Shutdown = std::pin::Pin<Box<dyn Future<Output = std::io::Result<()>> + Send>>;
+
+/// What the operator asked the binary to do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Command {
+    /// Bind and serve until the shutdown signal arrives.
+    Serve(SocketAddr),
+    /// Print the decode tallies for every master and exit.
+    Report,
+}
+
+impl Command {
+    /// Parses the command line.
+    ///
+    /// # Errors
+    ///
+    /// A usage message naming what was not understood. An unrecognised
+    /// argument is a refusal rather than a fallback to serving: a typo that
+    /// silently starts a server is a typo nobody finds.
+    pub fn parse(args: &[String]) -> Result<Self, String> {
+        let mut args = args.iter().map(String::as_str);
+        match (args.next(), args.next()) {
+            // No command at all serves, because that is what the operator has
+            // always typed. A WRONG command does not: see the last arm.
+            (None, _) | (Some("serve"), None) => Ok(Self::Serve(DEFAULT_ADDR)),
+            (Some("serve"), Some(addr)) => addr
+                .parse()
+                .map(Self::Serve)
+                .map_err(|e| format!("not a socket address: {addr:?} ({e})")),
+            (Some("report"), None) => Ok(Self::Report),
+            (Some(other), _) => Err(format!(
+                "unknown argument {other:?}; usage: api [serve [ADDR] | report]"
+            )),
+        }
+    }
+}
+
+/// Where each vendor's master is expected.
+#[must_use]
+pub fn master_paths(dir: &Path) -> Vec<(Vendor, PathBuf)> {
+    vec![
+        (Vendor::Groww, dir.join("groww_instruments.csv")),
+        (Vendor::Dhan, dir.join("dhan_scrip.csv")),
+    ]
+}
+
+/// The directory the masters are read from.
+///
+/// `BRUTEX_MASTERS`, or the working directory. This is the only place the
+/// environment is consulted; everything below takes the directory as an
+/// argument, so nothing else has to touch process-wide state to be
+/// deterministic — and nothing can, since setting an environment variable is
+/// `unsafe` under edition 2024 and this crate forbids `unsafe`.
+#[must_use]
+pub fn masters_dir() -> PathBuf {
+    masters_dir_from(std::env::var_os("BRUTEX_MASTERS"))
+}
+
+/// The masters directory implied by a value of `BRUTEX_MASTERS`.
+///
+/// Split from [`masters_dir`] so both outcomes are testable without mutating
+/// the environment of a process running tests in parallel.
+#[must_use]
+fn masters_dir_from(value: Option<std::ffi::OsString>) -> PathBuf {
+    value.map_or_else(|| PathBuf::from("."), PathBuf::from)
+}
+
+/// What one read of the masters produced: the universe, the notes, and whether
+/// any of it may be believed.
+#[derive(Debug)]
+pub struct Read {
+    /// One entry per distinct instrument.
+    pub merged: merge::Merged,
+    /// Everything an operator has to be told: per-vendor tallies, every
+    /// decline reason, every unreadable row's reason, and every disagreement.
+    pub notes: Vec<String>,
+    /// Whether a vendor was never read at all.
+    ///
+    /// Distinct from a merge conflict, and tracked separately because "the two
+    /// vendors disagree" and "there was only one vendor" are different facts
+    /// that must not collapse into one status.
+    pub unavailable: bool,
+    /// How many rows were declined under a listing class nobody recognises.
+    ///
+    /// Not a merge disagreement — it is one vendor's file using a code this
+    /// engine has never measured, which is how an alphabet moves under a
+    /// gate. Counted here so it reaches the status and the exit code, because
+    /// the reason string alone sat beside six routine ones and read like them.
+    pub unrecognised: usize,
+}
+
+impl Read {
+    /// Whether this read is fit to be believed.
+    ///
+    /// A missing vendor counts. So does any disagreement. So does a listing
+    /// class nobody recognises — that one is the difference between a routine
+    /// bond and an alphabet moving under us.
+    #[must_use]
+    pub fn is_clean(&self) -> bool {
+        !self.unavailable
+            && self.unrecognised == 0
+            && self.merged.verdict() == merge::Verdict::Clean
+    }
+
+    /// The one-word status a machine reads first.
+    #[must_use]
+    pub fn status(&self) -> &'static str {
+        if self.is_clean() { "ok" } else { "DEGRADED" }
+    }
+}
+
+/// Every vendor's kept listings, merged, plus one note per vendor.
+///
+/// A vendor whose file is missing produces a note saying so and no listings.
+/// It does not produce an empty success: `UNAVAILABLE` on the page is the
+/// difference between "this vendor lists nothing" and "this vendor was never
+/// read", and collapsing the two is exactly the silent degradation
+/// `CLAUDE.md` §4 forbids.
+#[must_use]
+pub fn universe(dir: &Path) -> Read {
+    let mut notes = Vec::new();
+    let mut sources = Vec::new();
+    let mut unavailable = false;
+    let mut unrecognised = 0;
+    for (vendor, path) in master_paths(dir) {
+        match master::load(&path, vendor) {
+            Ok(l) => {
+                let mut note = format!(
+                    "{}: {} kept, {} declined, {} unreadable",
+                    vendor.as_str(),
+                    l.kept.len(),
+                    l.skipped_total(),
+                    l.errors.len()
+                );
+                for (reason, n) in l.skipped_by_reason() {
+                    let _ = write!(note, " · {reason} {n}");
+                }
+                notes.push(note);
+                // AN UNREADABLE ROW SAYS WHY, AND WHERE. The reasons were
+                // collected with their line numbers and then read only for
+                // `.len()`, so `104 unreadable` was the whole of what an
+                // operator was told and the cause had to be grepped out of the
+                // raw CSV. Grouped by reason, so the output is bounded without
+                // any reason being hidden.
+                for (reason, n, first) in l.errors_by_reason() {
+                    notes.push(format!(
+                        "{} UNREADABLE · {reason} ×{n}, first at line {first}",
+                        vendor.as_str()
+                    ));
+                }
+                // The COUNT says an alphabet moved; the CODE says which one.
+                for (code, n) in &l.unrecognised {
+                    unrecognised += n;
+                    notes.push(format!(
+                        "{} UNRECOGNISED LISTING CLASS · {code:?} ×{n} — \
+                         this is not a bond, it is a code this engine has never seen",
+                        vendor.as_str()
+                    ));
+                }
+                sources.push(merge::Source {
+                    vendor,
+                    kept: l.kept,
+                    declined: l.declined,
+                });
+            }
+            Err(e) => {
+                unavailable = true;
+                notes.push(format!("{}: UNAVAILABLE — {e}", vendor.as_str()));
+            }
+        }
+    }
+    let merged = merge::merge(&sources);
+    for line in &merged.conflicts {
+        notes.push(format!("ISIN CONFLICT · {line}"));
+    }
+    for line in &merged.eligibility {
+        notes.push(format!("ELIGIBILITY CONFLICT · {line}"));
+    }
+    for (name, present, both) in merged.universe_census() {
+        notes.push(format!(
+            "{name}: {present} resolved, {both} confirmed by both vendors"
+        ));
+    }
+    // An index carries no ISIN, so nothing cross-checks its identity. Saying
+    // which members rest on one vendor is the only honest substitute.
+    let alone = merged.single_vendor_members();
+    if !alone.is_empty() {
+        notes.push(format!(
+            "UNCHECKED IDENTITY · {} universe member(s) named by one vendor only: {}",
+            alone.len(),
+            alone.join(", ")
+        ));
+    }
+    Read {
+        merged,
+        notes,
+        unavailable,
+        unrecognised,
+    }
+}
+
+/// Liveness plus the decode tallies, so a machine can check what a human sees.
+///
+/// The first line is `ok` or `DEGRADED`, and it is not decoration: it used to
+/// be an unconditional `ok` printed beside `dhan: UNAVAILABLE`, so a monitor
+/// reading the status, the exit code or the HTTP code saw green while one of
+/// the two vendors had never been read.
+#[must_use]
+pub fn report(dir: &Path) -> (String, bool) {
+    report_from(&universe(dir))
+}
+
+/// The decode report, from a universe that is **already loaded**.
+///
+/// Split for the same reason as [`instruments_html_from`]: `/health` is what a
+/// monitor polls, and polling it must not re-parse both masters. See that
+/// function for the measured cost.
+#[must_use]
+pub fn report_from(read: &Read) -> (String, bool) {
+    let mut out = format!("{}\n", read.status());
+    for note in &read.notes {
+        // Writing to a String is infallible; `unwrap_used` and `expect_used`
+        // are denied workspace-wide and neither belongs here.
+        let _ = writeln!(out, "{note}");
+    }
+    let _ = writeln!(
+        out,
+        "merged: {} instruments, {} isin conflicts, {} eligibility conflicts",
+        read.merged.len(),
+        read.merged.conflicts.len(),
+        read.merged.eligibility.len()
+    );
+    (out, read.is_clean())
+}
+
+/// Parses `?q=...` without a query-string dependency.
+///
+/// `+` and `%XX` are decoded because a symbol may be typed with spaces.
+/// Anything undecodable is kept literally rather than dropped — a query must
+/// never silently become a different query.
+#[must_use]
+pub fn parse_query(raw: &str) -> String {
+    param(raw, "q")
+}
+
+/// One named parameter out of a query string, decoded.
+///
+/// Named rather than positional because the page now carries two — the search
+/// text and the sort column — and reading the second by position would make
+/// `?sort=isin&q=NIFTY` mean something different from `?q=NIFTY&sort=isin`.
+#[must_use]
+pub fn param(raw: &str, name: &str) -> String {
+    let prefix = format!("{name}=");
+    for pair in raw.split('&') {
+        if let Some(v) = pair.strip_prefix(prefix.as_str()) {
+            return percent_decode(v);
+        }
+    }
+    String::new()
+}
+
+/// Decodes `+` and `%XX` escapes.
+fn percent_decode(s: &str) -> String {
+    let b = s.as_bytes();
+    let mut out = Vec::with_capacity(b.len());
+    let mut i = 0;
+    // `while let` rather than `while i < len` with an indexed read: the
+    // indexed form needs a `None` arm that cannot happen, and a branch no test
+    // can enter is a branch nobody has checked.
+    while let Some(&c) = b.get(i) {
+        match c {
+            b'+' => out.push(b' '),
+            b'%' => match hex_escape(b, i) {
+                Some(byte) => {
+                    out.push(byte);
+                    i += 2;
+                }
+                // A truncated or non-hex escape is kept LITERALLY. Dropping it
+                // would turn one query into a different query in silence.
+                None => out.push(b'%'),
+            },
+            _ => out.push(c),
+        }
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// The byte a `%XX` at `at` encodes, or `None` if it is not one.
+fn hex_escape(b: &[u8], at: usize) -> Option<u8> {
+    let hi = hex_digit(*b.get(at + 1)?)?;
+    let lo = hex_digit(*b.get(at + 2)?)?;
+    // At most 15 * 16 + 15 = 255, so this cannot overflow a byte.
+    Some(hi * 16 + lo)
+}
+
+/// The value of one hexadecimal digit, in either case.
+fn hex_digit(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Renders the instruments page for one query.
+///
+/// # Why the notes are not part of the title
+///
+/// They were, and only when the query was empty — the search branch built a
+/// title from the query alone and dropped `notes` on the floor. `notes` is the
+/// sole carrier of `<vendor>: UNAVAILABLE` and of every conflict line, so
+/// typing anything into the search box made the page stop saying that a
+/// vendor's master had never been read, and a row rendered with one vendor tag
+/// was byte-identical to a genuine single-vendor listing. With `PAGE_ROWS` at
+/// 200 against thousands of instruments, search is the only way to reach most
+/// of them, so that was not a corner case — it was the normal path. The notes
+/// are now a banner the page always carries, whatever was typed.
+#[must_use]
+pub fn instruments_html(dir: &Path, query: &str) -> String {
+    instruments_html_from(&universe(dir), query, "", false)
+}
+
+/// The instruments page, rendered from a universe that is **already loaded**.
+///
+/// # Why this split exists
+///
+/// [`instruments_html`] reads both masters from disk on every call. Serving a
+/// page through it parsed ~200,000 CSV rows to render 200 of them, and
+/// measured **150 ms per request** against the real files — cost proportional
+/// to the size of the masters, on a path `CLAUDE.md` §3 rule 4 requires to be
+/// constant.
+///
+/// No test caught it. A fixture of four rows parses in microseconds and passes
+/// with 100% coverage; only the 50 MB file shows the shape of the curve. That
+/// is the difference between *covered* and *correct*.
+///
+/// The masters are therefore read **once**, at startup, and every request
+/// renders from that. Re-reading is now an explicit operator action rather
+/// than a side effect of looking at the page.
+#[must_use]
+pub fn instruments_html_from(read: &Read, query: &str, sort: &str, all: bool) -> String {
+    let needle = query.to_uppercase();
+
+    // THE TRACKED UNIVERSE, and nothing else.
+    //
+    // The masters carry every NSE listing the gate accepts as a real share --
+    // about 2,700 per vendor. The engine tracks a strict subset: the NIFTY
+    // Total Market constituents, plus the index series. The other ~1,900 NSE
+    // equities are decoded, counted and declined here rather than in the
+    // decoder, because "is this a share" and "is this a share I follow" are
+    // different questions and collapsing them would mean anything outside the
+    // list never got validated at all.
+    //
+    // F&O needs no clause: every F&O stock underlying is already a Total
+    // Market constituent -- 208 of 208, measured, zero outside. F&O is a
+    // filter label on instruments already here, not a third source of rows.
+    // `all` lifts the universe filter so every listing the gate accepted is
+    // reachable. The DEFAULT is the tracked universe, because a page opening on
+    // 2,700 rows hides the 785 that matter — but a filter with no way past it
+    // hides a bug instead, so the escape hatch is a link on the page, not a
+    // recompile.
+    let tracked =
+        |u: Universe| all || u.contains(Universe::TOTAL_MARKET) || u.contains(Universe::INDEX);
+    let total = read
+        .merged
+        .by_key
+        .values()
+        .filter(|e| tracked(e.universe))
+        .count();
+
+    let mut keys: Vec<_> = read
+        .merged
+        .by_key
+        .iter()
+        .filter(|(_, e)| tracked(e.universe))
+        .filter(|(k, _)| needle.is_empty() || k.to_string().to_uppercase().contains(&needle))
+        .map(|(k, e)| (*k, *e))
+        .collect();
+    let matched = keys.len();
+    // Swept instruments first, then a stable order. Sorting by the key itself
+    // rather than by insertion makes the page byte-identical between reloads,
+    // which a HashMap iteration order would not.
+    // SORT ORDER IS PART OF THE URL, so a sorted page is linkable and a reload
+    // shows the same thing. Swept instruments lead every order except when the
+    // operator asked for a specific column — an implicit pin would silently
+    // contradict the column they clicked.
+    //
+    // Every arm ends in the key itself, so the order is TOTAL: two rows with
+    // equal ISINs still have one fixed order, and the page is byte-identical
+    // between reloads. A HashMap's iteration order is not, which is why this
+    // cannot be left to insertion.
+    match sort {
+        "symbol" => keys.sort_unstable_by_key(|(k, _)| (k.underlying, *k)),
+        "isin" => keys.sort_unstable_by_key(|(k, e)| (e.isin.map(|(_, i)| i), *k)),
+        "universe" => keys.sort_unstable_by_key(|(k, e)| (e.universe.bits(), *k)),
+        "kind" => keys.sort_unstable_by_key(|(k, _)| (k.kind, *k)),
+        "vendors" => keys.sort_unstable_by_key(|(k, e)| (e.vendors, *k)),
+        // "key", "" and anything unrecognised: the default order. An unknown
+        // column is NOT an error -- a stale bookmark should still render.
+        _ => keys.sort_unstable_by_key(|(k, _)| (!k.is_sweepable(), *k)),
+    }
+
+    let rows: Vec<render::Row> = keys
+        .into_iter()
+        .take(PAGE_ROWS)
+        .map(|(key, e)| render::Row {
+            key,
+            vendors: e.vendors,
+            isin: e.isin.map(|(_, i)| i),
+            conflict: e.conflict.map(|(_, i)| i),
+            universe: e.universe,
+        })
+        .collect();
+
+    // `total` is the whole universe; `matched` is what the filter selected.
+    // Reporting the right one keeps the page honest about what it looked at.
+    let (title, denominator) = if needle.is_empty() {
+        (
+            format!("brutex-rs · instruments · {}", read.status()),
+            total,
+        )
+    } else {
+        (
+            format!(
+                "brutex-rs · {} · search {query:?} · {matched} matched",
+                read.status()
+            ),
+            matched,
+        )
+    };
+    render::instruments_page(&title, denominator, &rows, query, sort, all, &read.notes)
+}
+
+/// The instruments page.
+async fn page(
+    axum::extract::State(read): axum::extract::State<Loaded>,
+    uri: axum::http::Uri,
+) -> axum::response::Html<String> {
+    let raw = uri.query().unwrap_or("");
+    let typed = parse_query(raw);
+    let sort = param(raw, "sort");
+    let all = param(raw, "all") == "1";
+    axum::response::Html(instruments_html_from(&read, &typed, &sort, all))
+}
+
+/// The health endpoint.
+///
+/// 200 only when the read is clean. A degraded universe answers 503, because a
+/// monitor reads the status code and nothing else — this used to return 200
+/// with `ok` on the first line while a vendor had never been read.
+async fn health(
+    axum::extract::State(read): axum::extract::State<Loaded>,
+) -> (axum::http::StatusCode, String) {
+    let (body, clean) = report_from(&read);
+    let code = if clean {
+        axum::http::StatusCode::OK
+    } else {
+        axum::http::StatusCode::SERVICE_UNAVAILABLE
+    };
+    (code, body)
+}
+
+/// The universe every request renders from, read once at startup.
+///
+/// `Arc` rather than a clone per request: [`Read`] owns a `HashMap` of every
+/// instrument, and cloning it per request would trade one O(rows) cost for
+/// another. An `Arc` clone is a refcount bump — constant, and the same bytes
+/// are shared by every concurrent request.
+///
+/// Shared **immutably**, so there is no lock on the read path and no
+/// contention that grows with concurrent readers.
+pub type Loaded = std::sync::Arc<Read>;
+
+/// Every route this server answers, serving from an already-loaded universe.
+///
+/// Takes the universe rather than a directory: a router holding a `PathBuf`
+/// can only re-read, and re-reading per request is the O(rows) cost this split
+/// exists to remove.
+pub fn router(read: Loaded) -> axum::Router {
+    axum::Router::new()
+        .route("/", axum::routing::get(page))
+        .route("/instruments", axum::routing::get(page))
+        .route("/health", axum::routing::get(health))
+        .with_state(read)
+}
+
+/// Serves on an already-bound listener until `shutdown` resolves.
+///
+/// The shutdown signal is a parameter rather than a `ctrl_c()` buried inside,
+/// so that a test can drive the whole serve path — accept, route, respond,
+/// stop — without a signal and without a hard kill.
+///
+/// # Errors
+///
+/// Whatever the server failed with. A server that stops for a reason is a
+/// reason the operator gets to read.
+pub async fn serve(
+    listener: tokio::net::TcpListener,
+    app: axum::Router,
+    shutdown: Shutdown,
+) -> std::io::Result<()> {
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            // The signal's own error is not actionable: a failed ctrl-c
+            // registration still means stop, and there is nothing else to do
+            // about it here.
+            let _ = shutdown.await;
+        })
+        .await
+}
+
+/// The exit code of a server that has stopped, and the reason if it fell over.
+///
+/// A separate function because a server that fails while accepting is not a
+/// state a test can conjure on demand — and an untestable arm inside `run`
+/// would be an uncovered branch that the coverage gate could never accept, so
+/// the branch lives where it can be exercised directly.
+fn stopped(outcome: std::io::Result<()>) -> u8 {
+    match outcome {
+        Ok(()) => OK,
+        Err(e) => {
+            eprintln!("server stopped: {e}");
+            FAILED
+        }
+    }
+}
+
+/// Everything went as asked.
+pub const OK: u8 = 0;
+/// It was asked for something reasonable and could not do it.
+pub const FAILED: u8 = 1;
+/// It was asked for something it does not understand. Distinct from
+/// [`FAILED`]: "I do not know what you mean" is not "I tried and failed".
+pub const MISUSED: u8 = 2;
+/// It did the work and the answer must not be trusted.
+///
+/// A vendor was never read, or two vendors disagreed, or a listing class
+/// nobody recognises turned up. Distinct from [`FAILED`] because the work
+/// completed and the output is real — it is the *universe* that is refused,
+/// not the run. D-0026. Zero here is what let a monitor read green while one
+/// of the two masters was missing.
+pub const DEGRADED: u8 = 3;
+
+/// Prints the report for `dir` and returns the exit code it earned.
+///
+/// A separate function for the same reason [`stopped`] is one: which directory
+/// `run` reads comes from the environment, and a test cannot set an
+/// environment variable here — `set_var` is `unsafe` under edition 2024 and
+/// this crate forbids `unsafe`. Left inline, the `OK` arm would be reachable
+/// only from the child process in `tests/binary.rs`, and a branch that only a
+/// subprocess can enter is a branch the coverage gate cannot hold. Taking the
+/// directory as an argument puts both arms where a test can drive them
+/// directly.
+fn reported(dir: &Path) -> u8 {
+    let (text, clean) = report(dir);
+    print!("{text}");
+    if clean { OK } else { DEGRADED }
+}
+
+/// Runs one command to completion and reports how it went.
+///
+/// Returns the exit code as a number rather than calling `exit`, so the whole
+/// thing — every arm of it — is callable from a test.
+pub async fn run(args: &[String], shutdown: Shutdown) -> u8 {
+    let dir = masters_dir();
+    match Command::parse(args) {
+        Ok(Command::Report) => reported(&dir),
+        Ok(Command::Serve(addr)) => match tokio::net::TcpListener::bind(addr).await {
+            Ok(listener) => {
+                println!("brutex-rs api listening on http://{addr}/instruments");
+                stopped(serve(listener, router(Loaded::new(universe(&dir))), shutdown).await)
+            }
+            Err(e) => {
+                eprintln!("cannot bind {addr}: {e}");
+                FAILED
+            }
+        },
+        Err(usage) => {
+            eprintln!("{usage}");
+            MISUSED
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::indexing_slicing,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    /// A directory holding one or both masters, named after the test.
+    fn masters(name: &str, groww: Option<&str>, dhan: Option<&str>) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("brutex-server-{name}"));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        for (file, body) in [("groww_instruments.csv", groww), ("dhan_scrip.csv", dhan)] {
+            let path = dir.join(file);
+            match body {
+                Some(text) => {
+                    let mut f = std::fs::File::create(&path).expect("create");
+                    f.write_all(text.as_bytes()).expect("write");
+                }
+                None => {
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+        }
+        dir
+    }
+
+    const GROWW_HEAD: &str = "exchange,segment,underlying_symbol,trading_symbol,\
+                              instrument_type,series,isin,expiry_date,strike_price\n";
+    // `SERIES` is the column the gate reads; `INSTRUMENT_TYPE` is present
+    // because the real file has it, and is deliberately never read. D-0025.
+    const DHAN_HEAD: &str = "EXCH_ID,SEGMENT,ISIN,INSTRUMENT,UNDERLYING_SYMBOL,SYMBOL_NAME,\
+                             INSTRUMENT_TYPE,SERIES,SM_EXPIRY_DATE,STRIKE_PRICE,OPTION_TYPE\n";
+
+    /// Both vendors, agreeing about NIFTY and RELIANCE.
+    fn agreeing(name: &str) -> PathBuf {
+        masters(
+            name,
+            Some(&format!(
+                "{GROWW_HEAD}\
+                 NSE,CASH,,NIFTY,IDX,,NIFTY,,\n\
+                 NSE,CASH,,RELIANCE,EQ,EQ,INE002A01018,,\n"
+            )),
+            Some(&format!(
+                "{DHAN_HEAD}\
+                 NSE,I,NA,INDEX,NIFTY,NIFTY,INDEX,NA,0001-01-01,,\n\
+                 NSE,E,INE002A01018,EQUITY,RELIANCE,RELIANCE INDUSTRIES,ES,EQ,,,\n"
+            )),
+        )
+    }
+
+    #[test]
+    fn the_command_line_is_parsed_or_refused_and_never_guessed() {
+        let parse = |args: &[&str]| {
+            let owned: Vec<String> = args.iter().map(|s| (*s).to_owned()).collect();
+            Command::parse(&owned)
+        };
+        assert_eq!(parse(&[]), Ok(Command::Serve(DEFAULT_ADDR)));
+        assert_eq!(parse(&["serve"]), Ok(Command::Serve(DEFAULT_ADDR)));
+        assert_eq!(
+            parse(&["serve", "0.0.0.0:9100"]),
+            Ok(Command::Serve("0.0.0.0:9100".parse().expect("valid")))
+        );
+        assert_eq!(parse(&["report"]), Ok(Command::Report));
+
+        // A typo that silently started a server is a typo nobody finds.
+        let e = parse(&["serv"]).expect_err("must refuse");
+        assert!(e.contains("unknown argument") && e.contains("usage"), "{e}");
+        let e = parse(&["report", "now"]).expect_err("must refuse");
+        assert!(e.contains("unknown"), "{e}");
+        let e = parse(&["serve", "not-an-address"]).expect_err("must refuse");
+        assert!(e.contains("not a socket address"), "{e}");
+        assert_eq!(DEFAULT_ADDR.port(), 8080);
+    }
+
+    #[test]
+    fn the_masters_directory_comes_from_the_environment_or_is_the_cwd() {
+        // Tested through the value rather than by setting the variable: under
+        // edition 2024 `set_var` is unsafe, this crate forbids unsafe, and a
+        // test that mutated process-wide state would be racing every other
+        // test in the binary anyway.
+        assert_eq!(masters_dir_from(None), PathBuf::from("."));
+        assert_eq!(
+            masters_dir_from(Some("/somewhere/else".into())),
+            PathBuf::from("/somewhere/else")
+        );
+    }
+
+    #[test]
+    fn a_server_that_falls_over_says_so_and_exits_non_zero() {
+        assert_eq!(stopped(Ok(())), OK);
+        assert_eq!(
+            stopped(Err(std::io::Error::other("the socket went away"))),
+            FAILED
+        );
+        assert_ne!(FAILED, MISUSED, "a misuse is not a failure");
+    }
+
+    #[test]
+    fn each_vendor_is_looked_for_under_its_own_file_name() {
+        let paths = master_paths(Path::new("/m"));
+        assert_eq!(paths.len(), 2);
+        assert!(paths[0].1.ends_with("groww_instruments.csv"));
+        assert!(paths[1].1.ends_with("dhan_scrip.csv"));
+    }
+
+    #[test]
+    fn a_query_string_is_decoded_without_a_dependency() {
+        assert_eq!(parse_query("q=NIFTY"), "NIFTY");
+        assert_eq!(parse_query("x=1&q=BANK"), "BANK");
+        assert_eq!(parse_query(""), "");
+        assert_eq!(parse_query("x=1"), "");
+        assert_eq!(parse_query("q=M%26M"), "M&M");
+        assert_eq!(parse_query("q=NIFTY+50"), "NIFTY 50");
+        // Both cases of hex, because a browser may send either.
+        assert_eq!(parse_query("q=%2f%2F"), "//");
+        assert_eq!(parse_query("q=%7e"), "~");
+        // Undecodable input is kept LITERALLY. A query must never silently
+        // become a different query.
+        assert_eq!(parse_query("q=100%"), "100%", "an escape at the very end");
+        assert_eq!(parse_query("q=a%2"), "a%2", "a truncated escape");
+        assert_eq!(parse_query("q=%zz"), "%zz", "not hex at all");
+        assert_eq!(parse_query("q=%2z"), "%2z", "half hex is not hex");
+    }
+
+    #[test]
+    fn the_report_names_every_vendor_and_every_decline_reason() {
+        let dir = agreeing("report");
+        let (text, clean) = report(&dir);
+        assert!(text.starts_with("ok\n"));
+        assert!(clean, "both vendors read, nothing disagreed");
+        assert!(text.contains("groww: 2 kept"), "{text}");
+        assert!(text.contains("dhan: 2 kept"), "{text}");
+        assert!(text.contains("merged: 2 instruments"), "{text}");
+        assert!(text.contains("0 isin conflicts"), "{text}");
+        assert!(text.contains("0 eligibility conflicts"), "{text}");
+        // The census is stated on every run, and it separates what two vendors
+        // confirmed from what one asserted.
+        assert!(
+            text.contains("F&O underlyings: 2 resolved, 2 confirmed by both vendors"),
+            "{text}"
+        );
+        assert!(
+            text.contains("NIFTY Total Market: 1 resolved, 1 confirmed by both vendors"),
+            "{text}"
+        );
+        assert!(
+            !text.contains("UNCHECKED"),
+            "nothing rests on one vendor here"
+        );
+    }
+
+    #[test]
+    fn a_missing_master_is_named_as_unavailable_and_the_status_says_so() {
+        // "This vendor lists nothing" and "this vendor was never read" are
+        // different facts, and collapsing them is the silent degradation the
+        // charter forbids. That was true of the NOTE and false of the STATUS:
+        // the first line said `ok` and the exit code was 0, so every monitor
+        // read green while half the universe had never been opened.
+        let dir = masters(
+            "missing",
+            Some(&format!("{GROWW_HEAD}NSE,CASH,,NIFTY,IDX,,NIFTY,,\n")),
+            None,
+        );
+        let (text, clean) = report(&dir);
+        assert!(text.starts_with("DEGRADED\n"), "{text}");
+        assert!(!clean, "a vendor that was never read is not a clean read");
+        assert!(text.contains("groww: 1 kept"), "{text}");
+        assert!(text.contains("dhan: UNAVAILABLE"), "{text}");
+        assert!(text.contains("merged: 1 instruments"), "{text}");
+    }
+
+    #[test]
+    fn the_report_counts_declines_by_reason() {
+        let dir = masters(
+            "reasons",
+            Some(&format!(
+                "{GROWW_HEAD}\
+                 NSE,CASH,,SOMEBOND,EQ,N2,INE002A01018,,\n\
+                 NSE,CASH,,SOMESME,EQ,SM,INE002A01018,,\n"
+            )),
+            None,
+        );
+        let (text, _) = report(&dir);
+        assert!(text.contains("not an equity listing 1"), "{text}");
+        assert!(text.contains("SME board 1"), "{text}");
+    }
+
+    #[test]
+    fn an_unrecognised_listing_class_names_the_code_and_degrades_the_run() {
+        // Renaming the equity series on the real Dhan master dropped 2,438
+        // shares under the same label a debenture gets, while the report
+        // printed `ok` and exited 0. The code is now named, the reason is its
+        // own, and the run is not clean.
+        let dir = masters(
+            "unrecognised",
+            Some(&format!(
+                "{GROWW_HEAD}NSE,CASH,,RELIANCE,EQ,EQX,INE002A01018,,\n"
+            )),
+            Some(&format!(
+                "{DHAN_HEAD}NSE,E,INE002A01018,EQUITY,RELIANCE,RELIANCE INDUSTRIES,ES,EQX,,,\n"
+            )),
+        );
+        let (text, clean) = report(&dir);
+        assert!(!clean, "an alphabet moving is not a routine skip");
+        assert!(text.starts_with("DEGRADED\n"), "{text}");
+        assert!(text.contains("unrecognised listing class 1"), "{text}");
+        assert!(
+            text.contains("UNRECOGNISED LISTING CLASS · \"EQX\" ×1"),
+            "the CODE is named, not just the count: {text}"
+        );
+        assert!(
+            text.contains("this engine has never seen"),
+            "and it says what that means: {text}"
+        );
+        // A routine bond, by contrast, leaves the run clean.
+        let dir = masters(
+            "routinebond",
+            Some(&format!(
+                "{GROWW_HEAD}NSE,CASH,,SOMEBOND,EQ,N2,INE002A01018,,\n"
+            )),
+            Some(&format!(
+                "{DHAN_HEAD}NSE,E,INE002A01018,EQUITY,SOMEBOND,SOME BOND,DEB,N2,,,\n"
+            )),
+        );
+        let (text, clean) = report(&dir);
+        assert!(clean, "{text}");
+        assert!(text.contains("not an equity listing 1"), "{text}");
+    }
+
+    #[test]
+    fn an_eligibility_disagreement_is_reported_and_degrades_the_run() {
+        // One vendor calls it an equity, the other calls it a fund. Both rows
+        // carry the SAME ISIN, so the check has the key it needs -- and before
+        // this the declined row was dropped at the reader, so the report said
+        // `0 conflicts` and exited 0.
+        let dir = masters(
+            "eligibility",
+            // Groww declines it: series MF is a fund.
+            Some(&format!(
+                "{GROWW_HEAD}NSE,CASH,,FISTIPD3GP,EQ,MF,INF090I01VS3,,\n"
+            )),
+            // Dhan keeps it: series EQ.
+            Some(&format!(
+                "{DHAN_HEAD}NSE,E,INF090I01VS3,EQUITY,FISTIPD3GP,FRANKLIN PLAN,ETF,EQ,,,\n"
+            )),
+        );
+        let (text, clean) = report(&dir);
+        assert!(!clean);
+        assert!(text.contains("ELIGIBILITY CONFLICT"), "{text}");
+        assert!(text.contains("1 eligibility conflicts"), "{text}");
+        assert!(text.contains("dhan kept it"), "{text}");
+        assert!(text.contains("groww declined it"), "{text}");
+        assert!(text.contains("INF090I01VS3"), "{text}");
+        // And it reaches a SEARCHED page, not only the unfiltered one.
+        let html = instruments_html(&dir, "FISTIP");
+        assert!(html.contains("ELIGIBILITY CONFLICT"), "{html}");
+    }
+
+    #[test]
+    fn an_isin_conflict_reaches_the_report_and_the_page() {
+        // The two vendors give one ticker two different ISINs. Neither the
+        // report nor the page may swallow that.
+        let dir = masters(
+            "conflict",
+            Some(&format!(
+                "{GROWW_HEAD}NSE,CASH,,CHOLAFIN,EQ,EQ,INE121A01024,,\n"
+            )),
+            Some(&format!(
+                "{DHAN_HEAD}NSE,E,INE121A08PJ0,EQUITY,CHOLAFIN,CHOLA,ES,EQ,,,\n"
+            )),
+        );
+        let (text, clean) = report(&dir);
+        assert!(text.contains("ISIN CONFLICT"), "{text}");
+        assert!(text.contains("1 isin conflicts"), "{text}");
+        assert!(
+            text.contains("INE121A01024") && text.contains("INE121A08PJ0"),
+            "{text}"
+        );
+        assert!(
+            !clean,
+            "D-0026: a disagreement REFUSES the universe rather than logging it"
+        );
+        assert!(text.starts_with("DEGRADED\n"), "{text}");
+
+        let html = instruments_html(&dir, "");
+        assert!(html.contains("ISIN CONFLICT"), "the page says so too");
+        assert!(html.contains("clash"), "and the row is marked");
+    }
+
+    #[test]
+    fn the_page_filters_on_the_query_and_says_which_total_it_means() {
+        let dir = agreeing("page");
+        let all = instruments_html(&dir, "");
+        assert!(all.contains("2 instruments total"));
+        assert!(all.contains("NSE-NIFTY") && all.contains("NSE-RELIANCE"));
+
+        let filtered = instruments_html(&dir, "reliance");
+        assert!(filtered.contains("1 matched"), "case-insensitive match");
+        assert!(filtered.contains("NSE-RELIANCE"));
+        assert!(!filtered.contains("NSE-NIFTY"));
+
+        let none = instruments_html(&dir, "NOTHINGLIKETHIS");
+        assert!(none.contains("0 matched"));
+        assert!(none.contains("<tbody></tbody>"));
+    }
+
+    #[test]
+    fn a_searched_page_still_says_a_vendor_was_never_read() {
+        // THE COLLAPSE `universe`'s OWN DOC SAYS SECTION 4 FORBIDS. The notes
+        // were folded into the title only when the query was empty, so typing
+        // anything made the page stop saying that a master was missing -- and
+        // with PAGE_ROWS at 200 against thousands of instruments, searching is
+        // the only way to reach most of them.
+        let dir = masters(
+            "searchnotes",
+            Some(&format!(
+                "{GROWW_HEAD}NSE,CASH,,RELIANCE,EQ,EQ,INE002A01018,,\n"
+            )),
+            None,
+        );
+        for query in ["", "RELIANCE", "NOTHINGLIKETHIS"] {
+            let html = instruments_html(&dir, query);
+            assert!(
+                html.contains("dhan: UNAVAILABLE"),
+                "query {query:?} must not hide an unread vendor: {html}"
+            );
+            assert!(
+                html.contains("DEGRADED"),
+                "query {query:?} must not claim the read was clean"
+            );
+        }
+        // A row from one vendor when the other was never read must not be
+        // byte-identical to a genuine single-vendor listing; the banner is
+        // what distinguishes them, and it is present above.
+        assert!(instruments_html(&dir, "RELIANCE").contains("1 matched"));
+    }
+
+    #[test]
+    fn an_unreadable_row_says_why_and_where_rather_than_only_how_many() {
+        // The line numbers and reasons were collected and then read only for
+        // `.len()`, so `104 unreadable` was the whole of what an operator was
+        // ever told. `NIFTY 100` is a real Dhan index ticker -- a space is not
+        // a legal Symbol -- and 104 rows of the real master are exactly that.
+        let dir = masters(
+            "unreadable",
+            Some(&format!(
+                "{GROWW_HEAD}\
+                 NSE,CASH,,RELIANCE,EQ,EQ,INE002A01018,,\n\
+                 NSE,CASH,,NIFTY 100,IDX,,NIFTY,,\n\
+                 NSE,CASH,,NIFTY 200,IDX,,NIFTY,,\n"
+            )),
+            None,
+        );
+        let (text, _) = report(&dir);
+        assert!(text.contains("2 unreadable"), "{text}");
+        assert!(
+            text.contains("groww UNREADABLE · malformed instrument identifier ×2, first at line 3"),
+            "the reason and the line, not a bare count: {text}"
+        );
+        assert!(instruments_html(&dir, "RELIANCE").contains("UNREADABLE"));
+    }
+
+    #[test]
+    fn a_row_too_short_for_its_columns_is_unreadable_never_a_routine_decline() {
+        // A truncated row used to default its missing fields to "", which the
+        // gate read as a series it does not recognise -- so a genuine share
+        // was dropped and reported as ordinary business with `0 unreadable`.
+        // The RELIANCE row below names the instrument and then stops before
+        // the series column.
+        let dir = masters(
+            "short",
+            Some(&format!(
+                "{GROWW_HEAD}\
+                 NSE,CASH,,RELIANCE,EQ\n\
+                 NSE,CASH,,CHOLAFIN,EQ,EQ,INE121A01024,,\n"
+            )),
+            None,
+        );
+        let (text, _) = report(&dir);
+        assert!(text.contains("groww: 1 kept"), "{text}");
+        assert!(text.contains("1 unreadable"), "{text}");
+        assert!(
+            text.contains("row has 5 field(s); the columns this vendor needs run to 9"),
+            "the shortfall is named: {text}"
+        );
+        assert!(
+            !text.contains("not an equity listing"),
+            "a truncated share is NOT a bond: {text}"
+        );
+    }
+
+    #[test]
+    fn the_swept_instruments_are_rendered_first() {
+        let dir = agreeing("order");
+        let html = instruments_html(&dir, "");
+        let nifty = html.find("NSE-NIFTY").expect("present");
+        let reliance = html.find("NSE-RELIANCE").expect("present");
+        assert!(nifty < reliance, "a swept instrument leads the page");
+    }
+
+    /// Reads one HTTP response off a fresh connection.
+    ///
+    /// A blocking client on a blocking thread, deliberately: it needs nothing
+    /// from `tokio` that this crate's feature set does not already have, and
+    /// awaiting it yields the runtime to the server task under test.
+    async fn get(addr: SocketAddr, path: &str) -> String {
+        let request = format!("GET {path} HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n");
+        tokio::task::spawn_blocking(move || {
+            use std::io::Read as _;
+            let mut s = std::net::TcpStream::connect(addr).expect("connect");
+            s.write_all(request.as_bytes()).expect("write");
+            let mut buf = String::new();
+            s.read_to_string(&mut buf).expect("read");
+            buf
+        })
+        .await
+        .expect("the client thread must not panic")
+    }
+
+    #[tokio::test]
+    async fn the_server_answers_every_route_and_then_shuts_down_gracefully() {
+        let dir = agreeing("serve");
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+
+        // The shutdown signal is a second listener rather than a channel: it
+        // needs nothing this crate does not already depend on, and connecting
+        // to it is an unambiguous "stop now".
+        let stopper = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let stop_addr = stopper.local_addr().expect("addr");
+        let served = tokio::spawn(serve(
+            listener,
+            router(Loaded::new(universe(&dir))),
+            Box::pin(async move { stopper.accept().await.map(|_| ()) }),
+        ));
+
+        let health = get(addr, "/health").await;
+        assert!(health.contains("200 OK"), "{health}");
+        assert!(health.contains("merged: 2 instruments"), "{health}");
+
+        let page = get(addr, "/instruments?q=NIFTY").await;
+        assert!(page.contains("200 OK"));
+        assert!(page.contains("NSE-NIFTY"));
+        assert!(
+            page.contains("groww: 2 kept"),
+            "a searched page still carries the notes: {page}"
+        );
+
+        let root = get(addr, "/").await;
+        assert!(root.contains("instruments total"));
+
+        let missing = get(addr, "/nope").await;
+        assert!(missing.contains("404"), "{missing}");
+
+        let _ = tokio::net::TcpStream::connect(stop_addr).await;
+        let outcome = served.await.expect("the serve task must not panic");
+        assert!(outcome.is_ok(), "a graceful shutdown is not a failure");
+    }
+
+    /// A signal that has already fired.
+    fn fired() -> Shutdown {
+        Box::pin(std::future::ready(Ok(())))
+    }
+
+    /// One command line, owned.
+    fn argv(args: &[&str]) -> Vec<String> {
+        args.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[tokio::test]
+    async fn run_serves_until_the_signal_and_exits_zero() {
+        // The server binds an ephemeral port, accepts nothing, and stops --
+        // which is the whole path through `run` minus the waiting.
+        assert_eq!(run(&argv(&["serve", "127.0.0.1:0"]), fired()).await, OK);
+    }
+
+    #[tokio::test]
+    async fn run_refuses_an_address_it_cannot_bind_and_says_which() {
+        let taken = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = taken.local_addr().expect("addr");
+        assert_eq!(
+            run(&argv(&["serve", &addr.to_string()]), fired()).await,
+            FAILED,
+            "an address already in use is a refusal, not a silent retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn health_answers_503_when_a_vendor_was_never_read() {
+        // A monitor reads the status code and nothing else. 200 with `ok` on
+        // the first line, beside `dhan: UNAVAILABLE` in the body, is the exact
+        // shape of a green light over a half-read universe.
+        let dir = masters(
+            "health503",
+            Some(&format!("{GROWW_HEAD}NSE,CASH,,NIFTY,IDX,,NIFTY,,\n")),
+            None,
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let stopper = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let stop_addr = stopper.local_addr().expect("addr");
+        let served = tokio::spawn(serve(
+            listener,
+            router(Loaded::new(universe(&dir))),
+            Box::pin(async move { stopper.accept().await.map(|_| ()) }),
+        ));
+
+        let health = get(addr, "/health").await;
+        assert!(health.contains("503"), "{health}");
+        assert!(health.contains("DEGRADED"), "{health}");
+        assert!(health.contains("dhan: UNAVAILABLE"), "{health}");
+
+        let _ = tokio::net::TcpStream::connect(stop_addr).await;
+        served
+            .await
+            .expect("task")
+            .expect("a graceful shutdown is not a failure");
+    }
+
+    #[test]
+    fn a_report_earns_zero_only_when_the_read_was_clean() {
+        // Both arms, driven directly. Which directory `run` reads comes from
+        // the environment and a test cannot set one here, so leaving this
+        // branch inside `run` would make the OK arm reachable only from the
+        // child process in tests/binary.rs -- and a branch only a subprocess
+        // can enter is a branch this gate cannot hold.
+        assert_eq!(reported(&agreeing("reported")), OK);
+        let missing = masters(
+            "reportedmissing",
+            Some(&format!("{GROWW_HEAD}NSE,CASH,,NIFTY,IDX,,NIFTY,,\n")),
+            None,
+        );
+        assert_eq!(reported(&missing), DEGRADED);
+    }
+
+    #[tokio::test]
+    async fn run_reports_and_refuses_nonsense_with_different_codes() {
+        // `run` reads BRUTEX_MASTERS, and a test cannot set it -- `set_var` is
+        // unsafe under edition 2024 and this crate forbids unsafe. The working
+        // directory during `cargo test` is the crate root, which holds no
+        // master at all, so this is the both-vendors-unavailable path and the
+        // exit code has to say so. `tests/binary.rs` drives the clean path,
+        // where it CAN set the variable, on a real child process.
+        assert_eq!(
+            run(&argv(&["report"]), fired()).await,
+            DEGRADED,
+            "no master anywhere is not a successful report"
+        );
+        assert_eq!(run(&argv(&["--wat"]), fired()).await, MISUSED);
+        assert_ne!(DEGRADED, OK, "a refused universe is not a success");
+        assert_ne!(DEGRADED, FAILED, "the run worked; its ANSWER is refused");
+        assert_ne!(DEGRADED, MISUSED);
+    }
+}

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -364,7 +364,7 @@ fn hex_digit(c: u8) -> Option<u8> {
 /// are now a banner the page always carries, whatever was typed.
 #[must_use]
 pub fn instruments_html(dir: &Path, query: &str) -> String {
-    instruments_html_from(&universe(dir), query, "", false)
+    instruments_html_from(&universe(dir), query, "", false, "")
 }
 
 /// The instruments page, rendered from a universe that is **already loaded**.
@@ -385,7 +385,13 @@ pub fn instruments_html(dir: &Path, query: &str) -> String {
 /// renders from that. Re-reading is now an explicit operator action rather
 /// than a side effect of looking at the page.
 #[must_use]
-pub fn instruments_html_from(read: &Read, query: &str, sort: &str, all: bool) -> String {
+pub fn instruments_html_from(
+    read: &Read,
+    query: &str,
+    sort: &str,
+    all: bool,
+    universe_filter: &str,
+) -> String {
     let needle = query.to_uppercase();
 
     // THE TRACKED UNIVERSE, and nothing else.
@@ -408,18 +414,38 @@ pub fn instruments_html_from(read: &Read, query: &str, sort: &str, all: bool) ->
     // recompile.
     let tracked =
         |u: Universe| all || u.contains(Universe::TOTAL_MARKET) || u.contains(Universe::INDEX);
-    let total = read
+    // COUNTS OVER THE WHOLE TRACKED SET, never over the rendered page. A pill
+    // that counts the 200 rows on screen says 52 when the answer is 208, and
+    // looks authoritative doing it.
+    let counts = read
         .merged
         .by_key
         .values()
         .filter(|e| tracked(e.universe))
-        .count();
+        .fold(render::UniverseCounts::default(), |mut c, e| {
+            c.all += 1;
+            c.fno += usize::from(e.universe.contains(Universe::FNO));
+            c.ntm += usize::from(e.universe.contains(Universe::TOTAL_MARKET));
+            c.index += usize::from(e.universe.contains(Universe::INDEX));
+            c
+        });
+    let total = counts.all;
+
+    // The universe pill, applied HERE so it selects from the whole set rather
+    // than hiding rows the page happened to load. An unrecognised value selects
+    // everything: a stale bookmark should render the page, not an empty one.
+    let selected = |u: Universe| match universe_filter {
+        "fno" => u.contains(Universe::FNO),
+        "ntm" => u.contains(Universe::TOTAL_MARKET),
+        "idx" => u.contains(Universe::INDEX),
+        _ => true,
+    };
 
     let mut keys: Vec<_> = read
         .merged
         .by_key
         .iter()
-        .filter(|(_, e)| tracked(e.universe))
+        .filter(|(_, e)| tracked(e.universe) && selected(e.universe))
         .filter(|(k, _)| needle.is_empty() || k.to_string().to_uppercase().contains(&needle))
         .map(|(k, e)| (*k, *e))
         .collect();
@@ -475,7 +501,17 @@ pub fn instruments_html_from(read: &Read, query: &str, sort: &str, all: bool) ->
             matched,
         )
     };
-    render::instruments_page(&title, denominator, &rows, query, sort, all, &read.notes)
+    render::instruments_page(&render::View {
+        title: &title,
+        total: denominator,
+        rows: &rows,
+        query,
+        sort,
+        all,
+        counts,
+        active: universe_filter,
+        notes: &read.notes,
+    })
 }
 
 /// The instruments page.
@@ -487,7 +523,8 @@ async fn page(
     let typed = parse_query(raw);
     let sort = param(raw, "sort");
     let all = param(raw, "all") == "1";
-    axum::response::Html(instruments_html_from(&read, &typed, &sort, all))
+    let u = param(raw, "u");
+    axum::response::Html(instruments_html_from(&read, &typed, &sort, all, &u))
 }
 
 /// The health endpoint.

--- a/crates/api/tests/binary.rs
+++ b/crates/api/tests/binary.rs
@@ -1,0 +1,125 @@
+//! Running the binary itself.
+//!
+//! `crates/api/src/main.rs` is the one file in this crate that a unit test
+//! cannot enter: `cargo test` compiles the binary with its own harness and
+//! never calls `main`. Every other line of the server therefore lives in the
+//! library, and this test exists to cover the call that is left — by actually
+//! running the process, with a command that terminates.
+//!
+//! It is not a smoke test. `docs/04-invariants.md` X-06 requires 100% line and
+//! branch coverage on every crate, with no omit list, and an untested `main`
+//! is the difference between a gate that holds and a gate with one exception
+//! in it. The coverage harness collects from child processes, so the run below
+//! is measured exactly like an in-process test.
+
+// The same exceptions every test module in this workspace takes: a test that
+// cannot panic cannot fail, and the lints that forbid panicking exist to keep
+// them out of the SERVER, not out of its tests.
+#![allow(
+    clippy::indexing_slicing,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+
+use std::process::Command;
+
+const GROWW_HEAD: &str = "exchange,segment,underlying_symbol,trading_symbol,instrument_type,\
+                          series,isin,expiry_date,strike_price\n";
+const DHAN_HEAD: &str = "EXCH_ID,SEGMENT,ISIN,INSTRUMENT,UNDERLYING_SYMBOL,SYMBOL_NAME,\
+                         SERIES,SM_EXPIRY_DATE,STRIKE_PRICE,OPTION_TYPE\n";
+
+/// A directory holding the given vendor masters, named after the test.
+///
+/// A `None` deletes that vendor's file, so a test can drive the
+/// vendor-was-never-read path deliberately rather than by accident.
+fn masters(name: &str, groww: Option<&str>, dhan: Option<&str>) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!("brutex-binary-{name}"));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    for (file, body) in [("groww_instruments.csv", groww), ("dhan_scrip.csv", dhan)] {
+        let path = dir.join(file);
+        match body {
+            Some(text) => std::fs::write(&path, text).expect("write"),
+            None => {
+                let _ = std::fs::remove_file(&path);
+            }
+        }
+    }
+    dir
+}
+
+/// Runs the binary once and returns its exit code, stdout and stderr.
+fn run(dir: &std::path::Path, arg: &str) -> (Option<i32>, String, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_api"))
+        .arg(arg)
+        .env("BRUTEX_MASTERS", dir)
+        .output()
+        .expect("the binary must run");
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn the_binary_reports_what_it_read_and_exits_zero() {
+    // BOTH masters present and agreeing, which is the only shape that may
+    // exit zero. The measured decline is a real bond on series `N2`.
+    let dir = masters(
+        "report",
+        Some(&format!(
+            "{GROWW_HEAD}\
+             NSE,CASH,,NIFTY,IDX,,NIFTY,,\n\
+             NSE,CASH,,RELIANCE,EQ,EQ,INE002A01018,,\n\
+             NSE,CASH,,SOMEBOND,EQ,N2,INE121A08PJ0,,\n"
+        )),
+        Some(&format!(
+            "{DHAN_HEAD}\
+             NSE,I,NA,INDEX,NIFTY,NIFTY,NA,0001-01-01,,\n\
+             NSE,E,INE002A01018,EQUITY,RELIANCE,RELIANCE INDUSTRIES LTD,EQ,,,\n\
+             NSE,E,INE121A08PJ0,EQUITY,SOMEBOND,SOME BOND,N2,,,\n"
+        )),
+    );
+    let (code, text, _) = run(&dir, "report");
+
+    assert_eq!(code, Some(0), "a clean read exits zero: {text}");
+    assert!(text.starts_with("ok\n"), "{text}");
+    assert!(text.contains("groww: 2 kept"), "{text}");
+    assert!(text.contains("dhan: 2 kept"), "{text}");
+    assert!(text.contains("not an equity listing 1"), "{text}");
+    assert!(text.contains("merged: 2 instruments"), "{text}");
+    assert!(text.contains("0 isin conflicts"), "{text}");
+    assert!(text.contains("0 eligibility conflicts"), "{text}");
+}
+
+#[test]
+fn the_binary_exits_non_zero_when_a_vendor_was_never_read() {
+    // The status line, the exit code and `/health` all used to report success
+    // beside `dhan: UNAVAILABLE`, so every machine check went green while half
+    // the universe had never been opened. D-0026.
+    let dir = masters(
+        "unavailable",
+        Some(&format!("{GROWW_HEAD}NSE,CASH,,NIFTY,IDX,,NIFTY,,\n")),
+        None,
+    );
+    let (code, text, _) = run(&dir, "report");
+    assert_eq!(code, Some(3), "DEGRADED, not success: {text}");
+    assert!(text.starts_with("DEGRADED\n"), "{text}");
+    assert!(text.contains("dhan: UNAVAILABLE"), "{text}");
+    // The work still happened and the output is still real -- it is the
+    // universe that is refused, not the run.
+    assert!(text.contains("groww: 1 kept"), "{text}");
+    assert!(text.contains("merged: 1 instruments"), "{text}");
+}
+
+#[test]
+fn the_binary_refuses_an_argument_it_does_not_understand() {
+    // Exit 2, and a usage line on stderr. A binary that silently started a
+    // server on a typo is a binary whose typos are found in production.
+    let dir = std::env::temp_dir();
+    let (code, _, err) = run(&dir, "--serv");
+    assert_eq!(code, Some(2), "a misuse is not a failure");
+    assert!(err.contains("unknown argument"), "{err}");
+    assert!(err.contains("usage:"), "{err}");
+}

--- a/crates/core/src/isin.rs
+++ b/crates/core/src/isin.rs
@@ -1,0 +1,326 @@
+//! An ISO 6166 ISIN — fixed width, check-digit verified, and deliberately
+//! **not** part of instrument identity.
+//!
+//! # Why an ISIN is a cross-check and never a key component
+//!
+//! An ISIN is the one field two vendors can be compared on: it is issued by a
+//! national numbering agency, not by a broker, so it is the same string in
+//! every master that carries it. That makes it the ideal *check* — and the
+//! worst possible *key component*.
+//!
+//! [`crate::instrument::InstrumentKey`] derives [`Hash`] and [`Eq`] over every
+//! field and is used directly as a `HashMap` key; that collision **is** the
+//! deduplication (`docs/05-decisions.md` D-0015). If the ISIN were a field of
+//! the key, then two vendors disagreeing about one instrument's ISIN would
+//! produce **two different keys**, the merge map would hold them as two
+//! separate instruments, and the disagreement would never be seen by anyone.
+//! A dedup mechanism that splits silently on the exact field you added to make
+//! it more precise is the failure `CLAUDE.md` §4 forbids: a fallback that
+//! hides a failure.
+//!
+//! Kept *beside* the key, the same disagreement is a single loud refusal that
+//! names the key and both ISINs — which is what D-0020 already requires of
+//! every other vendor disagreement.
+//!
+//! # Why the check digit is verified rather than trusted
+//!
+//! Refusing a malformed ISIN is only useful if "malformed" means more than
+//! "the wrong number of characters". The check digit is what turns a
+//! transcription error into a refusal instead of a plausible-looking
+//! identifier that silently points at nothing. Measured on the real masters:
+//! exactly **one** row in either file fails the check digit — `IN1520250085`,
+//! a state development loan — and it is a debt listing that the equity gate in
+//! [`crate::vendor`] declines before an ISIN is ever parsed. The check is
+//! therefore free in practice and loud the day it is not.
+//!
+//! Nothing here normalises. There is no padding, no case folding, no trimming:
+//! a value that is not an ISIN is refused, because inventing one is how a
+//! wrong identity enters a cross-check whose entire job is to catch wrong
+//! identities.
+
+use crate::error::InstrumentError;
+use std::fmt;
+
+/// The number of characters in an ISIN. ISO 6166 fixes this at 12.
+pub const ISIN_LEN: usize = 12;
+
+/// A validated ISO 6166 International Securities Identification Number.
+///
+/// Fixed 12 ASCII bytes and [`Copy`], so hashing one is a constant number of
+/// machine words — the same reason [`crate::symbol::Symbol`] is fixed width.
+/// A vendor that starts sending a longer identifier is a loud refusal at the
+/// boundary rather than a silently more expensive probe later.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Isin {
+    bytes: [u8; ISIN_LEN],
+}
+
+impl Isin {
+    /// Parses and validates an ISIN.
+    ///
+    /// The shape ISO 6166 requires: two uppercase letters of ISO 3166 country
+    /// code, nine uppercase alphanumeric characters of national number, and
+    /// one decimal check digit — which is verified, not assumed.
+    ///
+    /// # Errors
+    ///
+    /// [`InstrumentError::Malformed`] for any length other than
+    /// [`ISIN_LEN`], any character outside the position's alphabet, or a check
+    /// digit that does not match the value computed from the other eleven.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use brutex_core::isin::Isin;
+    /// // CHOLAFIN, the share.
+    /// assert_eq!(Isin::new("INE121A01024")?.as_str(), "INE121A01024");
+    /// // The same string with one digit changed no longer verifies.
+    /// assert!(Isin::new("INE121A01025").is_err());
+    /// # Ok::<(), brutex_core::error::InstrumentError>(())
+    /// ```
+    pub fn new(text: &str) -> Result<Self, InstrumentError> {
+        let src = text.as_bytes();
+        if src.len() != ISIN_LEN {
+            return Err(InstrumentError::Malformed);
+        }
+
+        // Zip rather than index: `indexing_slicing` is denied workspace-wide,
+        // and this runs on every equity row of every master.
+        let mut bytes = [0u8; ISIN_LEN];
+        for (i, (dst, &c)) in bytes.iter_mut().zip(src.iter()).enumerate() {
+            let allowed = match i {
+                // ISO 3166 country code. Lowercase is refused rather than
+                // upcased: `in` is not `IN`, it is a vendor bug.
+                0 | 1 => c.is_ascii_uppercase(),
+                // The check digit is decimal.
+                n if n == ISIN_LEN - 1 => c.is_ascii_digit(),
+                // The national number, e.g. `E121A01024`.
+                _ => c.is_ascii_uppercase() || c.is_ascii_digit(),
+            };
+            if !allowed {
+                return Err(InstrumentError::Malformed);
+            }
+            *dst = c;
+        }
+
+        // An irrefutable array pattern: the length is fixed at ISIN_LEN, so
+        // this introduces no branch that no test could ever reach. `split_last`
+        // would have returned an Option whose `None` arm is unreachable and
+        // therefore permanently uncovered.
+        let [.., check] = bytes;
+        if expected_check_digit(&bytes) != check - b'0' {
+            return Err(InstrumentError::Malformed);
+        }
+        Ok(Self { bytes })
+    }
+
+    /// The ISIN as text.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        // The constructor admits only ASCII, and ASCII is valid UTF-8.
+        std::str::from_utf8(&self.bytes).unwrap_or("")
+    }
+}
+
+/// The check digit ISO 6166 requires for the first eleven characters.
+///
+/// Every letter is expanded to its two-digit ordinal (`A` = 10 … `Z` = 35),
+/// then the Luhn mod-10 sum is taken over the expanded string with **the
+/// rightmost digit doubled** — it is the digit adjacent to the check digit.
+fn expected_check_digit(isin: &[u8; ISIN_LEN]) -> u8 {
+    let digits = || {
+        isin.iter().take(ISIN_LEN - 1).flat_map(|&c| {
+            let v = if c.is_ascii_digit() {
+                c - b'0'
+            } else {
+                c - b'A' + 10
+            };
+            // A letter expands to TWO digits, a digit to one. Yielding a pair
+            // and dropping the leading digit unless the value is ten or more
+            // keeps this allocation-free — no `Vec`, no scratch buffer, no
+            // bounds check.
+            std::iter::once(v / 10)
+                .filter(move |_| v >= 10)
+                .chain(std::iter::once(v % 10))
+        })
+    };
+
+    let n = digits().count();
+    // Each term is at most 9 — a doubled 9 is 18, which folds to 1 + 8 — and
+    // there are at most 22 terms, so the sum is at most 198 and an 8-bit
+    // accumulator cannot overflow. Stated rather than assumed, because a cast
+    // here would be a `cast_possible_truncation` the workspace denies.
+    let sum: u8 = digits()
+        .enumerate()
+        .map(|(i, d)| {
+            // Position counts from the RIGHT of the expanded string.
+            if (n - 1 - i) % 2 == 0 {
+                let doubled = d * 2;
+                doubled / 10 + doubled % 10
+            } else {
+                d
+            }
+        })
+        .sum();
+    (10 - sum % 10) % 10
+}
+
+impl fmt::Display for Isin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl fmt::Debug for Isin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Isin({})", self.as_str())
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::indexing_slicing,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_the_real_isins_this_engine_meets() {
+        // Every one of these is copied from a real master row.
+        for (text, what) in [
+            ("INE002A01018", "RELIANCE, the equity"),
+            ("INE121A01024", "CHOLAFIN, the equity"),
+            (
+                "INE121A08PJ0",
+                "CHOLAFIN, the 7.5% NCD — letters in the tail",
+            ),
+            ("INE775A08105", "MOTHERSON, the NCD"),
+            ("INE086A13016", "ELECTCAST, the warrant"),
+            ("INE657B01025", "BLUECHIP, whose Groww symbol is suffixed"),
+            ("INF179KC1JG3", "HDFCLIQUID, an ETF — an INF issuer prefix"),
+            (
+                "US0378331005",
+                "a non-Indian ISIN, so the check is not IN-only",
+            ),
+        ] {
+            assert!(Isin::new(text).is_ok(), "{text} ({what}) must parse");
+        }
+    }
+
+    #[test]
+    fn the_one_real_row_with_a_bad_check_digit_is_refused() {
+        // Measured: across both masters exactly one row carries an ISIN whose
+        // check digit does not verify — a state development loan. It is a debt
+        // listing, so the equity gate declines it before an ISIN is ever
+        // parsed; this test is what proves the digit itself is checked rather
+        // than the row merely being unreachable.
+        assert_eq!(Isin::new("IN1520250085"), Err(InstrumentError::Malformed));
+        // The same string with the digit the algorithm actually computes is
+        // accepted, which pins down that ONE character is what was wrong.
+        assert!(Isin::new("IN1520250086").is_ok());
+    }
+
+    #[test]
+    fn every_wrong_length_is_refused_rather_than_padded() {
+        for bad in [
+            "",
+            "INE002A0101",
+            "INE002A010188",
+            "INE002A01018 ",
+            " INE002A01018",
+        ] {
+            assert_eq!(
+                Isin::new(bad),
+                Err(InstrumentError::Malformed),
+                "{bad:?} must be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn each_position_enforces_its_own_alphabet() {
+        // Country code must be two uppercase letters.
+        assert_eq!(Isin::new("1NE002A01018"), Err(InstrumentError::Malformed));
+        assert_eq!(Isin::new("I2E002A01018"), Err(InstrumentError::Malformed));
+        assert_eq!(
+            Isin::new("ine002a01018"),
+            Err(InstrumentError::Malformed),
+            "lowercase is refused, never upcased"
+        );
+        // The national number is alphanumeric; punctuation is not.
+        assert_eq!(Isin::new("INE002-01018"), Err(InstrumentError::Malformed));
+        // The check digit is decimal.
+        assert_eq!(Isin::new("INE002A0101A"), Err(InstrumentError::Malformed));
+        // Twelve BYTES but eleven characters: it survives the length check and
+        // is refused by the alphabet rather than by a lucky length.
+        assert_eq!("INE002A010é".len(), ISIN_LEN, "the length check passes it");
+        assert_eq!(Isin::new("INE002A010é"), Err(InstrumentError::Malformed));
+    }
+
+    #[test]
+    fn a_single_wrong_digit_anywhere_fails_the_check() {
+        // A transcription error is exactly what the check digit exists to
+        // catch, and it is the reason this is verified rather than trusted.
+        for bad in [
+            "INE002A01017",
+            "INE002A01118",
+            "INE003A01018",
+            "INF002A01018",
+        ] {
+            assert_eq!(
+                Isin::new(bad),
+                Err(InstrumentError::Malformed),
+                "{bad} must fail the check digit"
+            );
+        }
+    }
+
+    #[test]
+    fn renders_for_humans_and_for_debug() {
+        let i = Isin::new("INE002A01018").expect("valid");
+        assert_eq!(i.as_str(), "INE002A01018");
+        assert_eq!(i.to_string(), "INE002A01018");
+        assert_eq!(format!("{i:?}"), "Isin(INE002A01018)");
+    }
+
+    #[test]
+    fn identity_is_the_twelve_bytes_and_nothing_else() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let hash = |i: &Isin| {
+            let mut h = DefaultHasher::new();
+            i.hash(&mut h);
+            h.finish()
+        };
+        let a = Isin::new("INE121A01024").expect("valid");
+        let b = Isin::new("INE121A01024").expect("valid");
+        let c = Isin::new("INE121A08PJ0").expect("valid");
+        assert_eq!(a, b);
+        assert_eq!(hash(&a), hash(&b));
+        assert_ne!(
+            a, c,
+            "the share and its issuer's NCD are NOT the same paper"
+        );
+        assert_ne!(hash(&a), hash(&c));
+        // Ord is the byte order, so a BTreeMap key sorts the way the strings
+        // do — `…A01024` before `…A08PJ0`.
+        assert!(a < c);
+        assert_eq!(a.cmp(&c), std::cmp::Ordering::Less);
+    }
+
+    #[test]
+    fn the_check_digit_matches_the_published_worked_example() {
+        // ISO 6166's own worked example is US0378331005: the expansion is
+        // 30 28 037833100, the Luhn sum is 45, and the check digit is 5.
+        let body = *b"US0378331005";
+        assert_eq!(expected_check_digit(&body), 5);
+        // And the same body with a deliberately wrong digit still computes 5,
+        // which is what makes the comparison in `new` meaningful.
+        let wrong = *b"US0378331000";
+        assert_eq!(expected_check_digit(&wrong), 5);
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,14 +15,18 @@
 //! |---|---|
 //! | [`error`] | every error this crate can return |
 //! | [`instrument`] | the one identity every vendor resolves to |
+//! | [`isin`] | the cross-check that is deliberately not part of identity |
 //! | [`price`] | paisa integers and the one float boundary |
 //! | [`symbol`] | fixed-width symbols, so hashing one is constant time |
+//! | [`universe`] | which lists a symbol belongs to |
 //! | [`vendor`] | one vendor master row in, one canonical key out |
 
 #![forbid(unsafe_code)]
 
 pub mod error;
 pub mod instrument;
+pub mod isin;
 pub mod price;
 pub mod symbol;
+pub mod universe;
 pub mod vendor;

--- a/crates/core/src/universe.rs
+++ b/crates/core/src/universe.rs
@@ -1,0 +1,1280 @@
+//! The instrument universes, as transcribed data.
+//!
+//! # Why these are Rust literals
+//!
+//! `CLAUDE.md` §2 permits no `.csv` in this repository, so a constituent list
+//! cannot be tracked as a data file. The *data* is fine; the *format* is not.
+//! These are transcriptions, and each names where it came from.
+//!
+//! # Why membership is not a field of [`crate::instrument::InstrumentKey`]
+//!
+//! `InstrumentKey` derives `Hash` and `Eq` over every field and is used as a
+//! `HashMap` key — that is the deduplication mechanism. If membership were a
+//! field, the *same contract* carrying different memberships would become two
+//! different keys and dedup would break silently. Membership is therefore a
+//! property looked up **from** the key, never part of it.
+//!
+//! # Cost
+//!
+//! Lookup is a binary search over a sorted array — O(log n) on 750 entries, so
+//! at most 10 comparisons. Not O(1), and saying otherwise would be false; a
+//! perfect hash would make it O(1) and is not worth the machinery at this size.
+//! Recorded as a departure from `CLAUDE.md` golden rule 4 in
+//! `docs/06-limits.md` §11, because a departure nobody wrote down is a claim
+//! nobody can check. Neither list is on the sweep's per-bar path — membership
+//! is asked once per instrument at merge time, never once per bar — which is
+//! why O(log n) is acceptable here and would not be there.
+//!
+//! # What consults this
+//!
+//! `api::server::universe` stamps every merged cash listing with its
+//! membership, and the page and the report both show it. That is not
+//! decoration: [`crate::vendor::Skip::SmeBoard`] declines 1,117 real shares on
+//! the ground that neither list contains an SME listing, and a claim that
+//! load-bearing is checked here rather than asserted in a comment — see
+//! [`of_equity`] and `no_measured_sme_ticker_belongs_to_either_universe`.
+
+use crate::instrument::{InstrumentKey, Kind};
+
+/// The 750 NIFTY Total Market constituents.
+///
+/// niftyindices.com: "750 stocks ... all stocks that are part of Nifty 500
+/// and Nifty Microcap 250". Transcribed from the local lake's NSE/CASH
+/// directories, every one of which matched the primary broker's equity list
+/// 750/750 with zero misses. The source and its evidence lane are recorded in
+/// `docs/00-charter.md` §4a, as golden rule 1 requires of any claim about an
+/// instrument.
+///
+/// Re-measured against both real masters on 2026-08-01 under the D-0025 gate:
+/// **750 of 750 resolve as a kept equity in BOTH vendors**, with agreeing
+/// ISINs and zero misses.
+///
+/// UNVERIFIED against an NSE constituent circular: this is a SNAPSHOT, and
+/// index membership is rebalanced. See `docs/06-limits.md` §11.
+pub const NIFTY_TOTAL_MARKET: [&str; 750] = [
+    "360ONE",
+    "3MINDIA",
+    "AADHARHFC",
+    "AARTIDRUGS",
+    "AARTIIND",
+    "AARTIPHARM",
+    "AAVAS",
+    "ABB",
+    "ABBOTINDIA",
+    "ABCAPITAL",
+    "ABDL",
+    "ABFRL",
+    "ABLBL",
+    "ABREL",
+    "ABSLAMC",
+    "ACC",
+    "ACE",
+    "ACI",
+    "ACMESOLAR",
+    "ACUTAAS",
+    "ADANIENSOL",
+    "ADANIENT",
+    "ADANIGREEN",
+    "ADANIPORTS",
+    "ADANIPOWER",
+    "ADVENZYMES",
+    "AEGISLOG",
+    "AEGISVOPAK",
+    "AEQUS",
+    "AETHER",
+    "AFCONS",
+    "AFFLE",
+    "AGARWALEYE",
+    "AGL",
+    "AHLUCONT",
+    "AIAENG",
+    "AIIL",
+    "AJANTPHARM",
+    "AKUMS",
+    "ALIVUS",
+    "ALKEM",
+    "ALKYLAMINE",
+    "ALOKINDS",
+    "AMBER",
+    "AMBUJACEM",
+    "ANANDRATHI",
+    "ANANTRAJ",
+    "ANGELONE",
+    "ANTHEM",
+    "ANUP",
+    "ANURAS",
+    "APARINDS",
+    "APLAPOLLO",
+    "APLLTD",
+    "APOLLO",
+    "APOLLOHOSP",
+    "APOLLOTYRE",
+    "APTUS",
+    "ARE&M",
+    "ARVIND",
+    "ARVINDFASN",
+    "ASAHIINDIA",
+    "ASHAPURMIN",
+    "ASHOKA",
+    "ASHOKLEY",
+    "ASIANPAINT",
+    "ASKAUTOLTD",
+    "ASTERDM",
+    "ASTRAL",
+    "ASTRAMICRO",
+    "ATGL",
+    "ATHERENERG",
+    "ATLANTAELE",
+    "ATUL",
+    "AUBANK",
+    "AURIONPRO",
+    "AUROPHARMA",
+    "AVALON",
+    "AVANTIFEED",
+    "AVL",
+    "AWFIS",
+    "AWL",
+    "AXISBANK",
+    "AXISCADES",
+    "AZAD",
+    "BAJAJ-AUTO",
+    "BAJAJELEC",
+    "BAJAJFINSV",
+    "BAJAJHFL",
+    "BAJAJHLDNG",
+    "BAJFINANCE",
+    "BALAMINES",
+    "BALKRISIND",
+    "BALRAMCHIN",
+    "BALUFORGE",
+    "BANCOINDIA",
+    "BANDHANBNK",
+    "BANKBARODA",
+    "BANKINDIA",
+    "BATAINDIA",
+    "BAYERCROP",
+    "BBOX",
+    "BBTC",
+    "BDL",
+    "BECTORFOOD",
+    "BEL",
+    "BELRISE",
+    "BEML",
+    "BERGEPAINT",
+    "BHARATFORG",
+    "BHARTIARTL",
+    "BHARTIHEXA",
+    "BHEL",
+    "BIKAJI",
+    "BIOCON",
+    "BIRLACORPN",
+    "BLACKBUCK",
+    "BLS",
+    "BLUEDART",
+    "BLUEJET",
+    "BLUESTARCO",
+    "BLUESTONE",
+    "BORORENEW",
+    "BOSCHLTD",
+    "BPCL",
+    "BRIGADE",
+    "BRITANNIA",
+    "BSE",
+    "BSOFT",
+    "CAMPUS",
+    "CAMS",
+    "CANBK",
+    "CANFINHOME",
+    "CANHLIFE",
+    "CAPILLARY",
+    "CAPLIPOINT",
+    "CARBORUNIV",
+    "CARTRADE",
+    "CASTROLIND",
+    "CCAVENUE",
+    "CCL",
+    "CDSL",
+    "CEATLTD",
+    "CELLO",
+    "CEMPRO",
+    "CENTRALBK",
+    "CENTURYPLY",
+    "CERA",
+    "CESC",
+    "CGCL",
+    "CGPOWER",
+    "CHALET",
+    "CHAMBLFERT",
+    "CHENNPETRO",
+    "CHOICEIN",
+    "CHOLAFIN",
+    "CHOLAHLDNG",
+    "CIEINDIA",
+    "CIPLA",
+    "CLEAN",
+    "CMSINFO",
+    "COALINDIA",
+    "COCHINSHIP",
+    "COFORGE",
+    "COHANCE",
+    "COLPAL",
+    "CONCOR",
+    "CONCORDBIO",
+    "COROMANDEL",
+    "CORONA",
+    "CPPLUS",
+    "CRAFTSMAN",
+    "CRAMC",
+    "CREDITACC",
+    "CRISIL",
+    "CRIZAC",
+    "CROMPTON",
+    "CSBBANK",
+    "CUB",
+    "CUMMINSIND",
+    "CUPID",
+    "CYIENT",
+    "DABUR",
+    "DALBHARAT",
+    "DATAMATICS",
+    "DATAPATTNS",
+    "DBL",
+    "DBREALTY",
+    "DCBBANK",
+    "DCMSHRIRAM",
+    "DEEPAKFERT",
+    "DEEPAKNTR",
+    "DELHIVERY",
+    "DEVYANI",
+    "DIACABS",
+    "DIVISLAB",
+    "DIXON",
+    "DLF",
+    "DMART",
+    "DOMS",
+    "DRREDDY",
+    "DYNAMATECH",
+    "ECLERX",
+    "EDELWEISS",
+    "EICHERMOT",
+    "EIDPARRY",
+    "EIEL",
+    "EIHOTEL",
+    "ELECON",
+    "ELECTCAST",
+    "ELGIEQUIP",
+    "ELLEN",
+    "EMAMILTD",
+    "EMBDL",
+    "EMCURE",
+    "EMIL",
+    "EMMVEE",
+    "ENDURANCE",
+    "ENGINERSIN",
+    "ENRIN",
+    "ENTERO",
+    "EPL",
+    "EQUITASBNK",
+    "ERIS",
+    "ESCORTS",
+    "ETERNAL",
+    "ETHOSLTD",
+    "EUREKAFORB",
+    "EXIDEIND",
+    "FACT",
+    "FEDERALBNK",
+    "FEDFINA",
+    "FIEMIND",
+    "FINCABLES",
+    "FINPIPE",
+    "FIRSTCRY",
+    "FIVESTAR",
+    "FLUOROCHEM",
+    "FORCEMOT",
+    "FORTIS",
+    "FSL",
+    "GABRIEL",
+    "GAEL",
+    "GAIL",
+    "GALLANTT",
+    "GESHIP",
+    "GHCL",
+    "GICRE",
+    "GILLETTE",
+    "GLAND",
+    "GLAXO",
+    "GLENMARK",
+    "GMDCLTD",
+    "GMMPFAUDLR",
+    "GMRAIRPORT",
+    "GMRP&UI",
+    "GNFC",
+    "GODFRYPHLP",
+    "GODIGIT",
+    "GODREJAGRO",
+    "GODREJCP",
+    "GODREJIND",
+    "GODREJPROP",
+    "GOKEX",
+    "GOKULAGRO",
+    "GPIL",
+    "GPPL",
+    "GRANULES",
+    "GRAPHITE",
+    "GRASIM",
+    "GRAVITA",
+    "GREAVESCOT",
+    "GROWW",
+    "GRSE",
+    "GRWRHITECH",
+    "GSFC",
+    "GVT&D",
+    "HAL",
+    "HAPPSTMNDS",
+    "HAVELLS",
+    "HBLENGINE",
+    "HCC",
+    "HCG",
+    "HCLTECH",
+    "HDBFS",
+    "HDFCAMC",
+    "HDFCBANK",
+    "HDFCLIFE",
+    "HEG",
+    "HEMIPROP",
+    "HERITGFOOD",
+    "HEROMOTOCO",
+    "HEXT",
+    "HFCL",
+    "HGINFRA",
+    "HINDALCO",
+    "HINDCOPPER",
+    "HINDPETRO",
+    "HINDUNILVR",
+    "HINDZINC",
+    "HOMEFIRST",
+    "HONASA",
+    "HONAUT",
+    "HSCL",
+    "HUDCO",
+    "HYUNDAI",
+    "ICICIAMC",
+    "ICICIBANK",
+    "ICICIGI",
+    "ICICIPRULI",
+    "ICIL",
+    "IDBI",
+    "IDEA",
+    "IDFCFIRSTB",
+    "IEX",
+    "IFBIND",
+    "IFCI",
+    "IGIL",
+    "IGL",
+    "IIFL",
+    "IIFLCAPS",
+    "IKS",
+    "IMFA",
+    "INDGN",
+    "INDHOTEL",
+    "INDIACEM",
+    "INDIAGLYCO",
+    "INDIAMART",
+    "INDIANB",
+    "INDIASHLTR",
+    "INDIGO",
+    "INDIGOPNTS",
+    "INDUSINDBK",
+    "INDUSTOWER",
+    "INFY",
+    "INOXGREEN",
+    "INOXINDIA",
+    "INOXWIND",
+    "INTELLECT",
+    "IOB",
+    "IOC",
+    "IONEXCHANG",
+    "IPCALAB",
+    "IRB",
+    "IRCON",
+    "IRCTC",
+    "IREDA",
+    "IRFC",
+    "ITC",
+    "ITCHOTELS",
+    "ITI",
+    "IXIGO",
+    "J&KBANK",
+    "JAIBALAJI",
+    "JAINREC",
+    "JAMNAAUTO",
+    "JAYNECOIND",
+    "JBMA",
+    "JINDALSAW",
+    "JINDALSTEL",
+    "JIOFIN",
+    "JKCEMENT",
+    "JKLAKSHMI",
+    "JKPAPER",
+    "JKTYRE",
+    "JLHL",
+    "JMFINANCIL",
+    "JPPOWER",
+    "JSFB",
+    "JSL",
+    "JSLL",
+    "JSWCEMENT",
+    "JSWDULUX",
+    "JSWENERGY",
+    "JSWINFRA",
+    "JSWSTEEL",
+    "JUBLFOOD",
+    "JUBLINGREA",
+    "JUBLPHARMA",
+    "JUSTDIAL",
+    "JWL",
+    "JYOTHYLAB",
+    "JYOTICNC",
+    "KAJARIACER",
+    "KALYANKJIL",
+    "KANSAINER",
+    "KARURVYSYA",
+    "KAYNES",
+    "KEC",
+    "KEI",
+    "KFINTECH",
+    "KIMS",
+    "KIRLOSBROS",
+    "KIRLOSENG",
+    "KIRLPNU",
+    "KITEX",
+    "KNRCON",
+    "KOTAKBANK",
+    "KPIGREEN",
+    "KPIL",
+    "KPITTECH",
+    "KPRMILL",
+    "KRBL",
+    "KRN",
+    "KSB",
+    "KSCL",
+    "KTKBANK",
+    "LALPATHLAB",
+    "LATENTVIEW",
+    "LAURUSLABS",
+    "LEMONTREE",
+    "LENSKART",
+    "LGEINDIA",
+    "LICHSGFIN",
+    "LICI",
+    "LINDEINDIA",
+    "LLOYDSENGG",
+    "LLOYDSENT",
+    "LLOYDSME",
+    "LODHA",
+    "LOTUSDEV",
+    "LT",
+    "LTF",
+    "LTFOODS",
+    "LTM",
+    "LTTS",
+    "LUMAXTECH",
+    "LUPIN",
+    "LXCHEM",
+    "M&M",
+    "M&MFIN",
+    "MAHABANK",
+    "MAHSCOOTER",
+    "MAHSEAMLES",
+    "MANAPPURAM",
+    "MANKIND",
+    "MANORAMA",
+    "MANYAVAR",
+    "MAPMYINDIA",
+    "MARICO",
+    "MARKSANS",
+    "MARUTI",
+    "MASTEK",
+    "MAXHEALTH",
+    "MAZDOCK",
+    "MCX",
+    "MEDANTA",
+    "MEDPLUS",
+    "MEESHO",
+    "METROPOLIS",
+    "MFSL",
+    "MGL",
+    "MIDHANI",
+    "MINDACORP",
+    "MMTC",
+    "MOIL",
+    "MOTHERSON",
+    "MOTILALOFS",
+    "MPHASIS",
+    "MRF",
+    "MRPL",
+    "MSTCLTD",
+    "MSUMI",
+    "MTARTECH",
+    "MUTHOOTFIN",
+    "NAM-INDIA",
+    "NATCOPHARM",
+    "NATIONALUM",
+    "NAUKRI",
+    "NAVA",
+    "NAVINFLUOR",
+    "NAZARA",
+    "NBCC",
+    "NCC",
+    "NEOGEN",
+    "NESCO",
+    "NESTLEIND",
+    "NETWEB",
+    "NETWORK18",
+    "NEULANDLAB",
+    "NEWGEN",
+    "NFL",
+    "NH",
+    "NHPC",
+    "NIACL",
+    "NIVABUPA",
+    "NLCINDIA",
+    "NMDC",
+    "NSLNISP",
+    "NTPC",
+    "NTPCGREEN",
+    "NUVAMA",
+    "NUVOCO",
+    "NYKAA",
+    "OBEROIRLTY",
+    "OFSS",
+    "OIL",
+    "OLAELEC",
+    "OLECTRA",
+    "ONESOURCE",
+    "ONGC",
+    "OPTIEMUS",
+    "ORIENTCEM",
+    "ORKLAINDIA",
+    "OSWALPUMPS",
+    "PAGEIND",
+    "PARADEEP",
+    "PARAS",
+    "PARKHOSPS",
+    "PATANJALI",
+    "PAYTM",
+    "PCBL",
+    "PCJEWELLER",
+    "PERSISTENT",
+    "PETRONET",
+    "PFC",
+    "PFIZER",
+    "PFOCUS",
+    "PGEL",
+    "PGIL",
+    "PHOENIXLTD",
+    "PICCADIL",
+    "PIDILITIND",
+    "PIIND",
+    "PINELABS",
+    "PIRAMALFIN",
+    "PNB",
+    "PNBHOUSING",
+    "PNCINFRA",
+    "PNGJL",
+    "POLICYBZR",
+    "POLYCAB",
+    "POLYMED",
+    "POONAWALLA",
+    "POWERGRID",
+    "POWERINDIA",
+    "POWERMECH",
+    "PPLPHARMA",
+    "PRAJIND",
+    "PREMIERENE",
+    "PRESTIGE",
+    "PRICOLLTD",
+    "PRIVISCL",
+    "PRSMJOHNSN",
+    "PRUDENT",
+    "PTC",
+    "PTCIL",
+    "PURVA",
+    "PVRINOX",
+    "PWL",
+    "QPOWER",
+    "QUESS",
+    "RADICO",
+    "RAILTEL",
+    "RAIN",
+    "RAINBOW",
+    "RALLIS",
+    "RAMCOCEM",
+    "RATEGAIN",
+    "RATNAMANI",
+    "RAYMONDLSL",
+    "RBA",
+    "RBLBANK",
+    "RCF",
+    "RECLTD",
+    "REDINGTON",
+    "REDTAPE",
+    "REFEX",
+    "RELAXO",
+    "RELIANCE",
+    "RELIGARE",
+    "RENUKA",
+    "RHIM",
+    "RITES",
+    "RKFORGE",
+    "ROUTE",
+    "RPOWER",
+    "RRKABEL",
+    "RTNINDIA",
+    "RTNPOWER",
+    "RUBICON",
+    "RVNL",
+    "SAATVIKGL",
+    "SAFARI",
+    "SAGILITY",
+    "SAIL",
+    "SAILIFE",
+    "SAMHI",
+    "SAMMAANCAP",
+    "SANDUMA",
+    "SANOFICONR",
+    "SANSERA",
+    "SAPPHIRE",
+    "SARDAEN",
+    "SAREGAMA",
+    "SBFC",
+    "SBICARD",
+    "SBILIFE",
+    "SBIN",
+    "SCHAEFFLER",
+    "SCHNEIDER",
+    "SCI",
+    "SENCO",
+    "SFL",
+    "SHAILY",
+    "SHAKTIPUMP",
+    "SHARDACROP",
+    "SHAREINDIA",
+    "SHILPAMED",
+    "SHREECEM",
+    "SHRIPISTON",
+    "SHRIRAMFIN",
+    "SHYAMMETL",
+    "SIEMENS",
+    "SIGNATURE",
+    "SJVN",
+    "SKFINDIA",
+    "SKFINDUS",
+    "SKIPPER",
+    "SKYGOLD",
+    "SMARTWORKS",
+    "SMLMAH",
+    "SOBHA",
+    "SOLARINDS",
+    "SONACOMS",
+    "SONATSOFTW",
+    "SOUTHBANK",
+    "SPARC",
+    "SPLPETRO",
+    "SRF",
+    "STAR",
+    "STARCEMENT",
+    "STARHEALTH",
+    "STLTECH",
+    "STYL",
+    "STYRENIX",
+    "SUBROS",
+    "SUDARSCHEM",
+    "SUDEEPPHRM",
+    "SUMICHEM",
+    "SUNDARMFIN",
+    "SUNPHARMA",
+    "SUNTECK",
+    "SUNTV",
+    "SUPREMEIND",
+    "SUPRIYA",
+    "SURYAROSNI",
+    "SUZLON",
+    "SWANCORP",
+    "SWIGGY",
+    "SWSOLAR",
+    "SYNGENE",
+    "SYRMA",
+    "TANLA",
+    "TARC",
+    "TARIL",
+    "TATACAP",
+    "TATACHEM",
+    "TATACOMM",
+    "TATACONSUM",
+    "TATAELXSI",
+    "TATAINVEST",
+    "TATAPOWER",
+    "TATASTEEL",
+    "TATATECH",
+    "TBOTEK",
+    "TCS",
+    "TDPOWERSYS",
+    "TECHM",
+    "TECHNOE",
+    "TEGA",
+    "TEJASNET",
+    "TENNIND",
+    "TEXRAIL",
+    "THANGAMAYL",
+    "THELEELA",
+    "THERMAX",
+    "THOMASCOOK",
+    "THYROCARE",
+    "TI",
+    "TIINDIA",
+    "TIMETECHNO",
+    "TIMKEN",
+    "TIPSMUSIC",
+    "TITAGARH",
+    "TITAN",
+    "TMB",
+    "TMCV",
+    "TMPV",
+    "TORNTPHARM",
+    "TORNTPOWER",
+    "TRANSRAILL",
+    "TRAVELFOOD",
+    "TRENT",
+    "TRIDENT",
+    "TRITURBINE",
+    "TRIVENI",
+    "TSFINV",
+    "TTML",
+    "TVSMOTOR",
+    "TVSSCS",
+    "UBL",
+    "UCOBANK",
+    "UJJIVANSFB",
+    "ULTRACEMCO",
+    "UNIONBANK",
+    "UNITDSPR",
+    "UNOMINDA",
+    "UPL",
+    "URBANCO",
+    "USHAMART",
+    "UTIAMC",
+    "UTLSOLAR",
+    "V2RETAIL",
+    "VAIBHAVGBL",
+    "VARROC",
+    "VBL",
+    "VEDL",
+    "VGUARD",
+    "VIJAYA",
+    "VIKRAMSOLR",
+    "VIPIND",
+    "VIYASH",
+    "VMART",
+    "VMM",
+    "VOLTAMP",
+    "VOLTAS",
+    "VTL",
+    "WAAREEENER",
+    "WAAREERTL",
+    "WABAG",
+    "WAKEFIT",
+    "WEBELSOLAR",
+    "WELCORP",
+    "WELENT",
+    "WELSPUNLIV",
+    "WESTLIFE",
+    "WEWORK",
+    "WHIRLPOOL",
+    "WIPRO",
+    "WOCKPHARMA",
+    "YATHARTH",
+    "YESBANK",
+    "ZAGGLE",
+    "ZEEL",
+    "ZENSARTECH",
+    "ZENTEC",
+    "ZFCVINDIA",
+    "ZYDUSLIFE",
+    "ZYDUSWELL",
+];
+
+/// Underlyings with listed futures or options on NSE.
+///
+/// DERIVED from both vendor masters and cross-checked: the two brokers agree
+/// exactly — 213 each, zero on either side only. Exchange test instruments
+/// (`*NSETEST`) are excluded. Recorded in `docs/00-charter.md` §4a.
+///
+/// Re-measured 2026-08-01 under the D-0025 gate: 208 of the 213 resolve as a
+/// kept equity in **both** vendors. The other five are indices, which carry no
+/// ISIN and therefore no cross-vendor check at all — `NIFTY`, `BANKNIFTY` and
+/// `FINNIFTY` are named identically by both masters, while `MIDCPNIFTY` and
+/// `NIFTYNXT50` are Dhan's spellings for the indices Groww calls
+/// `NIFTYMIDSELECT` and `NIFTYJR`. **211 of 213 are therefore confirmed by two
+/// vendors and 2 rest on one**, which `docs/06-limits.md` §12 records and
+/// `api::server::report` states on every run rather than leaving implied.
+pub const FNO_UNDERLYINGS: [&str; 213] = [
+    "360ONE",
+    "ABB",
+    "ABCAPITAL",
+    "ADANIENSOL",
+    "ADANIENT",
+    "ADANIGREEN",
+    "ADANIPORTS",
+    "ADANIPOWER",
+    "ALKEM",
+    "AMBER",
+    "AMBUJACEM",
+    "ANGELONE",
+    "APLAPOLLO",
+    "APOLLOHOSP",
+    "ASHOKLEY",
+    "ASIANPAINT",
+    "ASTRAL",
+    "AUBANK",
+    "AUROPHARMA",
+    "AXISBANK",
+    "BAJAJ-AUTO",
+    "BAJAJFINSV",
+    "BAJAJHLDNG",
+    "BAJFINANCE",
+    "BANDHANBNK",
+    "BANKBARODA",
+    "BANKINDIA",
+    "BANKNIFTY",
+    "BDL",
+    "BEL",
+    "BHARATFORG",
+    "BHARTIARTL",
+    "BHEL",
+    "BIOCON",
+    "BLUESTARCO",
+    "BOSCHLTD",
+    "BPCL",
+    "BRITANNIA",
+    "BSE",
+    "CAMS",
+    "CANBK",
+    "CDSL",
+    "CGPOWER",
+    "CHOLAFIN",
+    "CIPLA",
+    "COALINDIA",
+    "COCHINSHIP",
+    "COFORGE",
+    "COLPAL",
+    "CONCOR",
+    "CROMPTON",
+    "CUMMINSIND",
+    "DABUR",
+    "DALBHARAT",
+    "DELHIVERY",
+    "DIVISLAB",
+    "DIXON",
+    "DLF",
+    "DMART",
+    "DRREDDY",
+    "EICHERMOT",
+    "ETERNAL",
+    "FEDERALBNK",
+    "FINNIFTY",
+    "FORCEMOT",
+    "FORTIS",
+    "GAIL",
+    "GLENMARK",
+    "GMRAIRPORT",
+    "GODFRYPHLP",
+    "GODREJCP",
+    "GODREJPROP",
+    "GRASIM",
+    "GVT&D",
+    "HAL",
+    "HAVELLS",
+    "HCLTECH",
+    "HDFCAMC",
+    "HDFCBANK",
+    "HDFCLIFE",
+    "HEROMOTOCO",
+    "HINDALCO",
+    "HINDPETRO",
+    "HINDUNILVR",
+    "HINDZINC",
+    "HYUNDAI",
+    "ICICIBANK",
+    "ICICIGI",
+    "ICICIPRULI",
+    "IDEA",
+    "IDFCFIRSTB",
+    "IEX",
+    "INDHOTEL",
+    "INDIANB",
+    "INDIGO",
+    "INDUSINDBK",
+    "INDUSTOWER",
+    "INFY",
+    "INOXWIND",
+    "IOC",
+    "IREDA",
+    "IRFC",
+    "ITC",
+    "JINDALSTEL",
+    "JIOFIN",
+    "JSWENERGY",
+    "JSWSTEEL",
+    "JUBLFOOD",
+    "KALYANKJIL",
+    "KAYNES",
+    "KEI",
+    "KFINTECH",
+    "KOTAKBANK",
+    "KPITTECH",
+    "LAURUSLABS",
+    "LICHSGFIN",
+    "LICI",
+    "LODHA",
+    "LT",
+    "LTF",
+    "LTM",
+    "LUPIN",
+    "M&M",
+    "MANAPPURAM",
+    "MANKIND",
+    "MARICO",
+    "MARUTI",
+    "MAXHEALTH",
+    "MAZDOCK",
+    "MCX",
+    "MFSL",
+    "MIDCPNIFTY",
+    "MOTHERSON",
+    "MOTILALOFS",
+    "MPHASIS",
+    "MUTHOOTFIN",
+    "NAM-INDIA",
+    "NATIONALUM",
+    "NAUKRI",
+    "NBCC",
+    "NESTLEIND",
+    "NHPC",
+    "NIFTY",
+    "NIFTYNXT50",
+    "NMDC",
+    "NTPC",
+    "NYKAA",
+    "OBEROIRLTY",
+    "OFSS",
+    "OIL",
+    "ONGC",
+    "PAGEIND",
+    "PATANJALI",
+    "PAYTM",
+    "PERSISTENT",
+    "PETRONET",
+    "PFC",
+    "PGEL",
+    "PHOENIXLTD",
+    "PIDILITIND",
+    "PIIND",
+    "PNB",
+    "PNBHOUSING",
+    "POLICYBZR",
+    "POLYCAB",
+    "POWERGRID",
+    "POWERINDIA",
+    "PREMIERENE",
+    "PRESTIGE",
+    "RADICO",
+    "RBLBANK",
+    "RECLTD",
+    "RELIANCE",
+    "RVNL",
+    "SAIL",
+    "SBICARD",
+    "SBILIFE",
+    "SBIN",
+    "SHREECEM",
+    "SHRIRAMFIN",
+    "SIEMENS",
+    "SOLARINDS",
+    "SONACOMS",
+    "SRF",
+    "SUNPHARMA",
+    "SUPREMEIND",
+    "SUZLON",
+    "SWIGGY",
+    "TATACONSUM",
+    "TATAELXSI",
+    "TATAPOWER",
+    "TATASTEEL",
+    "TCS",
+    "TECHM",
+    "TIINDIA",
+    "TITAN",
+    "TMPV",
+    "TORNTPHARM",
+    "TRENT",
+    "TVSMOTOR",
+    "ULTRACEMCO",
+    "UNIONBANK",
+    "UNITDSPR",
+    "UNOMINDA",
+    "UPL",
+    "VBL",
+    "VEDL",
+    "VMM",
+    "VOLTAS",
+    "WAAREEENER",
+    "WIPRO",
+    "YESBANK",
+    "ZYDUSLIFE",
+];
+
+/// Which universes an instrument belongs to.
+///
+/// A bitset rather than an enum: an instrument belongs to **many** universes
+/// at once — a stock can be an F&O underlying *and* a Total Market
+/// constituent. Bits are append-only, exactly like the condition table: a new
+/// universe takes the next free bit and invalidates nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Universe(u32);
+
+impl Universe {
+    /// Belongs to no universe. Stored, never listed.
+    pub const NONE: Self = Self(0);
+    /// A spot index.
+    pub const INDEX: Self = Self(1 << 0);
+    /// Has listed futures or options.
+    pub const FNO: Self = Self(1 << 1);
+    /// A NIFTY Total Market constituent.
+    pub const TOTAL_MARKET: Self = Self(1 << 2);
+
+    /// Whether this set contains every bit of `other`.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Whether this set is empty.
+    #[must_use]
+    pub const fn is_none(self) -> bool {
+        self.0 == 0
+    }
+
+    /// The union of two sets.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// The raw bits.
+    #[must_use]
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+}
+
+/// The universes a cash-segment symbol belongs to.
+///
+/// Binary search over sorted arrays: at most ten comparisons on 750 entries.
+#[must_use]
+pub fn of_equity(symbol: &str) -> Universe {
+    let mut u = Universe::NONE;
+    if FNO_UNDERLYINGS.binary_search(&symbol).is_ok() {
+        u = u.union(Universe::FNO);
+    }
+    if NIFTY_TOTAL_MARKET.binary_search(&symbol).is_ok() {
+        u = u.union(Universe::TOTAL_MARKET);
+    }
+    u
+}
+
+/// The universes a merged instrument belongs to.
+///
+/// The entry point every caller outside this module uses, so that "which list
+/// is this in" is answered in one place from the whole key rather than from a
+/// bare string a caller had to remember to derive correctly. An index is
+/// [`Universe::INDEX`] and is never looked up in the equity lists — a spot
+/// index is not a constituent of itself, and `NIFTY` appears in
+/// [`FNO_UNDERLYINGS`] as the *underlying of its options*, which is a different
+/// fact from being a share.
+#[must_use]
+pub fn of_instrument(key: &InstrumentKey) -> Universe {
+    match key.kind {
+        Kind::Index => Universe::INDEX.union(of_equity(key.underlying.as_str())),
+        Kind::Equity => of_equity(key.underlying.as_str()),
+        // A live derivative is never stored, so it never reaches a universe.
+        // Saying `NONE` is accurate; inventing membership for it would not be.
+        Kind::Future { .. } | Kind::Option { .. } => Universe::NONE,
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::indexing_slicing,
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn both_lists_are_sorted_and_unique_so_binary_search_is_valid() {
+        // binary_search on an unsorted array returns garbage silently.
+        for (name, list) in [
+            ("NIFTY_TOTAL_MARKET", NIFTY_TOTAL_MARKET.as_slice()),
+            ("FNO_UNDERLYINGS", FNO_UNDERLYINGS.as_slice()),
+        ] {
+            for w in list.windows(2) {
+                assert!(w[0] < w[1], "{name} is not sorted or not unique at {w:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn the_counts_are_the_measured_ones() {
+        assert_eq!(NIFTY_TOTAL_MARKET.len(), 750, "niftyindices.com states 750");
+        assert_eq!(FNO_UNDERLYINGS.len(), 213, "both masters name 213, exactly");
+        assert!(
+            FNO_UNDERLYINGS.iter().all(|s| !s.contains("NSETEST")),
+            "exchange test instruments must never be a universe member"
+        );
+        assert!(
+            NIFTY_TOTAL_MARKET.iter().all(|s| !s.contains("NSETEST")),
+            "exchange test instruments must never be a universe member"
+        );
+    }
+
+    #[test]
+    fn no_measured_sme_ticker_belongs_to_either_universe() {
+        // THE CLAIM `Skip::SmeBoard` DECLINES 1,117 REAL SHARES ON. It was a
+        // sentence in a comment about a module nothing consulted; here it is a
+        // check. Every ticker below is verbatim from an `SM` or `ST` row of a
+        // real master -- they are the 22 rows whose series the two vendors
+        // disagree about, so they are also the SME rows most likely to be
+        // mis-boarded, plus two ordinary ones.
+        for sme in [
+            "DRONE",
+            "SATKARTAR",
+            "SOCL",
+            "WHITEFORCE",
+            "VLINFRA",
+            "SUNLITE",
+            "ARVINDPORT",
+            "YAAP",
+            "MOXSH",
+            "INVICTA",
+            "ARCIIL",
+            "RITEZONE",
+            "AILIMITED",
+            "ACCORD",
+        ] {
+            assert!(
+                of_equity(sme).is_none(),
+                "{sme} is an SME listing and is in neither universe"
+            );
+        }
+    }
+
+    #[test]
+    fn an_index_is_its_own_universe_and_a_live_derivative_is_in_none() {
+        use crate::instrument::{Exchange, Expiry, OptionSide, Segment};
+        use crate::price::Paisa;
+        use crate::symbol::Symbol;
+
+        let nifty = InstrumentKey::index(Exchange::Nse, "NIFTY").expect("valid");
+        let u = of_instrument(&nifty);
+        assert!(u.contains(Universe::INDEX));
+        assert!(
+            u.contains(Universe::FNO),
+            "NIFTY is also the underlying of its own options"
+        );
+        assert!(
+            !u.contains(Universe::TOTAL_MARKET),
+            "an index is not a share"
+        );
+
+        let sensex = InstrumentKey::index(Exchange::Nse, "NOTANINDEXWEKNOW").expect("valid");
+        assert_eq!(of_instrument(&sensex), Universe::INDEX);
+
+        let share = InstrumentKey {
+            exchange: Exchange::Nse,
+            segment: Segment::Cash,
+            underlying: Symbol::new("RELIANCE").expect("valid"),
+            kind: Kind::Equity,
+        };
+        let r = of_instrument(&share);
+        assert!(r.contains(Universe::FNO) && r.contains(Universe::TOTAL_MARKET));
+        assert!(!r.contains(Universe::INDEX));
+
+        // A derivative is never stored, so it is never a member of anything --
+        // not even of the universe its own underlying belongs to.
+        let fut = InstrumentKey {
+            segment: Segment::Fno,
+            kind: Kind::Future {
+                expiry: Expiry::new(2026, 8, 27).expect("valid"),
+            },
+            ..share
+        };
+        assert_eq!(of_instrument(&fut), Universe::NONE);
+        let opt = InstrumentKey {
+            kind: Kind::Option {
+                expiry: Expiry::new(2026, 8, 27).expect("valid"),
+                strike: Paisa::from_raw(1_945_000),
+                side: OptionSide::Call,
+            },
+            ..fut
+        };
+        assert_eq!(of_instrument(&opt), Universe::NONE);
+    }
+
+    #[test]
+    fn membership_is_a_set_not_a_category() {
+        // RELIANCE is both. The whole point of a bitset.
+        let r = of_equity("RELIANCE");
+        assert!(r.contains(Universe::FNO));
+        assert!(r.contains(Universe::TOTAL_MARKET));
+        assert!(!r.is_none());
+    }
+
+    #[test]
+    fn a_symbol_in_neither_belongs_to_nothing() {
+        let n = of_equity("NOT_A_REAL_SYMBOL");
+        assert!(n.is_none());
+        assert_eq!(n, Universe::NONE);
+        assert_eq!(n.bits(), 0);
+    }
+
+    #[test]
+    fn contains_is_a_superset_test_not_equality() {
+        let both = Universe::FNO.union(Universe::TOTAL_MARKET);
+        assert!(both.contains(Universe::FNO));
+        assert!(both.contains(Universe::TOTAL_MARKET));
+        assert!(both.contains(both));
+        assert!(
+            !Universe::FNO.contains(both),
+            "one bit does not contain two"
+        );
+        assert!(Universe::NONE.contains(Universe::NONE));
+        assert!(!Universe::NONE.contains(Universe::INDEX));
+    }
+
+    #[test]
+    fn bits_are_distinct_powers_of_two() {
+        // An append-only bitset is only safe if no two universes share a bit.
+        let all = [Universe::INDEX, Universe::FNO, Universe::TOTAL_MARKET];
+        for (i, a) in all.iter().enumerate() {
+            assert_eq!(a.bits().count_ones(), 1, "universe {i} is not a single bit");
+            for (j, b) in all.iter().enumerate() {
+                if i != j {
+                    assert_eq!(a.bits() & b.bits(), 0, "universes {i} and {j} share a bit");
+                }
+            }
+        }
+    }
+}

--- a/crates/core/src/vendor.rs
+++ b/crates/core/src/vendor.rs
@@ -30,7 +30,8 @@
 //! [`Paisa::from_rupees_half_up`] like every other price.
 
 use crate::error::InstrumentError;
-use crate::instrument::{Exchange, Expiry, InstrumentKey, Kind, OptionSide, Segment};
+use crate::instrument::{Exchange, Expiry, InstrumentKey, Kind, Segment};
+use crate::isin::Isin;
 use crate::price::Paisa;
 use crate::symbol::Symbol;
 
@@ -49,6 +50,9 @@ pub enum Vendor {
 }
 
 impl Vendor {
+    /// Every vendor this engine reads, in path order.
+    pub const ALL: [Self; 2] = [Self::Groww, Self::Dhan];
+
     /// The path segment for this vendor.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
@@ -56,6 +60,52 @@ impl Vendor {
             Self::Groww => "groww",
             Self::Dhan => "dhan",
         }
+    }
+
+    /// This vendor's bit in a [`VendorSet`].
+    const fn bit(self) -> u8 {
+        match self {
+            Self::Groww => 1 << 0,
+            Self::Dhan => 1 << 1,
+        }
+    }
+}
+
+/// A set of vendors, as a bitset.
+///
+/// A merged instrument is listed by one vendor or by several, and the set of
+/// vendors that named it is a *property of the merge*, never of the identity —
+/// exactly like [`crate::universe::Universe`], and for exactly the same reason:
+/// a field on [`InstrumentKey`] would split one instrument into two keys.
+///
+/// It exists rather than a pair of booleans because a `bool` per vendor forces
+/// every caller to `match` on [`Vendor`], which is `#[non_exhaustive]`. Outside
+/// this crate that match needs a wildcard arm that no test can ever reach, so
+/// the coverage gate can never go green on it. The bitset moves the one match
+/// here, where it is exhaustive and provable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct VendorSet(u8);
+
+impl VendorSet {
+    /// No vendor has named this instrument.
+    pub const EMPTY: Self = Self(0);
+
+    /// This set with `vendor` added. Adding twice is the same as adding once.
+    #[must_use]
+    pub const fn with(self, vendor: Vendor) -> Self {
+        Self(self.0 | vendor.bit())
+    }
+
+    /// Whether `vendor` is in this set.
+    #[must_use]
+    pub const fn contains(self, vendor: Vendor) -> bool {
+        self.0 & vendor.bit() != 0
+    }
+
+    /// Whether no vendor is in this set.
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
     }
 }
 
@@ -79,6 +129,26 @@ pub struct MasterRow<'a> {
     pub trading_symbol: &'a str,
     /// Instrument type: `IDX`, `EQ`, `FUT`, `CE`, `PE`.
     pub instrument_type: &'a str,
+    /// The **NSE board series** this cash-segment row trades under: `EQ`,
+    /// `BE`, `BZ`, `SM`, `N0`, `SG`, …
+    ///
+    /// This is one fact issued by one exchange, and both vendors carry it —
+    /// Groww in `series`, Dhan in `SERIES`. It is named for what it *means*
+    /// here rather than for either vendor's column heading, and it is read
+    /// through [`Vendor::master_columns`]. Empty on index and derivative rows,
+    /// which is why `board_of` is consulted only for cash equity.
+    ///
+    /// D-0025 replaced Dhan's `INSTRUMENT_TYPE` with `SERIES` here. That
+    /// column is a vendor-minted paper class, and it is **measurably wrong**:
+    /// it files 54 Franklin/PGIM/Bandhan mutual-fund plans as `ETF` and three
+    /// real listings (`IVZINNIFTY`, `INFRABEES`, `NARMADA`) as `Other`/`MF`.
+    /// The series column disagrees with it on exactly those 57 rows and is
+    /// right on all 57.
+    pub listing_class: &'a str,
+    /// The vendor's ISIN column. Empty, or junk, on anything that is not a
+    /// cash listing: measured, Groww writes the index ticker here on its
+    /// index rows (`NIFTY`) and Dhan writes `NA`. Read only for equity.
+    pub isin: &'a str,
     /// Expiry as `YYYY-MM-DD`, empty for cash and index rows.
     pub expiry: &'a str,
     /// Strike in **rupees**, empty for anything that is not an option.
@@ -86,6 +156,76 @@ pub struct MasterRow<'a> {
     /// The vendor's separate option-side column (`CE`/`PE`), empty when the
     /// vendor encodes the side in `instrument_type` instead.
     pub option_side: &'a str,
+}
+
+/// Which of a vendor's master columns fill a [`MasterRow`], by header name.
+///
+/// This lives beside the rest of the per-vendor knowledge rather than in the
+/// reader, for two reasons. A reader in another crate cannot match on
+/// [`Vendor`] without a wildcard arm — the enum is `#[non_exhaustive]` — and
+/// that arm is unreachable, untestable, and permanently uncovered. And a
+/// second reader would otherwise have to guess the same names again; the
+/// column map is vendor knowledge, and vendor knowledge belongs here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MasterColumns {
+    /// Header of the exchange column.
+    pub exchange: &'static str,
+    /// Header of the segment column.
+    pub segment: &'static str,
+    /// Header of the underlying-symbol column.
+    pub underlying: &'static str,
+    /// Header of the vendor's own tradable-symbol column.
+    pub trading_symbol: &'static str,
+    /// Header of the instrument-type column.
+    pub instrument_type: &'static str,
+    /// Header of the column carrying the NSE board series of a cash row.
+    pub listing_class: &'static str,
+    /// Header of the ISIN column.
+    pub isin: &'static str,
+    /// Header of the expiry column.
+    pub expiry: &'static str,
+    /// Header of the strike column.
+    pub strike: &'static str,
+    /// Header of the separate option-side column, when the vendor has one.
+    pub option_side: Option<&'static str>,
+}
+
+impl Vendor {
+    /// The header names this vendor's master uses for each field of a
+    /// [`MasterRow`].
+    #[must_use]
+    pub const fn master_columns(self) -> MasterColumns {
+        match self {
+            Self::Groww => MasterColumns {
+                exchange: "exchange",
+                segment: "segment",
+                underlying: "underlying_symbol",
+                trading_symbol: "trading_symbol",
+                instrument_type: "instrument_type",
+                listing_class: "series",
+                isin: "isin",
+                expiry: "expiry_date",
+                strike: "strike_price",
+                option_side: None,
+            },
+            Self::Dhan => MasterColumns {
+                exchange: "EXCH_ID",
+                segment: "SEGMENT",
+                underlying: "UNDERLYING_SYMBOL",
+                trading_symbol: "SYMBOL_NAME",
+                // The real type is INSTRUMENT. `INSTRUMENT_TYPE` is a
+                // different column holding a vendor-minted paper class (ES,
+                // DEB, ETF); it is deliberately NOT read — see the
+                // `listing_class` doc and D-0025.
+                instrument_type: "INSTRUMENT",
+                listing_class: "SERIES",
+                isin: "ISIN",
+                expiry: "SM_EXPIRY_DATE",
+                strike: "STRIKE_PRICE",
+                option_side: Some("OPTION_TYPE"),
+            },
+        }
+    }
 }
 
 /// A row was skipped, and why.
@@ -102,15 +242,219 @@ pub enum Skip {
     TestInstrument,
     /// A segment this engine does not store, such as commodity.
     ForeignSegment,
+    /// A **currently listed** future or option.
+    ///
+    /// A live contract's bars are today's. Backtesting runs on history, and
+    /// history is EXPIRED contracts — which come from the vendors' historical
+    /// endpoints and from the existing lake, never from the live instrument
+    /// master. Storing the live chain would add ~148,000 contracts holding a
+    /// few weeks of data each, none of which is ever swept.
+    LiveContract,
+    /// A row that trades on the equity segment but is **not a share**.
+    ///
+    /// A debenture, a government or corporate bond, a treasury bill, a mutual
+    /// fund unit, a REIT or an infrastructure trust unit, a warrant. Every one
+    /// of them is a real listing; none of them is an equity, and none belongs
+    /// in an equity universe.
+    ///
+    /// Raised only for a series code in [`NON_EQUITY_SERIES`] — a code this
+    /// engine has **measured and recognises**. A code it does not recognise
+    /// gets [`Skip::UnrecognisedListingClass`] instead, because "I know this
+    /// is a bond" and "I have never seen this code" are different facts and
+    /// filing them under one reason is how a rename becomes invisible.
+    ///
+    /// # Why this is a gate and not a nicety
+    ///
+    /// `INSTRUMENT = EQUITY` does not mean "a share". It means "trades on the
+    /// equity segment". Measured across both masters: of the 12,617 rows that
+    /// reach this gate, **7,137 are not equity at all** — 4,336 `SG` state
+    /// development loans, 1,106 `N0` debentures, 174 `MF` fund units, 164 `GS`
+    /// government securities, 85 `TB` treasury bills, and 116 further debt
+    /// codes.
+    ///
+    /// Without the gate those rows do not merely inflate a count — they
+    /// **capture the ticker**. Dhan line 167146 is
+    /// `NSE,E,19257,INE121A08PJ0,EQUITY,,CHOLAFIN,…,DEB,D1,…,5.0` — a 7.5% NCD
+    /// on series `D1` — and it appears **before** line 171414,
+    /// `NSE,E,685,INE121A01024,EQUITY,,CHOLAFIN,…,ES,EQ,…,10.0`, the share on
+    /// series `EQ`. An insert-if-absent merge therefore resolved `CHOLAFIN` to
+    /// the bond and took its tick size, silently and order-dependently.
+    /// `MOTHERSON` (`INE775A08105`, an NCD, series `D1`) and `ELECTCAST`
+    /// (`INE086A13016`, a warrant, series `W1`) went the same way. All three
+    /// are NIFTY Total Market members and two are F&O underlyings. After the
+    /// gate, duplicate tickers in Dhan's equity segment fall from **4 to 0**.
+    NotEquityListing,
+    /// A listing on the SME board rather than the main board.
+    ///
+    /// A separate reason from [`Skip::NotEquityListing`] on purpose: an SME
+    /// listing IS a share, so lumping it in with debentures would hide a real
+    /// choice behind a wrong label. It is declined because the engine's equity
+    /// universe is F&O underlyings plus NIFTY Total Market
+    /// ([`crate::universe`]), and neither contains an SME listing — measured,
+    /// and proven by
+    /// `crate::universe::no_measured_sme_ticker_belongs_to_either_universe`.
+    /// An SME row can only ever be stored, never swept and never ranked.
+    ///
+    /// Counted separately so the decision stays visible and reversible: the
+    /// day the universe widens, this reason names exactly what to re-admit.
+    /// Both vendors carry the board in the NSE series (`SM`, `ST`), so unlike
+    /// before D-0025 this reason is raised **symmetrically**: 558 rows at
+    /// Groww and 559 at Dhan, and the ISINs are the same paper.
+    SmeBoard,
+    /// A cash-equity row whose NSE series code this engine has never seen.
+    ///
+    /// # Why this is not filed with the bonds
+    ///
+    /// This is the variant that exists because of what happened when it did
+    /// not. Before it, both arms of the gate ended in `_ => NotEquity`, so an
+    /// unrecognised code was reported with the identical wording a routine
+    /// debenture gets. Demonstrated on the real Dhan master by rewriting the
+    /// equity series `EQ` to `EQX`: **2,438 shares vanished**, every F&O
+    /// underlying among them, the report still printed `ok`, and the only
+    /// trace was one counter moving. That is precisely the failure
+    /// `Vendor::segment_of` documents as unrepeatable.
+    ///
+    /// It is a decline rather than an error because the alphabet is genuinely
+    /// open-ended — NSE mints a debt series whenever it needs one and 120
+    /// already exist, so a new bond series must not fail an ingest. But it is
+    /// its **own** decline: its own reason string, its own counter, and the
+    /// offending code itself is carried to the operator by the reader (see
+    /// `api::master::Loaded::unrecognised`). A universe holding one is
+    /// *disputed*, so the process reporting it exits non-zero rather than
+    /// printing a routine skip and `ok`.
+    UnrecognisedListingClass,
+}
+
+impl Skip {
+    /// A short human-readable reason, stable enough to be a report key.
+    ///
+    /// It lives here rather than in a reporter because [`Skip`] is
+    /// `#[non_exhaustive]`: outside this crate every `match` on it needs a
+    /// wildcard arm, which silently swallows a variant added later under
+    /// whatever label the wildcard chose. Inside the crate the match is
+    /// exhaustive, so a new variant is a compile error until it is named.
+    #[must_use]
+    pub const fn reason(self) -> &'static str {
+        match self {
+            Self::ForeignExchange => "foreign exchange",
+            Self::TestInstrument => "exchange test instrument",
+            Self::ForeignSegment => "segment not stored",
+            Self::LiveContract => "live derivative contract",
+            Self::NotEquityListing => "not an equity listing",
+            Self::SmeBoard => "SME board",
+            Self::UnrecognisedListingClass => "unrecognised listing class",
+        }
+    }
+
+    /// Whether this decline is a routine business outcome.
+    ///
+    /// Every reason here is a *deliberate* decline, but they are not equally
+    /// expected. A bond, a foreign exchange and a live contract are what a
+    /// master is full of. An unrecognised series code is the vendor, or the
+    /// exchange, having changed something under us — and the difference has to
+    /// reach an exit code, or the two are the same fact to a monitor.
+    #[must_use]
+    pub const fn is_routine(self) -> bool {
+        !matches!(self, Self::UnrecognisedListingClass)
+    }
+
+    /// Whether this decline judges the **paper** rather than the venue.
+    ///
+    /// Only a judgement about the paper can contradict another vendor keeping
+    /// the same ISIN. A decline for the exchange, the segment or the contract
+    /// being live says where the row was found, and the same security
+    /// legitimately appears at another venue — `RELIANCE` is `INE002A01018` on
+    /// both NSE and BSE, and one vendor declining the BSE row while the other
+    /// keeps the NSE row is two correct decisions about two different rows.
+    /// Treating that as a disagreement produced 3,000 false conflicts on the
+    /// real masters, which is a check nobody would read twice.
+    #[must_use]
+    pub const fn judges_the_paper(self) -> bool {
+        matches!(
+            self,
+            Self::NotEquityListing | Self::SmeBoard | Self::UnrecognisedListingClass
+        )
+    }
+}
+
+/// A row this engine keeps: the canonical key, and the vendor's ISIN **beside
+/// it** rather than in it.
+///
+/// See [`crate::isin`] for why the ISIN is not a field of [`InstrumentKey`].
+/// Every field is fixed-width and [`Copy`], so a listing is as cheap to hash
+/// and move as the key alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Listing {
+    /// The canonical identity, from the columns the vendor actually fills.
+    pub key: InstrumentKey,
+    /// The vendor's ISIN for this row, when it has one. `None` for an index,
+    /// which has no ISIN at all — no sentinel is invented for NIFTY.
+    pub isin: Option<Isin>,
+    /// The same identity with the vendor's own series suffix removed, when
+    /// the symbol carries one — `BLUECHIP-BE` under series `BE` gives
+    /// `BLUECHIP`.
+    ///
+    /// A **candidate**, never a substitution. Groww leaks
+    /// `internal_trading_symbol` into `trading_symbol` on exactly 209 of the
+    /// 4,080 ISINs the two masters share, and the leak reaches tradeable
+    /// equity and ETFs (`BLUECHIP-BE`, `CBAZAAR-ST`, `HDFCLIQUID-EQ`,
+    /// `LOWVOL-EQ`), so "only debt is suffixed" is false. But `BAJAJ-AUTO` is
+    /// a real ticker that ends in a dash, and stripping blind would
+    /// manufacture the very collision [`crate::symbol`] refuses to
+    /// manufacture. So this is computed only when the trailing segment IS the
+    /// row's own series, and the caller adopts it only when a second vendor
+    /// confirms the identity by ISIN.
+    pub unsuffixed: Option<InstrumentKey>,
+}
+
+/// A row this engine declined, and the evidence of what it declined.
+///
+/// # Why the ISIN travels with a decline
+///
+/// A merge that only compares the rows both vendors KEPT cannot see the
+/// disagreement that actually matters: one vendor calling a security an equity
+/// while the other calls it a bond. Before this struct existed, a declined row
+/// was dropped at the reader and the merge reported `0 conflicts` while the
+/// two masters disagreed about the eligibility of 62 instruments — every one
+/// of which carried the **same ISIN in both files**, so the check had the key
+/// it needed and never looked. See `api::merge::Merged::eligibility`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Declined {
+    /// Why the row was declined.
+    pub reason: Skip,
+    /// The row's ISIN, when the vendor gave one that parses.
+    ///
+    /// `None` is not a failure being hidden: the row is declined and counted
+    /// under [`Declined::reason`] either way, and this field is *evidence for
+    /// a cross-check*, never identity. It is deliberately parsed leniently
+    /// here — unlike on a kept equity, where a bad ISIN is an error — because
+    /// the one real row in either master whose check digit fails
+    /// (`IN1520250085`, a state development loan) is a declined row, and
+    /// erroring on it would turn a correct decline into a false failure.
+    pub isin: Option<Isin>,
 }
 
 /// The outcome of reading one master row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Decoded {
     /// A real instrument this engine stores.
-    Keep(InstrumentKey),
-    /// A row deliberately declined, with the reason.
-    Skipped(Skip),
+    Keep(Listing),
+    /// A row deliberately declined, with the reason and the evidence.
+    Skipped(Declined),
+}
+
+impl Decoded {
+    /// The reason this row was declined, or `None` if it was kept.
+    ///
+    /// Exists so a caller that cares only about the reason does not have to
+    /// spell out the evidence beside it.
+    #[must_use]
+    pub const fn skip(self) -> Option<Skip> {
+        match self {
+            Self::Keep(_) => None,
+            Self::Skipped(d) => Some(d.reason),
+        }
+    }
 }
 
 /// Exchange test listings carry these markers in the underlying symbol.
@@ -133,6 +477,124 @@ enum SegmentVerdict {
     Store,
     /// A segment this engine legitimately does not store.
     Decline,
+}
+
+/// What an NSE board series means to us.
+///
+/// Consulted **only** for a row that already decoded as cash equity. An index
+/// row has no series at all — Groww leaves `series` empty on all 24 of its NSE
+/// index rows, Dhan writes `NA` — so gating on it before the instrument type
+/// is known would decline `NIFTY` and `BANKNIFTY`, which is every instrument
+/// the engine exists to sweep.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EquityVerdict {
+    /// A genuine main-board share or ETF.
+    MainBoard,
+    /// A share, but on the SME board.
+    Sme,
+    /// Not a share at all: debt, a fund unit, a warrant.
+    NotEquity,
+    /// A code this engine has never seen. Never merely "not equity".
+    Unrecognised,
+}
+
+/// The NSE series codes that ARE the equity board.
+///
+/// Measured across both real masters, 2026-08-01, over every cash-equity row:
+///
+/// | Series | Rows | What it is |
+/// |---|---:|---|
+/// | `EQ` | 4,845 | the rolling-settlement equity board |
+/// | `BE` | 580 | trade-for-trade equity |
+/// | `BZ` | 63 | trade-for-trade under surveillance |
+/// | `E1` | 5 | partly-paid equity |
+/// | `IT` | 4 | trade-for-trade, illiquid |
+/// | `SZ` | 3 | trade-for-trade, surveillance (second list) |
+///
+/// `BZ`, `IT`, `SZ` and `E1` were declined before D-0025, and the decline was
+/// counted under "not an equity listing", which was false about 30 real
+/// shares — `HDIL`, `HMT`, `RAJESHEXPO`, `IL&FSENGG`, `ANSALAPI`, `FEL`,
+/// `ARSHIYA`, `CEREBRAINT` among them. Three independent confirmations that
+/// they are equity: the ISIN's NSDL security-type digits are `01` (ordinary
+/// equity) on 27 of the 30 and `IN9…` (partly paid) on the other 3, against
+/// `08` for the `CHOLAFIN` NCD and `13` for the `ELECTCAST` warrant this gate
+/// still declines; every one of them is `ES` in Dhan's paper-class column; and
+/// they are ordinary listed companies.
+///
+/// Sorted, because `board_of` binary-searches it and an unsorted array makes
+/// `binary_search` return garbage in silence.
+pub const EQUITY_BOARD_SERIES: [&str; 6] = ["BE", "BZ", "E1", "EQ", "IT", "SZ"];
+
+/// The NSE series codes that are the SME board.
+///
+/// Measured: `SM` 815 rows and `ST` 302 across both masters. A share, on a
+/// board this engine's universes do not reach. See [`Skip::SmeBoard`].
+pub const SME_BOARD_SERIES: [&str; 2] = ["SM", "ST"];
+
+/// Every NSE series this engine has measured that is **not** an equity.
+///
+/// 120 codes, transcribed from the union of both real masters on 2026-08-01 —
+/// every distinct `series` on a Groww `NSE`/`CASH`/`EQ` row and every distinct
+/// `SERIES` on a Dhan `NSE`/`E`/`EQUITY` row, minus the eight board codes
+/// above. Debentures (`N0`…`NZ`, `Y*`, `Z*`, `AK`…`BX`, `D1`, `W1`), state
+/// development loans (`SG`), government securities (`GS`, `GB`), treasury
+/// bills (`TB`), fund units (`MF`, `SF`), REITs (`RR`), infrastructure trusts
+/// (`IV`),
+/// pass-through certificates and preference shares (`P1`).
+///
+/// # Why an explicit list rather than "everything else"
+///
+/// "Everything else" is what made a renamed equity code indistinguishable from
+/// a bond. Enumerating what is known turns the unknown into its own visible
+/// outcome — [`Skip::UnrecognisedListingClass`]. The list is data, so a new
+/// NSE debt series is a one-line append and nothing else moves.
+///
+/// Sorted, for `board_of`'s binary search.
+pub const NON_EQUITY_SERIES: [&str; 120] = [
+    "AK", "AL", "AM", "AN", "AZ", "BA", "BC", "BR", "BS", "BU", "BV", "BW", "BX", "D1", "GB", "GS",
+    "IV", "MF", "N0", "N1", "N2", "N3", "N4", "N5", "N6", "N7", "N8", "N9", "NA", "NB", "NC", "ND",
+    "NE", "NF", "NG", "NH", "NI", "NJ", "NK", "NL", "NM", "NN", "NO", "NP", "NQ", "NR", "NS", "NT",
+    "NU", "NV", "NW", "NX", "NY", "NZ", "P1", "RR", "SF", "SG", "TB", "W1", "Y0", "Y1", "Y2", "Y3",
+    "Y4", "Y5", "Y6", "Y7", "Y8", "Y9", "YA", "YB", "YC", "YD", "YG", "YH", "YI", "YJ", "YK", "YL",
+    "YM", "YP", "YQ", "YR", "YS", "YT", "YU", "YV", "YW", "YX", "YY", "YZ", "Z0", "Z1", "Z2", "Z3",
+    "Z4", "Z5", "Z6", "Z7", "Z8", "Z9", "ZC", "ZF", "ZG", "ZH", "ZI", "ZJ", "ZK", "ZL", "ZM", "ZN",
+    "ZO", "ZP", "ZQ", "ZR", "ZS", "ZT", "ZY", "ZZ",
+];
+
+/// What an NSE board series means, for either vendor.
+///
+/// # Why this is not per-vendor any more
+///
+/// It was, and the doc argued that it had to be: "the two alphabets are
+/// disjoint, and one flat table invites one vendor's code to be silently
+/// accepted for the other". That argument was true of the columns the gate
+/// used to read — Groww's NSE `series` against Dhan's own `INSTRUMENT_TYPE`
+/// paper class — and it stopped being true when D-0025 pointed both vendors at
+/// the series. A series code is minted by the exchange, not by a broker, so it
+/// is **one alphabet**, and duplicating it per vendor would be two copies of
+/// one fact free to drift apart.
+///
+/// It is not an assumption. Measured on the 4,080 ISINs the two masters share:
+/// the two vendors' series columns disagree on 22 rows — all of them
+/// snapshot skew inside one board, `EQ`↔`BE` or `SM`↔`ST`, e.g. `SICALLOG` —
+/// and the verdict this function returns differs on **0**.
+///
+/// An unrecognised code is a decline, not an error, for the reason
+/// [`Skip::UnrecognisedListingClass`] gives — but it is its own decline, and
+/// never confused with a bond.
+fn board_of(series: &str) -> EquityVerdict {
+    // Dhan pads this column, e.g. `"   ES   "`. Trimming Groww's already-tight
+    // values costs nothing and cannot change a verdict.
+    let series = series.trim();
+    if EQUITY_BOARD_SERIES.binary_search(&series).is_ok() {
+        EquityVerdict::MainBoard
+    } else if SME_BOARD_SERIES.binary_search(&series).is_ok() {
+        EquityVerdict::Sme
+    } else if NON_EQUITY_SERIES.binary_search(&series).is_ok() {
+        EquityVerdict::NotEquity
+    } else {
+        EquityVerdict::Unrecognised
+    }
 }
 
 impl Vendor {
@@ -214,10 +676,20 @@ impl Vendor {
 /// *validly* not ours, and quietly dropping a row we failed to understand is
 /// how an instrument silently vanishes from a universe.
 pub fn decode_master_row(vendor: Vendor, row: MasterRow<'_>) -> Result<Decoded, InstrumentError> {
+    // A declined row's ISIN is EVIDENCE, never identity, so it is parsed
+    // leniently and only ever used to compare two vendors' verdicts. Computed
+    // once here rather than at each of the seven decline sites below.
+    let declined = |reason: Skip| {
+        Ok(Decoded::Skipped(Declined {
+            reason,
+            isin: Isin::new(row.isin).ok(),
+        }))
+    };
+
     // Only NSE is stored. D-0017. An unparseable exchange is a decline: a
     // master legitimately lists venues we do not store.
     if !matches!(Exchange::parse(row.exchange), Ok(Exchange::Nse)) {
-        return Ok(Decoded::Skipped(Skip::ForeignExchange));
+        return declined(Skip::ForeignExchange);
     }
     let exchange = Exchange::Nse;
 
@@ -225,7 +697,7 @@ pub fn decode_master_row(vendor: Vendor, row: MasterRow<'_>) -> Result<Decoded, 
         .iter()
         .any(|m| row.underlying.contains(m) || row.trading_symbol.contains(m))
     {
-        return Ok(Decoded::Skipped(Skip::TestInstrument));
+        return declined(Skip::TestInstrument);
     }
 
     // The vendor's segment column is a GATE, never our segment. The primary
@@ -235,11 +707,11 @@ pub fn decode_master_row(vendor: Vendor, row: MasterRow<'_>) -> Result<Decoded, 
     // instrument type below, which is the only field whose meaning is stable
     // across vendors.
     if matches!(vendor.segment_of(row.segment)?, SegmentVerdict::Decline) {
-        return Ok(Decoded::Skipped(Skip::ForeignSegment));
+        return declined(Skip::ForeignSegment);
     }
 
     let Some(ty) = vendor.type_of(row.instrument_type, row.option_side)? else {
-        return Ok(Decoded::Skipped(Skip::ForeignSegment));
+        return declined(Skip::ForeignSegment);
     };
 
     // WHERE THE INSTRUMENT IS NAMED DEPENDS ON WHAT IT IS.
@@ -253,40 +725,121 @@ pub fn decode_master_row(vendor: Vendor, row: MasterRow<'_>) -> Result<Decoded, 
     //
     // Reading one column for everything fails either way round. This was found
     // by decoding the real master, not by reading it.
-    let name = match ty {
-        "IDX" | "EQ" => row.trading_symbol,
-        _ => row.underlying,
+    // WHERE THE TICKER LIVES IS PER-VENDOR AND OPPOSITE BETWEEN THEM.
+    //
+    // Groww leaves `underlying_symbol` EMPTY on all 4,104 cash and index rows
+    // and puts the ticker in `trading_symbol`.
+    //
+    // Dhan does the reverse: `UNDERLYING_SYMBOL` is the ticker (`GOLDSTAR`,
+    // `ARE&M`) while `SYMBOL_NAME` is the COMPANY NAME -- "GOLDSTAR POWER
+    // LIMITED", "AMARA RAJA ENERGY MOB LTD". 9,623 of its 9,674 NSE equity
+    // rows carry a space there, so reading it refused almost the entire
+    // vendor. Measured, not guessed.
+    //
+    // Preferring the underlying and falling back to the trading symbol
+    // satisfies both without a vendor branch: Groww's underlying is empty so
+    // the fallback fires; Dhan's is populated so it wins.
+    let name = if row.underlying.is_empty() {
+        row.trading_symbol
+    } else {
+        row.underlying
     };
     let underlying = Symbol::new(name)?;
 
+    // A live instrument master lists only CURRENTLY LISTED contracts -- both
+    // vendors purge on expiry, and the earliest expiry in either master is
+    // three days from now. So every derivative row here is live by definition,
+    // and none of it is backtest data. The expiry is still PARSED first, so a
+    // malformed date is an error rather than being hidden behind the skip.
     let (segment, kind) = match ty {
         "IDX" => (Segment::Index, Kind::Index),
-        "EQ" => (Segment::Cash, Kind::Equity),
-        "FUT" => (
-            Segment::Fno,
-            Kind::Future {
-                expiry: parse_expiry(row.expiry)?,
-            },
-        ),
-        _ => (
-            Segment::Fno,
-            Kind::Option {
-                expiry: parse_expiry(row.expiry)?,
-                strike: parse_strike(row.strike_rupees)?,
-                side: if ty == "CE" {
-                    OptionSide::Call
-                } else {
-                    OptionSide::Put
-                },
-            },
-        ),
+        // THE EQUITY GATE APPLIES HERE AND ONLY HERE. An index row carries no
+        // series -- Groww's `series` is empty on all 24 of its NSE index rows
+        // and Dhan writes `NA` -- so gating any earlier deletes NIFTY and
+        // BANKNIFTY.
+        "EQ" => match board_of(row.listing_class) {
+            EquityVerdict::MainBoard => (Segment::Cash, Kind::Equity),
+            EquityVerdict::Sme => return declined(Skip::SmeBoard),
+            EquityVerdict::NotEquity => return declined(Skip::NotEquityListing),
+            EquityVerdict::Unrecognised => return declined(Skip::UnrecognisedListingClass),
+        },
+        "FUT" => {
+            parse_expiry(row.expiry)?;
+            return declined(Skip::LiveContract);
+        }
+        _ => {
+            parse_expiry(row.expiry)?;
+            parse_strike(row.strike_rupees)?;
+            return declined(Skip::LiveContract);
+        }
     };
 
-    Ok(Decoded::Keep(InstrumentKey {
+    let key = InstrumentKey {
         exchange,
         segment,
         underlying,
         kind,
+    };
+
+    // THE ISIN IS READ FOR EQUITY AND NOTHING ELSE, and it is read only after
+    // the gate above. Both halves of that sentence are load-bearing:
+    //
+    //   * An index row's ISIN column is not empty, it is JUNK. Measured: Groww
+    //     writes the index ticker there (`NIFTY`) and Dhan writes `NA`.
+    //     Parsing it would refuse every index in both masters.
+    //   * The one row in either master whose check digit does not verify,
+    //     `IN1520250085`, is a state development loan on series `SG`. It never
+    //     reaches this line because the gate declined it first. Order is what
+    //     keeps that true.
+    //
+    // On an equity row the ISIN is REQUIRED, not optional: every one of the
+    // 2,726 Groww and 2,774 Dhan main-board rows carries one, so a missing or
+    // malformed value means the row is not what we think it is, and that is an
+    // error rather than a quiet `None`.
+    let isin = match kind {
+        Kind::Equity => Some(Isin::new(row.isin)?),
+        _ => None,
+    };
+
+    Ok(Decoded::Keep(Listing {
+        key,
+        isin,
+        unsuffixed: unsuffixed_key(key, name, row.listing_class)?,
+    }))
+}
+
+/// The same key with the row's own series suffix removed, if it has one.
+///
+/// `BLUECHIP-BE` under series `BE` gives `BLUECHIP`; `RELIANCE` under `EQ`
+/// gives nothing; and `BAJAJ-AUTO` under `EQ` gives nothing either, which is
+/// the whole point — the trailing segment must BE the row's own series, not
+/// merely look like a suffix.
+///
+/// # Errors
+///
+/// [`InstrumentError::Malformed`] if stripping would leave nothing to name the
+/// instrument with. A row called `-EQ` is a vendor bug, and a bug is loud here
+/// rather than silently unstripped.
+fn unsuffixed_key(
+    key: InstrumentKey,
+    name: &str,
+    class: &str,
+) -> Result<Option<InstrumentKey>, InstrumentError> {
+    // Only a cash listing has a series. An empty class would make
+    // `strip_suffix` succeed on every symbol, so it is excluded explicitly.
+    let class = class.trim();
+    if key.kind != Kind::Equity || class.is_empty() {
+        return Ok(None);
+    }
+    let Some(stripped) = name
+        .strip_suffix(class)
+        .and_then(|rest| rest.strip_suffix('-'))
+    else {
+        return Ok(None);
+    };
+    Ok(Some(InstrumentKey {
+        underlying: Symbol::new(stripped)?,
+        ..key
     }))
 }
 
@@ -335,33 +888,34 @@ fn parse_strike(text: &str) -> Result<Paisa, InstrumentError> {
 mod tests {
     use super::*;
 
-    /// The kept key, or `None` if the row was skipped.
+    /// A real main-board ISIN, so that a row which reaches the ISIN parse
+    /// carries one. `RELIANCE`, verbatim from both masters.
+    const REAL_ISIN: &str = "INE002A01018";
+
+    /// The whole kept listing, or `None` if the row was skipped.
     ///
     /// Returning an Option rather than destructuring with `else { panic!() }`
     /// keeps every branch reachable, so the coverage gate stays honest: an
     /// unreachable panic arm is an uncovered region that no test can ever
     /// exercise.
-    fn kept(d: Decoded) -> Option<InstrumentKey> {
+    fn listing(d: Decoded) -> Option<Listing> {
         match d {
-            Decoded::Keep(k) => Some(k),
+            Decoded::Keep(l) => Some(l),
             Decoded::Skipped(_) => None,
         }
     }
 
-    /// The option fields, or `None` if the kind is not an option.
-    fn as_option(k: Kind) -> Option<(Expiry, Paisa, OptionSide)> {
-        match k {
-            Kind::Option {
-                expiry,
-                strike,
-                side,
-            } => Some((expiry, strike, side)),
-            Kind::Index | Kind::Equity | Kind::Future { .. } => None,
-        }
+    /// The kept key alone, for the tests that care only about identity.
+    fn kept(d: Decoded) -> Option<InstrumentKey> {
+        listing(d).map(|l| l.key)
     }
 
     /// Builds a Groww-shaped row. `trading_symbol` mirrors `underlying` for
     /// derivative rows, which is what the real master does.
+    ///
+    /// The listing class and ISIN are those of an ordinary main-board share,
+    /// because that is what most rows are; every test of the equity gate sets
+    /// them explicitly rather than relying on this.
     fn row<'a>(
         exchange: &'a str,
         segment: &'a str,
@@ -376,6 +930,8 @@ mod tests {
             underlying,
             trading_symbol: underlying,
             instrument_type: ty,
+            listing_class: "EQ",
+            isin: REAL_ISIN,
             expiry,
             strike_rupees: strike,
             option_side: "",
@@ -387,21 +943,20 @@ mod tests {
         decode_master_row(Vendor::Groww, r)
     }
 
+    /// A decline with no ISIN beside it, for the helpers' own tests.
+    fn bare(reason: Skip) -> Decoded {
+        Decoded::Skipped(Declined { reason, isin: None })
+    }
+
     #[test]
-    fn the_test_helpers_cover_their_negative_arms() {
-        // These two helpers exist so no test needs an unreachable panic arm.
-        // Their None branches must themselves be exercised, or they become
-        // the uncovered regions they were introduced to remove.
-        assert!(kept(Decoded::Skipped(Skip::TestInstrument)).is_none());
-        assert!(kept(Decoded::Skipped(Skip::ForeignExchange)).is_none());
-        assert!(as_option(Kind::Index).is_none());
-        assert!(as_option(Kind::Equity).is_none());
-        assert!(
-            as_option(Kind::Future {
-                expiry: Expiry::new(2026, 9, 29).expect("valid"),
-            })
-            .is_none()
-        );
+    fn the_kept_helper_covers_its_negative_arm() {
+        assert!(kept(bare(Skip::TestInstrument)).is_none());
+        assert!(kept(bare(Skip::LiveContract)).is_none());
+        // `skip` is the mirror image, and both arms are exercised here so no
+        // caller has to prove them again.
+        assert_eq!(bare(Skip::LiveContract).skip(), Some(Skip::LiveContract));
+        let keep = groww(row("NSE", "CASH", "RELIANCE", "EQ", "", "")).expect("ok");
+        assert_eq!(keep.skip(), None, "a kept row was not skipped");
     }
 
     #[test]
@@ -424,73 +979,16 @@ mod tests {
     }
 
     #[test]
-    fn a_real_weekly_option_row_decodes_from_columns_not_the_symbol() {
-        // Real row: trading_symbol NIFTY2680419450CE, expiry_date 2026-08-04,
-        // strike_price 19450. The symbol encodes 26|8|04 and the monthly form
-        // encodes no day at all -- which is exactly why identity comes from
-        // the columns and never from the display string.
-        let got =
-            groww(row("NSE", "FNO", "NIFTY", "CE", "2026-08-04", "19450")).expect("well formed");
-        let key = kept(got).expect("must be kept");
-        let (expiry, strike, side) = as_option(key.kind).expect("must be an option");
-        assert_eq!((expiry.year(), expiry.month(), expiry.day()), (2026, 8, 4));
-        assert_eq!(strike.raw(), 1_945_000, "19450 rupees is 1,945,000 paisa");
-        assert_eq!(side, OptionSide::Call);
-        assert!(!key.is_sweepable(), "options are stored, never swept");
-    }
-
-    #[test]
-    fn a_real_monthly_option_row_keeps_the_day_the_column_gives() {
-        // BANKNIFTY25DEC27000PE expires 2025-12-24. A day-first reading of
-        // "25DEC" would produce the 25th. The column says the 24th, and the
-        // column wins -- this test fails if anyone reintroduces symbol parsing.
-        let got = groww(row("NSE", "FNO", "BANKNIFTY", "PE", "2025-12-24", "27000"))
-            .expect("well formed");
-        let key = kept(got).expect("must be kept");
-        let (expiry, strike, _) = as_option(key.kind).expect("must be an option");
-        assert_eq!(expiry.day(), 24, "the column says 24, not the symbol's 25");
-        assert_eq!(strike.raw(), 2_700_000);
-    }
-
-    #[test]
-    fn strike_conversion_is_rupees_to_paisa() {
-        // A missed multiply here makes every strike wrong by 100x.
-        for (rupees, paisa) in [
-            ("27000", 2_700_000_i64),
-            ("19450", 1_945_000),
-            ("96", 9_600),
-        ] {
-            let got =
-                groww(row("NSE", "FNO", "NIFTY", "CE", "2026-08-04", rupees)).expect("well formed");
-            let key = kept(got).expect("kept");
-            let (_, strike, _) = as_option(key.kind).expect("option");
-            assert_eq!(strike.raw(), paisa, "{rupees} rupees");
-        }
-    }
-
-    #[test]
-    fn a_future_decodes_and_is_never_sweepable() {
-        // Real row: 360ONE26SEPFUT, expiry_date 2026-09-29.
-        let got = groww(row("NSE", "FNO", "360ONE", "FUT", "2026-09-29", "")).expect("well formed");
-        let key = kept(got).expect("kept");
-        assert_eq!(
-            key.kind,
-            Kind::Future {
-                expiry: Expiry::new(2026, 9, 29).expect("valid")
-            }
-        );
-        assert!(!key.is_sweepable());
-    }
-
-    #[test]
     fn exchange_test_instruments_are_skipped() {
         // Real rows: 031NSETEST36DECFUT and 061NSETEST36DECFUT. Storing these
         // would put fabricated instruments beside real ones, indistinguishable
         // afterwards.
         for u in ["031NSETEST", "061NSETEST", "BSETEST01"] {
             assert_eq!(
-                groww(row("NSE", "FNO", u, "FUT", "2036-11-27", "")).expect("ok"),
-                Decoded::Skipped(Skip::TestInstrument),
+                groww(row("NSE", "FNO", u, "FUT", "2036-11-27", ""))
+                    .expect("ok")
+                    .skip(),
+                Some(Skip::TestInstrument),
                 "{u} must be skipped"
             );
         }
@@ -500,20 +998,26 @@ mod tests {
     fn bse_and_unknown_exchanges_are_skipped_not_stored() {
         // D-0017 -- NSE only.
         assert_eq!(
-            groww(row("BSE", "CASH", "SENSEX", "IDX", "", "")).expect("ok"),
-            Decoded::Skipped(Skip::ForeignExchange)
+            groww(row("BSE", "CASH", "SENSEX", "IDX", "", ""))
+                .expect("ok")
+                .skip(),
+            Some(Skip::ForeignExchange)
         );
         assert_eq!(
-            groww(row("MCX", "COMMODITY", "GOLD", "FUT", "2026-08-05", "")).expect("ok"),
-            Decoded::Skipped(Skip::ForeignExchange)
+            groww(row("MCX", "COMMODITY", "GOLD", "FUT", "2026-08-05", ""))
+                .expect("ok")
+                .skip(),
+            Some(Skip::ForeignExchange)
         );
     }
 
     #[test]
     fn commodity_segment_is_skipped() {
         assert_eq!(
-            groww(row("NSE", "COMMODITY", "GOLD", "FUT", "2026-08-05", "")).expect("ok"),
-            Decoded::Skipped(Skip::ForeignSegment)
+            groww(row("NSE", "COMMODITY", "GOLD", "FUT", "2026-08-05", ""))
+                .expect("ok")
+                .skip(),
+            Some(Skip::ForeignSegment)
         );
     }
 
@@ -570,19 +1074,6 @@ mod tests {
     }
 
     #[test]
-    fn both_vendors_spelling_one_contract_produce_one_key() {
-        // THIS is the deduplication, at the row level. The two brokers ship
-        // different column layouts; once decoded they are the same key.
-        let from_groww =
-            groww(row("NSE", "FNO", "NIFTY", "CE", "2026-08-04", "19450")).expect("ok");
-        // Same contract, lower-case underlying, strike with a trailing decimal
-        // -- both of which a different vendor legitimately emits.
-        let from_dhan =
-            groww(row("NSE", "FNO", "nifty", "CE", "2026-08-04", "19450.0")).expect("ok");
-        assert_eq!(from_groww, from_dhan, "one contract, one identity");
-    }
-
-    #[test]
     fn the_real_nifty_row_decodes_from_the_columns_the_master_actually_fills() {
         // THE ROW THAT BROKE EVERYTHING. Verbatim from the master:
         //   NSE,NIFTY,NIFTY,NSE-NIFTY,NIFTY 50,IDX,CASH,,NIFTY,,,,,,,,,0,0,,0
@@ -598,6 +1089,10 @@ mod tests {
             underlying: "", // <-- exactly as the file has it
             trading_symbol: "NIFTY",
             instrument_type: "IDX",
+            // Empty series and an isin column holding the TICKER, both
+            // exactly as the file has them. Neither may reach a validator.
+            listing_class: "",
+            isin: "NIFTY",
             expiry: "",
             strike_rupees: "",
             option_side: "",
@@ -612,67 +1107,6 @@ mod tests {
     }
 
     #[test]
-    fn a_derivative_takes_its_underlying_not_its_contract_symbol() {
-        // The opposite direction: trading_symbol here is the CONTRACT, and a
-        // real one is `ASHOKLEY26SEP117.5CE` -- which contains a '.' and is
-        // not a legal Symbol. Reading col 3 for everything breaks 1,664 rows.
-        let real = MasterRow {
-            exchange: "NSE",
-            segment: "FNO",
-            underlying: "ASHOKLEY",
-            trading_symbol: "ASHOKLEY26SEP117.5CE",
-            instrument_type: "CE",
-            expiry: "2026-09-29",
-            strike_rupees: "117.5",
-            option_side: "",
-        };
-        let key = kept(groww(real).expect("must decode")).expect("kept");
-        assert_eq!(key.underlying.as_str(), "ASHOKLEY");
-        let (_, strike, _) = as_option(key.kind).expect("option");
-        assert_eq!(strike.raw(), 11_750, "117.5 rupees is 11,750 paisa");
-    }
-
-    #[test]
-    fn dhan_single_letter_segments_map_instead_of_discarding_the_vendor() {
-        // As written before this fix, EVERY Dhan row -- all 200,460 -- was
-        // reported Skipped(ForeignSegment). An entire broker vanished and the
-        // decoder called it routine.
-        let dhan_nifty = MasterRow {
-            exchange: "NSE",
-            segment: "I",
-            underlying: "NIFTY",
-            trading_symbol: "NIFTY",
-            instrument_type: "INDEX",
-            expiry: "",
-            strike_rupees: "",
-            option_side: "",
-        };
-        let key =
-            kept(decode_master_row(Vendor::Dhan, dhan_nifty).expect("must decode")).expect("kept");
-        assert!(key.is_sweepable(), "NIFTY from Dhan must be sweepable too");
-
-        let dhan_opt = MasterRow {
-            exchange: "NSE",
-            segment: "D",
-            underlying: "NIFTY",
-            trading_symbol: "NIFTY26AUG19450CE",
-            instrument_type: "OPTIDX",
-            expiry: "2026-08-04",
-            strike_rupees: "19450.00000",
-            option_side: "CE",
-        };
-        let key =
-            kept(decode_master_row(Vendor::Dhan, dhan_opt).expect("must decode")).expect("kept");
-        let (_, strike, side) = as_option(key.kind).expect("option");
-        assert_eq!(strike.raw(), 1_945_000);
-        assert_eq!(
-            side,
-            OptionSide::Call,
-            "side comes from OPTION_TYPE, not the type code"
-        );
-    }
-
-    #[test]
     fn an_unknown_vendor_code_is_loud_never_a_silent_decline() {
         // This is the whole lesson. Treating an unrecognised code as "not ours"
         // is what let 200,460 Dhan rows disappear while reporting a routine
@@ -683,6 +1117,8 @@ mod tests {
             underlying: "NIFTY",
             trading_symbol: "NIFTY",
             instrument_type: "INDEX",
+            listing_class: "NA",
+            isin: "NA",
             expiry: "",
             strike_rupees: "",
             option_side: "",
@@ -715,44 +1151,16 @@ mod tests {
             underlying: "USDINR",
             trading_symbol: "USDINR",
             instrument_type: "OPTCUR",
+            listing_class: "",
+            isin: "",
             expiry: "2026-08-04",
             strike_rupees: "83.625",
             option_side: "CE",
         };
         assert_eq!(
-            decode_master_row(Vendor::Dhan, cur).expect("ok"),
-            Decoded::Skipped(Skip::ForeignSegment)
+            decode_master_row(Vendor::Dhan, cur).expect("ok").skip(),
+            Some(Skip::ForeignSegment)
         );
-    }
-
-    #[test]
-    fn dhan_puts_and_a_missing_option_side_are_both_handled() {
-        let base = MasterRow {
-            exchange: "NSE",
-            segment: "D",
-            underlying: "NIFTY",
-            trading_symbol: "NIFTY26AUG19450PE",
-            instrument_type: "OPTIDX",
-            expiry: "2026-08-04",
-            strike_rupees: "19450",
-            option_side: "PE",
-        };
-        let key = kept(decode_master_row(Vendor::Dhan, base).expect("ok")).expect("kept");
-        let (_, _, side) = as_option(key.kind).expect("option");
-        assert_eq!(side, OptionSide::Put);
-
-        // An option row with no side is unreadable, not a decline: we would be
-        // guessing call-versus-put, which is the whole contract.
-        for bad in ["", "XX", "ce"] {
-            let r = MasterRow {
-                option_side: bad,
-                ..base
-            };
-            assert!(
-                decode_master_row(Vendor::Dhan, r).is_err(),
-                "option_side {bad:?} must be an error"
-            );
-        }
     }
 
     #[test]
@@ -765,54 +1173,716 @@ mod tests {
             underlying: "USDINR",
             trading_symbol: "USDINR26AUGFUT",
             instrument_type: "FUTCUR",
+            listing_class: "",
+            isin: "",
             expiry: "2026-08-26",
             strike_rupees: "",
             option_side: "",
         };
         assert_eq!(
-            decode_master_row(Vendor::Dhan, cur).expect("ok"),
-            Decoded::Skipped(Skip::ForeignSegment)
+            decode_master_row(Vendor::Dhan, cur).expect("ok").skip(),
+            Some(Skip::ForeignSegment)
         );
     }
 
     #[test]
-    fn dhan_equities_and_futures_decode_too() {
-        // Real Dhan NSE shapes: EQUITY under segment E, FUTSTK/FUTIDX under D.
-        let eq = MasterRow {
+    fn every_live_derivative_is_skipped_not_stored() {
+        // The operator's rule, enforced at the decoder: a live instrument
+        // master lists ONLY currently-listed contracts -- both vendors purge
+        // on expiry and the earliest expiry in either is days away. Backtests
+        // run on EXPIRED contracts, which come from the historical endpoints
+        // and the lake. Storing the live chain adds ~148,000 contracts holding
+        // a few weeks each, none ever swept.
+        for (ty, strike) in [("FUT", ""), ("CE", "19450"), ("PE", "19450")] {
+            assert_eq!(
+                groww(row("NSE", "FNO", "NIFTY", ty, "2026-08-04", strike))
+                    .expect("ok")
+                    .skip(),
+                Some(Skip::LiveContract),
+                "{ty} must be skipped as a live contract"
+            );
+        }
+        // Dhan's spellings too.
+        for ty in ["FUTIDX", "FUTSTK", "OPTIDX", "OPTSTK"] {
+            let r = MasterRow {
+                exchange: "NSE",
+                segment: "D",
+                underlying: "NIFTY",
+                trading_symbol: "NIFTY",
+                instrument_type: ty,
+                listing_class: "",
+                isin: "",
+                expiry: "2026-08-04",
+                strike_rupees: "19450",
+                option_side: "CE",
+            };
+            assert_eq!(
+                decode_master_row(Vendor::Dhan, r).expect("ok").skip(),
+                Some(Skip::LiveContract),
+                "{ty} must be skipped"
+            );
+        }
+    }
+
+    #[test]
+    fn dhan_reads_the_option_side_from_its_own_column() {
+        // Dhan types EVERY option as OPTSTK/OPTIDX and carries call-versus-put
+        // in a separate field, so both values must be read and anything else
+        // must be loud -- an option whose side we cannot read is not an option
+        // we can store.
+        let opt = |side| MasterRow {
+            exchange: "NSE",
+            segment: "D",
+            underlying: "NIFTY",
+            trading_symbol: "NIFTY",
+            instrument_type: "OPTIDX",
+            listing_class: "",
+            isin: "",
+            expiry: "2026-08-04",
+            strike_rupees: "19450",
+            option_side: side,
+        };
+        for side in ["CE", "PE"] {
+            assert_eq!(
+                decode_master_row(Vendor::Dhan, opt(side))
+                    .expect("ok")
+                    .skip(),
+                Some(Skip::LiveContract),
+                "{side} must decode before being declined as live"
+            );
+        }
+        for side in ["", "XX", "ce"] {
+            assert_eq!(
+                decode_master_row(Vendor::Dhan, opt(side)),
+                Err(InstrumentError::Malformed),
+                "{side:?} is not a side this vendor emits"
+            );
+        }
+    }
+
+    #[test]
+    fn a_malformed_derivative_still_errors_rather_than_hiding_behind_the_skip() {
+        // The expiry and strike are parsed BEFORE the skip, so a vendor that
+        // starts emitting a bad date is a loud failure rather than being
+        // silently swallowed by "it was live anyway".
+        assert!(groww(row("NSE", "FNO", "NIFTY", "FUT", "not-a-date", "")).is_err());
+        assert!(groww(row("NSE", "FNO", "NIFTY", "CE", "2026-08-04", "abc")).is_err());
+        assert!(groww(row("NSE", "FNO", "NIFTY", "CE", "2026-02-31", "1")).is_err());
+    }
+
+    #[test]
+    fn indices_and_equities_are_still_kept_from_both_vendors() {
+        // Both name columns empty is unnameable -- an ERROR, never a skip,
+        // because a row we cannot name is how an instrument silently vanishes.
+        assert!(groww(row("NSE", "CASH", "", "IDX", "", "")).is_err());
+
+        let nifty = kept(
+            groww(MasterRow {
+                exchange: "NSE",
+                segment: "CASH",
+                underlying: "",
+                trading_symbol: "NIFTY",
+                instrument_type: "IDX",
+                listing_class: "",
+                isin: "NIFTY",
+                expiry: "",
+                strike_rupees: "",
+                option_side: "",
+            })
+            .expect("ok"),
+        )
+        .expect("kept");
+        assert!(nifty.is_sweepable());
+
+        let dhan_eq = kept(
+            decode_master_row(
+                Vendor::Dhan,
+                MasterRow {
+                    exchange: "NSE",
+                    segment: "E",
+                    underlying: "RELIANCE",
+                    trading_symbol: "RELIANCE INDUSTRIES LTD",
+                    instrument_type: "EQUITY",
+                    listing_class: "EQ",
+                    isin: REAL_ISIN,
+                    expiry: "",
+                    strike_rupees: "",
+                    option_side: "",
+                },
+            )
+            .expect("ok"),
+        )
+        .expect("kept");
+        assert_eq!(dhan_eq.kind, Kind::Equity);
+    }
+
+    // ---------------------------------------------------------------------
+    // The equity-listing gate.
+    // ---------------------------------------------------------------------
+
+    /// A Dhan `SEGMENT=E`, `INSTRUMENT=EQUITY` row, which is what every
+    /// listing on the equity segment is — share, bond or fund alike.
+    ///
+    /// `series` is Dhan's own `SERIES` column, which is the NSE board series
+    /// and the only column this gate reads. D-0025.
+    fn dhan_cash<'a>(ticker: &'a str, series: &'a str, isin: &'a str) -> MasterRow<'a> {
+        MasterRow {
             exchange: "NSE",
             segment: "E",
-            underlying: "RELIANCE",
-            trading_symbol: "RELIANCE",
+            underlying: ticker,
+            trading_symbol: "CHOLAMANDALAM IN & FIN CO",
             instrument_type: "EQUITY",
+            listing_class: series,
+            isin,
             expiry: "",
             strike_rupees: "",
             option_side: "",
-        };
-        let key = kept(decode_master_row(Vendor::Dhan, eq).expect("ok")).expect("kept");
-        assert_eq!(key.kind, Kind::Equity);
-        assert_eq!(key.segment, Segment::Cash);
-
-        for t in ["FUTSTK", "FUTIDX"] {
-            let f = MasterRow {
-                segment: "D",
-                underlying: "NIFTY",
-                instrument_type: t,
-                expiry: "2026-08-27",
-                ..eq
-            };
-            let key = kept(decode_master_row(Vendor::Dhan, f).expect("ok")).expect("kept");
-            assert!(
-                as_option(key.kind).is_none(),
-                "{t} is a future, not an option"
-            );
-            assert_eq!(
-                key.kind,
-                Kind::Future {
-                    expiry: Expiry::new(2026, 8, 27).expect("valid")
-                },
-                "{t}"
-            );
-            assert_eq!(key.segment, Segment::Fno);
         }
+    }
+
+    /// A Groww `CASH`/`EQ` row on a given NSE series.
+    fn groww_cash<'a>(ticker: &'a str, series: &'a str, isin: &'a str) -> MasterRow<'a> {
+        MasterRow {
+            underlying: "",
+            trading_symbol: ticker,
+            listing_class: series,
+            isin,
+            ..row("NSE", "CASH", ticker, "EQ", "", "")
+        }
+    }
+
+    #[test]
+    fn the_cholafin_bond_is_declined_and_the_cholafin_share_is_kept() {
+        // THE COLLISION THIS GATE EXISTS FOR. Both rows are verbatim from the
+        // real Dhan master; both are NSE/E/EQUITY with ticker CHOLAFIN. The
+        // BOND is at line 167146 and the SHARE at 171414, so the bond comes
+        // FIRST and an insert-if-absent merge resolved CHOLAFIN to a 7.5% NCD
+        // and took its tick size of 5.0 instead of the share's 10.0 --
+        // silently, and dependent on nothing but file order. The bond's real
+        // SERIES is `D1`; the share's is `EQ`.
+        let bond = dhan_cash("CHOLAFIN", "D1", "INE121A08PJ0");
+        assert_eq!(
+            decode_master_row(Vendor::Dhan, bond).expect("ok").skip(),
+            Some(Skip::NotEquityListing),
+            "the NCD must never take the CHOLAFIN ticker"
+        );
+
+        let share = dhan_cash("CHOLAFIN", "EQ", "INE121A01024");
+        let l = listing(decode_master_row(Vendor::Dhan, share).expect("ok")).expect("kept");
+        assert_eq!(l.key.underlying.as_str(), "CHOLAFIN");
+        assert_eq!(l.key.kind, Kind::Equity);
+        assert_eq!(
+            l.isin.map(|i| i.to_string()).as_deref(),
+            Some("INE121A01024"),
+            "the share's own ISIN travels beside the key"
+        );
+    }
+
+    #[test]
+    fn the_other_two_measured_ticker_captures_are_declined_too() {
+        // MOTHERSON's NCD (series D1) and ELECTCAST's warrant (series W1) are
+        // the other two rows that captured a live ticker, and the share of each
+        // name is on series EQ. All three are NIFTY Total Market members. Every
+        // series below is verbatim from the real Dhan master.
+        for (ticker, series, isin) in [
+            ("MOTHERSON", "D1", "INE775A08105"),
+            ("ELECTCAST", "W1", "INE086A13016"),
+        ] {
+            assert_eq!(
+                decode_master_row(Vendor::Dhan, dhan_cash(ticker, series, isin))
+                    .expect("ok")
+                    .skip(),
+                Some(Skip::NotEquityListing),
+                "{ticker} series {series} must be declined"
+            );
+        }
+        for (ticker, isin) in [("MOTHERSON", "INE775A01035"), ("ELECTCAST", "INE086A01029")] {
+            let l = listing(
+                decode_master_row(Vendor::Dhan, dhan_cash(ticker, "EQ", isin)).expect("ok"),
+            )
+            .expect("kept");
+            assert_eq!(l.isin.map(|i| i.to_string()).as_deref(), Some(isin));
+        }
+    }
+
+    #[test]
+    fn dhans_class_column_is_trimmed_before_it_is_read() {
+        // The column is whitespace padded. Reading it untrimmed would decline
+        // every genuine share in the file -- a total loss reported as a
+        // routine skip, which is the failure this repository has already had
+        // once.
+        for padded in ["   EQ   ", " EQ", "EQ ", "EQ", "  BE  ", "BE"] {
+            let l = listing(
+                decode_master_row(Vendor::Dhan, dhan_cash("RELIANCE", padded, REAL_ISIN))
+                    .expect("ok"),
+            )
+            .expect("kept");
+            assert_eq!(l.key.kind, Kind::Equity, "{padded:?} must be kept");
+        }
+    }
+
+    #[test]
+    fn a_mutual_fund_plan_is_declined_from_both_vendors_on_one_series_alphabet() {
+        // Dhan files 54 open-ended fund plans as INSTRUMENT_TYPE=ETF while its
+        // OWN series column says MF; Groww carries 29 of the same ISINs under
+        // series=MF and declines them. Reading the paper class kept all 54 as
+        // equities -- the exact category Skip::NotEquityListing exists to
+        // remove. Reading the series declines them from BOTH vendors, which is
+        // the whole point of D-0025.
+        for (vendor, row) in [
+            (Vendor::Dhan, dhan_cash("FISTIPD3GP", "MF", "INF090I01VS3")),
+            (
+                Vendor::Groww,
+                groww_cash("FISTIPD3GP", "MF", "INF090I01VS3"),
+            ),
+        ] {
+            // The vendor name is bound rather than called inside the failure
+            // message: a call there is a region that only runs when the
+            // assertion FAILS, so it can never be covered by a passing test.
+            let who = vendor.as_str();
+            assert_eq!(
+                decode_master_row(vendor, row).expect("ok").skip(),
+                Some(Skip::NotEquityListing),
+                "{who} must decline the fund plan"
+            );
+        }
+        // And a genuine exchange-traded fund on the EQ series is still kept --
+        // HDFCLIQUID carries an INF issuer prefix too, so "INF means a fund"
+        // would have been the wrong rule.
+        let etf = listing(
+            decode_master_row(Vendor::Dhan, dhan_cash("HDFCLIQUID", "EQ", "INF179KC1JG3"))
+                .expect("ok"),
+        )
+        .expect("kept");
+        assert_eq!(etf.key.kind, Kind::Equity);
+    }
+
+    #[test]
+    fn the_surveillance_and_partly_paid_equity_series_are_kept_not_called_debt() {
+        // BZ (25 Groww / 38 Dhan rows), IT (2/2), SZ (1/2) and E1 (2/3) are
+        // trade-for-trade, surveillance and partly-paid EQUITY. Declining them
+        // under "not an equity listing" was false about 30 real shares.
+        // RAJESHEXPO/INE343B01030 and HMT/INE262A01018 are verbatim from the
+        // masters; the NSDL security-type digits of both are `01`, ordinary
+        // equity, against `08` for the CHOLAFIN NCD.
+        for series in ["BZ", "IT", "SZ", "E1"] {
+            for (vendor, r) in [
+                (
+                    Vendor::Groww,
+                    groww_cash("RAJESHEXPO", series, "INE343B01030"),
+                ),
+                (
+                    Vendor::Dhan,
+                    dhan_cash("RAJESHEXPO", series, "INE343B01030"),
+                ),
+            ] {
+                let who = vendor.as_str();
+                let l = listing(decode_master_row(vendor, r).expect("ok")).expect("kept");
+                assert_eq!(
+                    l.key.kind,
+                    Kind::Equity,
+                    "series {series} is equity at {who}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn an_unrecognised_series_is_its_own_loud_reason_never_a_bond() {
+        // THE FAILURE THIS VARIANT EXISTS FOR. Both arms of the gate used to
+        // end in `_ => NotEquity`, so renaming the equity series EQ to EQX on
+        // the real Dhan master silently dropped 2,438 shares -- every F&O
+        // underlying among them -- while the report printed `ok` and exit 0,
+        // and the only trace was one bond counter rising.
+        for code in ["EQX", "XX", "eq", "es", "ETF", "ES", "DEB", "", "  "] {
+            assert_eq!(
+                decode_master_row(Vendor::Dhan, dhan_cash("RELIANCE", code, REAL_ISIN))
+                    .expect("ok")
+                    .skip(),
+                Some(Skip::UnrecognisedListingClass),
+                "{code:?} is not a series this engine has measured"
+            );
+        }
+        // It is a DECLINE and not an error, because NSE mints debt series at
+        // will -- but never the same decline as a bond.
+        assert_ne!(Skip::UnrecognisedListingClass, Skip::NotEquityListing);
+        assert!(!Skip::UnrecognisedListingClass.is_routine());
+        assert!(Skip::NotEquityListing.is_routine());
+        assert!(Skip::SmeBoard.is_routine());
+    }
+
+    #[test]
+    fn every_measured_debt_and_fund_class_is_declined_by_name() {
+        // The 7,137 rows that are on the equity segment and are not equity.
+        // Both vendors, one NSE series alphabet.
+        for series in [
+            "N0", "N1", "SG", "GS", "MF", "IV", "Y1", "Z9", "AK", "D1", "W1", "TB", "GB", "RR",
+            "P1", "SF", "ZZ",
+        ] {
+            for vendor in Vendor::ALL {
+                let r = match vendor {
+                    Vendor::Groww => groww_cash("SOMEBOND", series, REAL_ISIN),
+                    _ => dhan_cash("SOMEBOND", series, REAL_ISIN),
+                };
+                let who = vendor.as_str();
+                assert_eq!(
+                    decode_master_row(vendor, r).expect("ok").skip(),
+                    Some(Skip::NotEquityListing),
+                    "series {series:?} must be declined at {who}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_measured_series_tables_are_sorted_disjoint_and_complete() {
+        // `board_of` binary-searches all three, and binary_search on an
+        // unsorted array returns garbage in silence.
+        for (name, list) in [
+            ("EQUITY_BOARD_SERIES", EQUITY_BOARD_SERIES.as_slice()),
+            ("SME_BOARD_SERIES", SME_BOARD_SERIES.as_slice()),
+            ("NON_EQUITY_SERIES", NON_EQUITY_SERIES.as_slice()),
+        ] {
+            for w in list.windows(2) {
+                assert!(w[0] < w[1], "{name} is unsorted or not unique at {w:?}");
+            }
+            for code in list {
+                assert!(!code.is_empty(), "{name} holds an empty code");
+            }
+        }
+        // A code in two tables would make the verdict depend on the order the
+        // tables happen to be searched in.
+        for a in EQUITY_BOARD_SERIES {
+            assert!(!SME_BOARD_SERIES.contains(&a));
+            assert!(!NON_EQUITY_SERIES.contains(&a));
+        }
+        for a in SME_BOARD_SERIES {
+            assert!(!NON_EQUITY_SERIES.contains(&a));
+        }
+        // 128 distinct codes were measured across both masters.
+        assert_eq!(
+            EQUITY_BOARD_SERIES.len() + SME_BOARD_SERIES.len() + NON_EQUITY_SERIES.len(),
+            128
+        );
+    }
+
+    #[test]
+    fn the_equity_board_is_kept_and_the_sme_board_is_declined_separately() {
+        // EQ and BE are the equity board; SM and ST are the SME board. The SME
+        // rows get their OWN reason so the decision stays visible: an SME
+        // listing IS a share, it is simply not in any universe the engine
+        // ranks over.
+        for series in ["EQ", "BE"] {
+            let r = MasterRow {
+                listing_class: series,
+                ..row("NSE", "CASH", "RELIANCE", "EQ", "", "")
+            };
+            assert_eq!(
+                listing(groww(r).expect("ok")).expect("kept").key.kind,
+                Kind::Equity,
+                "series {series} is the equity board"
+            );
+        }
+        // Symmetrically at BOTH vendors, since D-0025 -- 558 rows at Groww and
+        // 559 at Dhan, the same paper by ISIN. Before it, Dhan kept every one
+        // of them because its paper class calls an SME share `ES`.
+        for series in ["SM", "ST"] {
+            for (vendor, r) in [
+                (Vendor::Groww, groww_cash("SOMESME", series, REAL_ISIN)),
+                (Vendor::Dhan, dhan_cash("SOMESME", series, REAL_ISIN)),
+            ] {
+                let who = vendor.as_str();
+                assert_eq!(
+                    decode_master_row(vendor, r).expect("ok").skip(),
+                    Some(Skip::SmeBoard),
+                    "series {series} is the SME board at {who}, and says so"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_declined_row_carries_its_isin_as_evidence_for_the_cross_check() {
+        // A merge that only compares what both vendors KEPT cannot see an
+        // ELIGIBILITY disagreement. The ISIN is what makes one visible, so it
+        // travels with the decline -- leniently, because the declined row is
+        // declined either way.
+        let d = decode_master_row(Vendor::Dhan, dhan_cash("CHOLAFIN", "D1", "INE121A08PJ0"))
+            .expect("ok");
+        assert_eq!(
+            d,
+            Decoded::Skipped(Declined {
+                reason: Skip::NotEquityListing,
+                isin: Isin::new("INE121A08PJ0").ok(),
+            })
+        );
+        // An unparseable ISIN on a declined row yields no evidence and no
+        // error: the row is declined and counted regardless.
+        let sdl = decode_master_row(Vendor::Dhan, dhan_cash("61GJ28", "SG", "IN1520250085"))
+            .expect("a declined row must never fail on its own ISIN");
+        assert_eq!(
+            sdl,
+            Decoded::Skipped(Declined {
+                reason: Skip::NotEquityListing,
+                isin: None,
+            })
+        );
+    }
+
+    #[test]
+    fn an_index_row_survives_the_gate_from_both_vendors() {
+        // THE ROW THAT MUST NOT BE GATED. An index has no series at all --
+        // Groww leaves the column empty, Dhan writes `NA` -- so a gate applied
+        // before the instrument type is known deletes NIFTY and BANKNIFTY,
+        // which is every instrument the engine exists to sweep.
+        for sym in ["NIFTY", "BANKNIFTY"] {
+            let g = MasterRow {
+                underlying: "",
+                trading_symbol: sym,
+                listing_class: "",
+                isin: sym,
+                ..row("NSE", "CASH", sym, "IDX", "", "")
+            };
+            let gl = listing(groww(g).expect("ok")).expect("kept");
+            assert!(gl.key.is_sweepable(), "Groww {sym} must survive the gate");
+            assert_eq!(gl.isin, None, "an index has no ISIN, and none is invented");
+
+            let d = MasterRow {
+                exchange: "NSE",
+                segment: "I",
+                underlying: sym,
+                trading_symbol: sym,
+                instrument_type: "INDEX",
+                listing_class: "NA",
+                isin: "NA",
+                expiry: "0001-01-01",
+                strike_rupees: "",
+                option_side: "XX",
+            };
+            let dl = listing(decode_master_row(Vendor::Dhan, d).expect("ok")).expect("kept");
+            assert!(dl.key.is_sweepable(), "Dhan {sym} must survive the gate");
+            assert_eq!(
+                dl.isin, None,
+                "`NA` is not an ISIN and is not parsed as one"
+            );
+        }
+    }
+
+    #[test]
+    fn the_gate_never_sees_a_derivative_row() {
+        // A live derivative carries no series either. It is declined for being
+        // live, and the reason must say so rather than saying "not equity".
+        let r = MasterRow {
+            listing_class: "",
+            isin: "",
+            ..row("NSE", "FNO", "NIFTY", "FUT", "2026-08-04", "")
+        };
+        assert_eq!(
+            groww(r).expect("ok").skip(),
+            Some(Skip::LiveContract),
+            "the reason must be the true one"
+        );
+    }
+
+    #[test]
+    fn a_kept_equity_must_carry_a_parseable_isin() {
+        // Every one of the main-board rows in either master has one, so a
+        // missing or malformed value means the row is not what it claims.
+        for bad in ["", "NA", "INE002A01019", "INE002A0101"] {
+            let r = MasterRow {
+                isin: bad,
+                ..row("NSE", "CASH", "RELIANCE", "EQ", "", "")
+            };
+            assert_eq!(
+                groww(r),
+                Err(InstrumentError::Malformed),
+                "{bad:?} must be loud, never a quiet None"
+            );
+        }
+    }
+
+    #[test]
+    fn the_sdl_with_the_bad_check_digit_never_reaches_the_isin_parse() {
+        // IN1520250085 is the one row in either master whose check digit does
+        // not verify. It is a state development loan on series `SG`, so the
+        // gate declines it FIRST -- which is why the ISIN is parsed after the
+        // gate and not before. Order is the whole content of this test.
+        assert_eq!(
+            decode_master_row(Vendor::Dhan, dhan_cash("61GJ28", "SG", "IN1520250085"))
+                .expect("ok")
+                .skip(),
+            Some(Skip::NotEquityListing)
+        );
+        // And it really would have been refused, had it got that far.
+        assert!(Isin::new("IN1520250085").is_err());
+    }
+
+    // ---------------------------------------------------------------------
+    // The series suffix.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn a_series_suffix_is_offered_as_a_candidate_never_applied() {
+        // Groww leaks internal_trading_symbol into trading_symbol on 209 of
+        // the 4,080 shared ISINs. The decoder offers the stripped identity; it
+        // does not adopt it, because only a second vendor's ISIN can confirm
+        // that BLUECHIP-BE and BLUECHIP are one instrument.
+        let r = MasterRow {
+            underlying: "",
+            trading_symbol: "BLUECHIP-BE",
+            listing_class: "BE",
+            isin: "INE657B01025",
+            ..row("NSE", "CASH", "BLUECHIP-BE", "EQ", "", "")
+        };
+        let l = listing(groww(r).expect("ok")).expect("kept");
+        assert_eq!(
+            l.key.underlying.as_str(),
+            "BLUECHIP-BE",
+            "the key is what the vendor said, unchanged"
+        );
+        assert_eq!(
+            l.unsuffixed.map(|k| k.underlying.as_str().to_owned()),
+            Some("BLUECHIP".to_owned()),
+            "and the stripped form is offered beside it"
+        );
+    }
+
+    #[test]
+    fn a_dash_that_is_not_the_rows_own_series_is_never_stripped() {
+        // BAJAJ-AUTO is a real ticker ending in a dash. Stripping blind would
+        // manufacture the collision Symbol::new refuses to manufacture.
+        for (ticker, series) in [
+            ("BAJAJ-AUTO", "EQ"),
+            ("NAM-INDIA", "EQ"),
+            ("RELIANCE", "EQ"),
+            ("LOWVOL-EQ", "BE"),
+        ] {
+            let r = MasterRow {
+                underlying: "",
+                trading_symbol: ticker,
+                listing_class: series,
+                ..row("NSE", "CASH", ticker, "EQ", "", "")
+            };
+            assert_eq!(
+                listing(groww(r).expect("ok")).expect("kept").unsuffixed,
+                None,
+                "{ticker} under series {series} must not be stripped"
+            );
+        }
+    }
+
+    #[test]
+    fn stripping_to_nothing_is_an_error_rather_than_a_silent_no_op() {
+        let r = MasterRow {
+            underlying: "",
+            trading_symbol: "-EQ",
+            listing_class: "EQ",
+            ..row("NSE", "CASH", "-EQ", "EQ", "", "")
+        };
+        assert_eq!(groww(r), Err(InstrumentError::Malformed));
+    }
+
+    #[test]
+    fn nothing_but_a_cash_listing_is_offered_a_stripped_key() {
+        // An index has no series, so there is nothing to strip and no
+        // candidate to offer -- even when its ticker happens to end in a dash
+        // and a word.
+        let r = MasterRow {
+            underlying: "",
+            trading_symbol: "NIFTY-IDX",
+            listing_class: "IDX",
+            isin: "NIFTY-IDX",
+            ..row("NSE", "CASH", "NIFTY-IDX", "IDX", "", "")
+        };
+        assert_eq!(
+            listing(groww(r).expect("ok")).expect("kept").unsuffixed,
+            None
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // The vendor tables.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn every_skip_reason_is_distinct_and_says_what_it_declined() {
+        let all = [
+            Skip::ForeignExchange,
+            Skip::TestInstrument,
+            Skip::ForeignSegment,
+            Skip::LiveContract,
+            Skip::NotEquityListing,
+            Skip::SmeBoard,
+            Skip::UnrecognisedListingClass,
+        ];
+        let rendered: Vec<&str> = all.iter().map(|s| s.reason()).collect();
+        for (i, a) in rendered.iter().enumerate() {
+            assert!(!a.is_empty(), "reason {i} is empty");
+            for (j, b) in rendered.iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b, "reasons {i} and {j} are the same string");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn each_vendor_names_its_own_columns_and_no_two_agree() {
+        let g = Vendor::Groww.master_columns();
+        let d = Vendor::Dhan.master_columns();
+        // Both read the NSE board series, under each vendor's own spelling.
+        // Dhan's `INSTRUMENT_TYPE` is a vendor-minted paper class and is
+        // deliberately not read at all -- D-0025.
+        assert_eq!(g.listing_class, "series");
+        assert_eq!(d.listing_class, "SERIES");
+        assert_eq!(d.instrument_type, "INSTRUMENT", "not INSTRUMENT_TYPE");
+        assert!(
+            [
+                g.exchange,
+                g.segment,
+                g.underlying,
+                g.trading_symbol,
+                g.instrument_type,
+                g.listing_class,
+                g.isin,
+                g.expiry,
+                g.strike,
+                d.exchange,
+                d.segment,
+                d.underlying,
+                d.trading_symbol,
+                d.instrument_type,
+                d.listing_class,
+                d.isin,
+                d.expiry,
+                d.strike,
+            ]
+            .iter()
+            .all(|n| *n != "INSTRUMENT_TYPE"),
+            "the measurably-wrong column must not be read by any field"
+        );
+        assert_eq!(g.isin, "isin");
+        assert_eq!(d.isin, "ISIN");
+        assert_eq!(g.option_side, None, "Groww types CE and PE directly");
+        assert_eq!(d.option_side, Some("OPTION_TYPE"));
+        assert_ne!(g, d);
+    }
+
+    #[test]
+    fn a_vendor_set_is_a_set_and_every_vendor_has_its_own_bit() {
+        let mut s = VendorSet::EMPTY;
+        assert!(s.is_empty());
+        for v in Vendor::ALL {
+            assert!(!s.contains(v));
+            s = s.with(v);
+            assert!(s.contains(v));
+        }
+        assert!(!s.is_empty());
+        assert_eq!(s, s.with(Vendor::Groww), "adding twice is adding once");
+        assert_eq!(VendorSet::default(), VendorSet::EMPTY);
+        // One bit each, or two vendors would be indistinguishable.
+        let only_dhan = VendorSet::EMPTY.with(Vendor::Dhan);
+        assert!(only_dhan.contains(Vendor::Dhan));
+        assert!(!only_dhan.contains(Vendor::Groww));
     }
 }

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name         = "store"
+version      = { workspace = true }
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+publish      = { workspace = true }
+description  = "The fixed-stride bar file: bytes on disk, addressed by arithmetic."
+
+[dependencies]
+# The lib target is `brutex_core`, and it MUST be referred to by that name.
+# Depending on it under the key `core` shadows the sysroot crate inside
+# rustdoc's generated doc-test harness, which itself references
+# `core::result` and `core::fmt` -- so every doc-test in this crate fails to
+# compile with "cannot find `result` in `core`". Proven twice now: once in
+# crates/core itself, once here.
+brutex_core = { path = "../core", package = "core", version = "0.1.0" }
+
+# ---------------------------------------------------------------------------
+# There is no checksum dependency, on purpose.
+#
+# `crc32c` is listed in the workspace dependency table, but taking it here
+# would add a package to Cargo.lock during a session in which another workflow
+# is editing a second crate's manifest, and CI gate 4 builds `--locked
+# --offline`. The polynomial is four lines of arithmetic (`src/crc.rs`) and is
+# verified against the published check value for `b"123456789"`, so the
+# dependency buys nothing this crate cannot prove about itself.
+# ---------------------------------------------------------------------------
+
+[lints]
+workspace = true

--- a/crates/store/src/block.rs
+++ b/crates/store/src/block.rs
@@ -1,0 +1,140 @@
+//! The per-block checksum: what turns a lost write into a refusal.
+//!
+//! # Why this module exists
+//!
+//! [`crate::format::FLAG_CHECKSUMS`] was declared and never implemented, which
+//! left a real hole rather than a missing feature. The header commit's whole
+//! crash argument assumes the appended records reach stable storage before the
+//! slot write. When that assumption is broken — and it is the *likely* break,
+//! because page 0 is re-dirtied on every commit and is therefore the hottest
+//! writeback candidate in the file — the header names records whose bytes are
+//! zeros from a newly allocated extent.
+//!
+//! Nothing in the record can detect that. An all-zero [`crate::format::Bar`]
+//! satisfies `ohlc_is_sane`, and its `open_interest` of zero is a **real**
+//! zero rather than [`crate::format::OI_NULL`], so a spot-index file quietly
+//! acquires derivative-shaped bars that go on to enter a sweep. A checksum
+//! taken when the records were written is the only thing that can say those
+//! bytes are not the bytes that were committed.
+//!
+//! # The domain is the committed prefix, not the nominal block
+//!
+//! [`Layout::covered_byte_range`] is the range, and both sides derive it from
+//! the same `n_valid`. The tail block of a file holds only the records the
+//! counter covers, so checksumming its nominal 4088 bytes would read past EOF
+//! for 72 of every 73 states a file passes through. A writer recomputes the
+//! tail block's checksum on every commit that lands in it; a reader verifies
+//! against the `n_valid` it read from the header. Same counter, same length,
+//! same answer — `CLAUDE.md` §3 rule 5.
+//!
+//! # No I/O
+//!
+//! This module takes bytes and returns numbers. The sidecar file it feeds is
+//! [`crate::path::FileKind::Checksums`]; reading and writing it belongs to a
+//! writer that does not exist yet.
+
+use crate::crc::crc32c;
+use crate::format::FormatError;
+use crate::header::Header;
+use crate::layout::Layout;
+
+/// The checksum a writer stores for `block`, given that block's bytes.
+///
+/// `bytes` must be exactly the range [`Layout::covered_byte_range`] names for
+/// this block under this counter — offering more or fewer is refused rather
+/// than trimmed, because a checksum over the wrong length is a number that
+/// will never match again and nobody will know why.
+///
+/// # Errors
+///
+/// [`FormatError::BlockNotCommitted`] for a block past the counter,
+/// [`FormatError::BlockLengthMismatch`] when `bytes` is not the covered
+/// length, or [`FormatError::OffsetOverflow`] from the geometry.
+///
+/// # Examples
+///
+/// ```
+/// # use store::{block, format::FormatError, layout::Layout};
+/// let v2 = Layout::V2;
+/// // One record committed: the tail block covers exactly that record.
+/// let record = [7u8; 56];
+/// let sealed = block::seal(v2, 1, 0, &record)?;
+/// assert_eq!(block::seal(v2, 1, 0, &record)?, sealed, "idempotent");
+/// // The same bytes at a length the geometry does not give the block.
+/// assert!(block::seal(v2, 1, 0, &[7u8; 55]).is_err());
+/// # Ok::<(), FormatError>(())
+/// ```
+pub fn seal(layout: Layout, n_valid: u64, block: u64, bytes: &[u8]) -> Result<u32, FormatError> {
+    let need = covered_len(layout, n_valid, block)?;
+    let len = byte_count(bytes);
+    if len != need {
+        return Err(FormatError::BlockLengthMismatch {
+            block,
+            len: bytes.len(),
+            need,
+        });
+    }
+    Ok(crc32c(bytes.iter().copied()))
+}
+
+/// Verifies one block's committed bytes against its stored checksum.
+///
+/// # Errors
+///
+/// [`FormatError::ChecksumsAbsent`] when the header does not declare
+/// checksums — "verified" and "there was nothing to verify against" are
+/// different answers and this refuses to conflate them.
+/// [`FormatError::BlockChecksum`] naming the block and both numbers when the
+/// bytes are not the bytes that were sealed. Plus anything [`seal`] refuses.
+///
+/// # Examples
+///
+/// ```
+/// # use store::{block, format::{FLAG_CHECKSUMS, FormatError}, header::Header, layout::Layout};
+/// let v2 = Layout::V2;
+/// let header = Header::genesis(1, 60, FLAG_CHECKSUMS).advance(1, 100, 100)?;
+/// let record = [7u8; 56];
+/// let sealed = block::seal(v2, header.n_valid, 0, &record)?;
+/// assert_eq!(block::verify(&header, v2, 0, &record, sealed), Ok(()));
+///
+/// // The write was lost and the extent reads as zeros. The bar is "sane"
+/// // and its open interest is a real zero; only the checksum knows.
+/// assert!(block::verify(&header, v2, 0, &[0u8; 56], sealed).is_err());
+/// # Ok::<(), FormatError>(())
+/// ```
+pub fn verify(
+    header: &Header,
+    layout: Layout,
+    block: u64,
+    bytes: &[u8],
+    stored: u32,
+) -> Result<(), FormatError> {
+    if !header.checksums_present() {
+        return Err(FormatError::ChecksumsAbsent);
+    }
+    let computed = seal(layout, header.n_valid, block, bytes)?;
+    if computed == stored {
+        Ok(())
+    } else {
+        Err(FormatError::BlockChecksum {
+            block,
+            stored,
+            computed,
+        })
+    }
+}
+
+/// How many bytes `block` covers under `n_valid`.
+fn covered_len(layout: Layout, n_valid: u64, block: u64) -> Result<u64, FormatError> {
+    let (start, end) = layout.covered_byte_range(block, n_valid)?;
+    Ok(end - start)
+}
+
+/// The length of `bytes` as a `u64`, without a cast this workspace denies.
+///
+/// Counted rather than converted: `usize`→`u64` is a widening cast on every
+/// target this builds for, so a checked conversion would carry a failure arm
+/// no test could ever reach, and coverage would never close.
+fn byte_count(bytes: &[u8]) -> u64 {
+    bytes.iter().fold(0u64, |seen, _| seen.saturating_add(1))
+}

--- a/crates/store/src/crc.rs
+++ b/crates/store/src/crc.rs
@@ -1,0 +1,61 @@
+//! CRC-32C (Castagnoli) — the one checksum this store computes.
+//!
+//! # Why the polynomial lives here rather than in a dependency
+//!
+//! The whole function is four lines of arithmetic and it is *checkable*: every
+//! published description of this polynomial carries the same check value for
+//! the input `b"123456789"`, and [`CHECK_VALUE`] is asserted against this
+//! implementation by `store::unit::the_crc_matches_the_published_check_value`.
+//! A dependency would have to be taken on faith unless the same check ran
+//! anyway.
+//!
+//! # Why CRC at all
+//!
+//! `docs/05-decisions.md` D-0005. A flipped bit in a raw `i64` price yields a
+//! *different, plausible* price. There is no parse to fail and no structure to
+//! violate, so without a checksum the corruption is silent, permanent, and
+//! inherited by every result derived from it.
+
+/// The reflected CRC-32C generator polynomial: `0x1EDC_6F41`, bit-reversed.
+///
+/// Reflected form is used because the loop shifts right, which is what makes
+/// it a shift and a mask rather than a bit-order fixup per byte.
+const POLYNOMIAL: u32 = 0x82F6_3B78;
+
+/// CRC-32C of `b"123456789"`.
+///
+/// This is the check value that identifies the Castagnoli polynomial. It is a
+/// published constant, not a value read out of this implementation — the test
+/// that compares them therefore verifies the code, not the constant.
+pub const CHECK_VALUE: u32 = 0xE306_9283;
+
+/// CRC-32C over a byte stream.
+///
+/// Takes an iterator rather than a slice so a caller can check a
+/// *discontiguous* range without copying — the header slot checksums every
+/// byte of its slot except the four bytes holding the checksum itself, which
+/// is two slices and one allocation if this took `&[u8]`.
+///
+/// # Examples
+///
+/// ```
+/// # use store::crc::{crc32c, CHECK_VALUE};
+/// assert_eq!(crc32c(*b"123456789"), CHECK_VALUE);
+/// ```
+#[must_use]
+pub fn crc32c<I>(bytes: I) -> u32
+where
+    I: IntoIterator<Item = u8>,
+{
+    let mut crc = u32::MAX;
+    for byte in bytes {
+        crc ^= u32::from(byte);
+        for _ in 0..8u8 {
+            // `0 - (crc & 1)` is all-ones when the low bit is set and all-zeros
+            // when it is not, so the polynomial is applied without a branch.
+            let mask = 0u32.wrapping_sub(crc & 1);
+            crc = (crc >> 1) ^ (POLYNOMIAL & mask);
+        }
+    }
+    !crc
+}

--- a/crates/store/src/format.rs
+++ b/crates/store/src/format.rs
@@ -1,0 +1,469 @@
+//! The record, the shared constants, and every error the bytes can produce.
+//!
+//! ```text
+//! byte 0                 32768                                      EOF
+//!   ├──── header region ────┼─── record 0 ─┼─── record 1 ─┼── … ───────┤
+//!    2 slots × 16384 spacing    56 bytes       56 bytes
+//! ```
+//!
+//! **Address of record *i*: `header_len + i·stride`.** An add, a multiply, a
+//! load. No search, no decode, no allocation — which is the entire reason the
+//! format exists and the only thing that makes bar lookup O(1).
+//!
+//! The two numbers in that formula are **not** read from this module by the
+//! read path. They come from [`crate::layout::Layout`], selected by the file's
+//! own `format_version`. The constants here are version 2's definition, and
+//! `store::unit::the_constants_are_the_current_versions_layout` pins them to
+//! it.
+//!
+//! # Why this is version 2 and not an edited version 1
+//!
+//! `CLAUDE.md` §3 rule 8: *store format versions are never mutated in place*.
+//! Version 1 — the geometry `docs/02-store-format.md` described before this
+//! change — had a **64-byte header region holding one slot**, an 8-byte
+//! `header_crc` at offset 48 covering bytes 0..48, and a byte-addressed
+//! 4096-byte checksum block. Every one of those numbers is different now: the
+//! header region is two slots spaced a failure unit apart, the checksum is
+//! four bytes at offset 56 covering everything except itself, a `generation`
+//! field was inserted at offset 16, and the block is counted in records.
+//!
+//! Keeping `MAGIC = b"BRUTEXB1"` and `FORMAT_VERSION = 1` across that would
+//! make two incompatible geometries answer to one number, which is precisely
+//! what [`crate::layout`]'s dispatch exists to make impossible. So the change
+//! mints a version: [`MAGIC`] is `b"BRUTEXB2"` and [`FORMAT_VERSION`] is 2.
+//!
+//! Version 1 is **retired**, not deleted — see [`RETIRED_VERSIONS`]. It is
+//! refused by number, naming the reason, so a version-1 file is never read at
+//! version 2's offsets and never reported as a destroyed header.
+
+use brutex_core::price::Paisa;
+
+/// Bytes of fields in one header slot. A **family** constant: every format
+/// version fills 64 bytes at the start of its slot.
+///
+/// This is what makes a header self-describing without knowing its version
+/// first. A reader that cannot yet know the layout still knows where each slot
+/// begins and how much of it to checksum, so it can decode whichever slots
+/// survived a crash and let the magic and version inside them decide the rest.
+/// Freezing the slot size is the price of that bootstrap, and it is cheap: a
+/// new field takes reserved space in a new version, never more slot.
+pub const SLOT_LEN: usize = 64;
+
+/// Bytes from the start of one header slot to the start of the next. A
+/// **family** constant, for the same bootstrap reason as [`SLOT_LEN`].
+///
+/// # Why 16384 and not 64
+///
+/// The two-slot header is only worth having if a write to one slot cannot
+/// damage the other. Storage does not fail at byte granularity: the smallest
+/// unit a device programs or a filesystem writes back is a block or a page,
+/// and a partially programmed unit takes **everything in it** with it. At
+/// 64-byte spacing both slots share one such unit, so the redundancy is
+/// nominal — which is exactly why ext4 and F2FS separate their redundant
+/// superblocks and checkpoint packs by whole blocks rather than by bytes.
+///
+/// Measured on the two hosts this repository runs on:
+///
+/// | Host | Device block | Page |
+/// |---|---|---|
+/// | Apple M4 Pro, macOS, APFS (`diskutil info /`, `sysctl hw.pagesize`) | 4096 | 16384 |
+/// | GitHub CI runner, `x86_64` Linux, ext4 | 4096 | 4096 |
+///
+/// 16384 is the largest of those, so one slot per 16384 bytes puts the two
+/// slots in different failure units on **both** hosts. It is a constant rather
+/// than a query of the host, because a geometry that differed between the two
+/// would make the same bytes verify differently on each — `CLAUDE.md` §3
+/// rule 5, the same argument that rejected a page-sized [`BLOCK_LEN`].
+///
+/// *Rejected — 4096.* It equals the device block on both hosts but is smaller
+/// than this machine's 16384-byte page, and page-granular writeback is a real
+/// failure unit. The saving is 16 KiB per file, against a month file of
+/// roughly 440 KiB.
+///
+/// **Honest limit:** this separates the slots by every unit that was measured.
+/// It is not a proof. A failure whose granularity exceeds 16384 bytes — an
+/// erase block, a dead device — takes both slots, and no arrangement inside
+/// one file survives that. See the limits this crate reports.
+pub const SLOT_STRIDE: u64 = 16_384;
+
+/// The most header slots any version may declare. A **family** bound.
+///
+/// [`crate::header::Header::read_region`] must know how much of a buffer can
+/// possibly be header before it knows the version, or a long buffer lets
+/// record bytes audition as header slots. This is that bound.
+pub const MAX_SLOT_COUNT: u64 = 2;
+
+/// [`MAX_SLOT_COUNT`] as a `usize`, for iterator bounds.
+///
+/// Written as a literal in both widths rather than converted: this workspace
+/// denies casts that can truncate, and a fallible conversion here would have a
+/// failure arm no test could ever reach. The assertion below keeps the two
+/// honest.
+pub const MAX_SLOTS: usize = 2;
+
+const _: () = assert!(MAX_SLOT_COUNT == 2 && MAX_SLOTS == 2);
+
+/// The seven bytes shared by every version's magic.
+///
+/// Checked before the version is, so a file that is not a bar file at all is
+/// named as such instead of being reported as an absurd version number.
+pub const MAGIC_FAMILY: [u8; 7] = *b"BRUTEXB";
+
+/// Identifies a version-2 bar file.
+pub const MAGIC: [u8; 8] = *b"BRUTEXB2";
+
+/// The only format version this build writes.
+pub const FORMAT_VERSION: u16 = 2;
+
+/// Versions that existed and are no longer readable by this build.
+///
+/// Version 1 described a 64-byte single-slot header with an 8-byte checksum at
+/// offset 48 and a byte-addressed 4096-byte block. That header shape is not
+/// this one, so decoding a version-1 file with this decoder would lift every
+/// field from the wrong offset.
+///
+/// It is listed rather than forgotten so the refusal can say *why*. A version
+/// that is merely absent from [`crate::layout::Layout::KNOWN`] reports
+/// [`FormatError::UnknownVersion`], which reads as "this file is from the
+/// future"; a retired version reports [`FormatError::RetiredVersion`], which
+/// is the truth. `CLAUDE.md` §3 rule 8 makes the number append-only: it is
+/// never reused for a different geometry.
+///
+/// No version-1 file can exist — version 1 never had a reader or a writer in
+/// this repository, only constants. The entry costs one comparison and removes
+/// the only way this build could misread one if that assumption is wrong.
+///
+/// A fixed-size array rather than a slice so the retirement test can be a
+/// `const fn` that destructures it: retiring a second version changes the
+/// length, which is a compile error at every destructuring site rather than a
+/// silent drift.
+pub const RETIRED_VERSIONS: [u16; 1] = [1];
+
+/// Version 2: bytes of header region before the first record.
+///
+/// [`MAX_SLOT_COUNT`] slots at [`SLOT_STRIDE`] spacing. One slot could not be
+/// updated atomically — see [`crate::header`].
+///
+/// Spelled as a literal rather than the product because that product needs a
+/// `usize`→`u64` cast, and this workspace denies casts that can truncate.
+/// `store::unit::the_constants_are_the_current_versions_layout` proves the
+/// relationship instead, with a checked conversion.
+pub const HEADER_LEN: u64 = 32_768;
+
+/// Version 2: header slots. Writes alternate between them.
+pub const SLOT_COUNT: u64 = 2;
+
+/// Version 2: bytes per record. Read it from the layout; never assume it.
+pub const RECORD_STRIDE: u64 = 56;
+
+/// Version 2: whole records covered by one checksum block.
+pub const RECORDS_PER_BLOCK: u64 = 73;
+
+/// Version 2: bytes per checksummed block.
+///
+/// A whole multiple of [`RECORD_STRIDE`], which is the entire point: a record
+/// cannot begin in one block and end in the next, so verifying it needs one
+/// checksum and never two. See [`crate::layout`].
+pub const BLOCK_LEN: u64 = RECORD_STRIDE * RECORDS_PER_BLOCK;
+
+const _: () = assert!(BLOCK_LEN.is_multiple_of(RECORD_STRIDE));
+const _: () = assert!(BLOCK_LEN / RECORD_STRIDE == RECORDS_PER_BLOCK);
+const _: () = assert!(RECORDS_PER_BLOCK > 0);
+const _: () = assert!(HEADER_LEN == SLOT_COUNT * SLOT_STRIDE);
+const _: () = assert!(SLOT_COUNT <= MAX_SLOT_COUNT);
+const _: () = assert!(BLOCK_LEN == 4088);
+const _: () = assert!(SLOT_STRIDE >= 16_384);
+
+/// Bit 0 of [`Header::flags`]: per-block checksums are present.
+///
+/// A file that sets it carries a sidecar of one [`crate::block`] checksum per
+/// block; a file that does not carries none, and a reader must say so rather
+/// than reporting an unverified block as verified.
+///
+/// [`Header::flags`]: crate::header::Header::flags
+pub const FLAG_CHECKSUMS: u32 = 1;
+
+/// Open interest is absent, as opposed to genuinely zero.
+///
+/// Spot indices carry no open interest and store this sentinel. Conflating it
+/// with a real `0` would make a derivative series and an index series
+/// indistinguishable on a field that decides which is which.
+pub const OI_NULL: i64 = i64::MIN;
+
+/// One bar. Seven `i64`, 56 bytes, no padding.
+///
+/// `#[repr(C)]` fixes the field order so the layout is the format rather than
+/// a compiler choice. The assertions below are compile errors, not tests —
+/// `docs/04-invariants.md` S-01.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Bar {
+    /// Microseconds since the Unix epoch, UTC. The **open** of the bar's
+    /// interval — verified against 1,706,290 lake bars, not assumed.
+    pub ts_micros: i64,
+    /// Open, in paisa.
+    pub open: i64,
+    /// High, in paisa.
+    pub high: i64,
+    /// Low, in paisa.
+    pub low: i64,
+    /// Close, in paisa.
+    pub close: i64,
+    /// Contracts or shares. `0` is a real zero, not an absence.
+    pub volume: i64,
+    /// Open interest, or [`OI_NULL`] when absent.
+    pub open_interest: i64,
+}
+
+const _: () = assert!(size_of::<Bar>() == 56);
+const _: () = assert!(align_of::<Bar>() == 8);
+const _: () = assert!(RECORD_STRIDE == 56);
+
+impl Bar {
+    /// Whether open interest is absent rather than zero.
+    #[must_use]
+    pub const fn oi_is_null(&self) -> bool {
+        self.open_interest == OI_NULL
+    }
+
+    /// Open interest as a value, or `None` when absent.
+    #[must_use]
+    pub const fn oi(&self) -> Option<i64> {
+        if self.oi_is_null() {
+            None
+        } else {
+            Some(self.open_interest)
+        }
+    }
+
+    /// Whether the OHLC values are internally consistent.
+    ///
+    /// Checked at the write boundary, never at read: a file that already holds
+    /// an impossible bar is corrupt, and the CRC is what detects that. This
+    /// exists so an impossible bar never reaches the disk in the first place.
+    ///
+    /// Note what it deliberately does **not** claim: an all-zero record
+    /// satisfies it. Zeros are a legal flat bar with a real open interest of
+    /// zero, so this can never distinguish a bar from a lost write. That is
+    /// [`crate::block`]'s job, and it is why `FLAG_CHECKSUMS` is not
+    /// decoration.
+    #[must_use]
+    pub const fn ohlc_is_sane(&self) -> bool {
+        let hi_ok = self.high >= self.open && self.high >= self.low && self.high >= self.close;
+        let lo_ok = self.low <= self.open && self.low <= self.close;
+        hi_ok && lo_ok
+    }
+
+    /// The close, as a price.
+    #[must_use]
+    pub const fn close_price(&self) -> Paisa {
+        Paisa::from_raw(self.close)
+    }
+}
+
+/// Something about the bytes is wrong.
+///
+/// Every variant names the value it saw. A refusal that does not say what it
+/// refused sends the reader back to a hex dump, which is where a "just retry
+/// it" habit comes from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum FormatError {
+    /// A byte offset would not fit in `u64`.
+    ///
+    /// Refused rather than wrapped: a wrapped offset addresses a *different,
+    /// valid-looking* record.
+    OffsetOverflow,
+    /// A slot buffer is shorter than [`SLOT_LEN`].
+    SlotTooShort {
+        /// Bytes the caller supplied.
+        len: usize,
+    },
+    /// The header region is shorter than its version's slot count demands.
+    ///
+    /// A short region silently returns whichever older commit happened to fit,
+    /// which is a fallback that hides a failure. Refused instead.
+    HeaderRegionTooShort {
+        /// Whole slots the region actually holds.
+        slots: u64,
+        /// Whole slots the version declares.
+        need: u64,
+    },
+    /// The first seven bytes are not [`MAGIC_FAMILY`].
+    NotABarFile,
+    /// The header names a version this build does not know.
+    ///
+    /// Refused rather than guessed: `docs/02-store-format.md` mints a new
+    /// version for every layout change precisely so old files stay readable at
+    /// their own stride, and guessing defeats that.
+    UnknownVersion(u16),
+    /// The header names a version this build knows of and cannot decode.
+    ///
+    /// Distinct from [`FormatError::UnknownVersion`] because the two send an
+    /// operator to opposite places: an unknown version means the file is newer
+    /// than the build, a retired one means it is older. See
+    /// [`RETIRED_VERSIONS`].
+    RetiredVersion(u16),
+    /// The magic's version byte disagrees with the `format_version` field.
+    ///
+    /// Two independent statements of the same fact; when they differ the file
+    /// is not what either of them claims.
+    MagicVersionMismatch(u16),
+    /// The header names a stride other than the one its version defines.
+    StrideMismatch(u16),
+    /// The file is shorter than its version's header region.
+    TooShortForHeader,
+    /// `n_valid` claims more records than the file can hold.
+    ///
+    /// Trusting the counter over the file length would read past the end and
+    /// return whatever bytes happened to be there.
+    CounterExceedsFile,
+    /// Appending would push `n_valid` past `u64::MAX`.
+    CounterOverflow,
+    /// The generation counter cannot be advanced again.
+    ///
+    /// Refused rather than wrapped, because a wrapped generation would make
+    /// the *oldest* slot win and silently un-commit records.
+    GenerationExhausted,
+    /// An append's timestamps do not follow the records already committed.
+    ///
+    /// Bars are append-only in time. A batch that begins at or before the
+    /// file's last timestamp is a re-pull landing on top of newer data, which
+    /// no checksum can detect afterwards because the bytes are well formed.
+    TimestampsOutOfOrder {
+        /// The last timestamp already committed, or the batch's own first.
+        previous: i64,
+        /// The timestamp that did not follow it.
+        next: i64,
+    },
+    /// A slot's stored checksum does not match its bytes.
+    SlotChecksum {
+        /// The checksum the slot carries.
+        stored: u32,
+        /// The checksum its bytes actually produce.
+        computed: u32,
+    },
+    /// A block's stored checksum does not match its bytes.
+    BlockChecksum {
+        /// Which block.
+        block: u64,
+        /// The checksum the sidecar carries.
+        stored: u32,
+        /// The checksum the block's committed bytes actually produce.
+        computed: u32,
+    },
+    /// A block index past the last block the commit counter covers.
+    ///
+    /// Verifying it would checksum bytes nobody committed and report the
+    /// result as if it meant something.
+    BlockNotCommitted {
+        /// The block asked for.
+        block: u64,
+        /// How many blocks the counter covers.
+        blocks: u64,
+    },
+    /// A caller offered a block's bytes at a length the geometry does not give
+    /// that block.
+    BlockLengthMismatch {
+        /// Which block.
+        block: u64,
+        /// Bytes the caller supplied.
+        len: usize,
+        /// Bytes the block covers under the current commit counter.
+        need: u64,
+    },
+    /// The file declares no block checksums, so a block cannot be verified.
+    ///
+    /// Reported rather than passed: "verified" and "there was nothing to
+    /// verify against" are not the same answer.
+    ChecksumsAbsent,
+    /// A slot's generation says it should live in a different slot.
+    ///
+    /// A writer that puts a commit in the wrong slot can overwrite the only
+    /// surviving copy of the previous one, so this is refused rather than
+    /// tolerated.
+    SlotPositionMismatch {
+        /// Where `generation % slot_count` says it belongs.
+        expected: u64,
+        /// Where it was found.
+        found: u64,
+    },
+    /// A declared layout is not a geometry a file could have.
+    ///
+    /// Refused at declaration rather than guarded at every use: a zero
+    /// `records_per_block` is a division fault, and a header region that is
+    /// not a whole number of slots puts a slot at an offset no reader looks
+    /// at.
+    DegenerateLayout {
+        /// Which field of the declaration is impossible.
+        field: &'static str,
+    },
+    /// No slot in the header region decoded.
+    ///
+    /// Not a torn tail — a torn tail is unobservable. This means every copy of
+    /// the header is damaged, and there is nothing to fall back to that would
+    /// not be a guess.
+    NoValidHeader,
+}
+
+impl std::fmt::Display for FormatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::OffsetOverflow => f.write_str("record offset overflows u64"),
+            Self::SlotTooShort { len } => {
+                write!(f, "header slot is {len} bytes, needs {SLOT_LEN}")
+            }
+            Self::HeaderRegionTooShort { slots, need } => {
+                write!(f, "header region holds {slots} whole slots, needs {need}")
+            }
+            Self::NotABarFile => f.write_str("magic does not begin BRUTEXB"),
+            Self::UnknownVersion(v) => write!(f, "unknown format version {v}"),
+            Self::RetiredVersion(v) => {
+                write!(f, "format version {v} is retired and cannot be decoded")
+            }
+            Self::MagicVersionMismatch(v) => {
+                write!(f, "magic does not belong to format version {v}")
+            }
+            Self::StrideMismatch(s) => write!(f, "record stride {s} is not the version's stride"),
+            Self::TooShortForHeader => f.write_str("file is shorter than its header region"),
+            Self::CounterExceedsFile => {
+                f.write_str("n_valid claims more records than the file holds")
+            }
+            Self::CounterOverflow => f.write_str("n_valid would overflow u64"),
+            Self::GenerationExhausted => f.write_str("header generation cannot advance past u64"),
+            Self::TimestampsOutOfOrder { previous, next } => {
+                write!(f, "timestamp {next} does not follow {previous}")
+            }
+            Self::SlotChecksum { stored, computed } => {
+                write!(f, "header slot checksum {stored:#010x} != {computed:#010x}")
+            }
+            Self::BlockChecksum {
+                block,
+                stored,
+                computed,
+            } => write!(
+                f,
+                "block {block} checksum {stored:#010x} != {computed:#010x}"
+            ),
+            Self::BlockNotCommitted { block, blocks } => {
+                write!(f, "block {block} is past the {blocks} blocks committed")
+            }
+            Self::BlockLengthMismatch { block, len, need } => {
+                write!(f, "block {block} was offered {len} bytes, covers {need}")
+            }
+            Self::ChecksumsAbsent => f.write_str("the file declares no block checksums"),
+            Self::SlotPositionMismatch { expected, found } => {
+                write!(
+                    f,
+                    "header slot {found} holds a commit belonging in {expected}"
+                )
+            }
+            Self::DegenerateLayout { field } => {
+                write!(f, "layout field {field} is not a geometry a file can have")
+            }
+            Self::NoValidHeader => f.write_str("no header slot survived; the header is unreadable"),
+        }
+    }
+}
+
+impl std::error::Error for FormatError {}

--- a/crates/store/src/header.rs
+++ b/crates/store/src/header.rs
@@ -511,7 +511,7 @@ impl Header {
     /// # Ok::<(), FormatError>(())
     /// ```
     pub fn read_region(region: &[u8], file_len: u64) -> Result<Self, FormatError> {
-        let (mut header, mut layout) = best_candidate(region, None)?;
+        let (header, layout) = best_candidate(region, None)?;
 
         let slots = whole_slots(region);
         if slots < layout.slot_count() {
@@ -521,18 +521,27 @@ impl Header {
             });
         }
 
-        loop {
-            match header.validate(layout, file_len) {
-                Ok(()) => return Ok(header),
-                Err(refusal) => match best_candidate(region, Some(header.generation)) {
-                    Ok((older, older_layout)) => {
-                        header = older;
-                        layout = older_layout;
-                    }
-                    Err(_) => return Err(refusal),
-                },
+        // Newest first, at most one candidate per slot position. Bounded by
+        // the family slot count rather than by the generation strictly
+        // decreasing: a loop that leaned on the comparison would *hang* rather
+        // than fail if that comparison ever stopped being strict, and a hang
+        // is the one failure a test suite cannot report.
+        let mut newest = Some((header, layout));
+        let mut refusal = FormatError::NoValidHeader;
+        for _ in 0..MAX_SLOTS {
+            let Some((candidate, geometry)) = newest else {
+                return Err(refusal);
+            };
+            match candidate.validate(geometry, file_len) {
+                Ok(()) => return Ok(candidate),
+                Err(refused) => refusal = refused,
             }
+            // The "no older candidate" error is dropped on purpose: the
+            // refusal from the newest slot that decoded says more about the
+            // file than "nothing else was there".
+            newest = best_candidate(region, Some(candidate.generation)).ok();
         }
+        Err(refusal)
     }
 
     /// The 64-byte slot image for this header, checksum computed.
@@ -575,32 +584,34 @@ impl Header {
 /// would diagnose an intact file from another version as a destroyed header.
 fn best_candidate(region: &[u8], below: Option<u64>) -> Result<(Header, Layout), FormatError> {
     let mut fault: Option<FormatError> = None;
-    let mut best: Option<(Header, Layout)> = None;
 
-    for (index, chunk) in (0u64..).zip(region.chunks(SLOT_STRIDE_LEN).take(MAX_SLOTS)) {
-        match Header::decode_parts(chunk) {
+    // `max_by_key` rather than a hand-written comparison: two positionally
+    // valid slots can never share a generation, so `>` and `>=` would behave
+    // identically there and no test could tell them apart.
+    let best = (0u64..)
+        .zip(region.chunks(SLOT_STRIDE_LEN).take(MAX_SLOTS))
+        .filter_map(|(index, chunk)| match Header::decode_parts(chunk) {
             Err(refusal) => {
                 if is_specific(refusal) {
                     fault.get_or_insert(refusal);
                 }
+                None
             }
             Ok((header, layout)) => {
                 let expected = header.generation % layout.slot_count();
                 if index == expected {
-                    if below.is_none_or(|limit| header.generation < limit)
-                        && best.is_none_or(|(seen, _)| header.generation > seen.generation)
-                    {
-                        best = Some((header, layout));
-                    }
+                    Some((header, layout))
                 } else {
                     fault.get_or_insert(FormatError::SlotPositionMismatch {
                         expected,
                         found: index,
                     });
+                    None
                 }
             }
-        }
-    }
+        })
+        .filter(|(header, _)| below.is_none_or(|limit| header.generation < limit))
+        .max_by_key(|(header, _)| header.generation);
 
     best.ok_or(fault.unwrap_or(FormatError::NoValidHeader))
 }
@@ -632,10 +643,15 @@ fn whole_slots(region: &[u8]) -> u64 {
 /// *anywhere* in the 64 bytes is detected — there is no window a corruption
 /// can land in and be called clean. All 512 of them are walked by
 /// `store::fault::a_single_bit_flip_in_any_header_byte_is_detected`.
-fn covered(slot: &[u8]) -> impl Iterator<Item = u8> + '_ {
+///
+/// Takes an array rather than a slice so the tail needs no length: after
+/// skipping to the reserved bytes there are exactly `SLOT_LEN - OFF_RESERVED`
+/// of them left, and a `take` that can never truncate is arithmetic no test
+/// could ever exercise.
+fn covered(slot: &[u8; SLOT_LEN]) -> impl Iterator<Item = u8> + '_ {
     slot.iter()
         .take(OFF_CRC)
-        .chain(slot.iter().skip(OFF_RESERVED).take(SLOT_LEN - OFF_RESERVED))
+        .chain(slot.iter().skip(OFF_RESERVED))
         .copied()
 }
 

--- a/crates/store/src/header.rs
+++ b/crates/store/src/header.rs
@@ -630,8 +630,8 @@ fn whole_slots(region: &[u8]) -> u64 {
 ///
 /// Covering the reserved tail as well as the fields means a flipped bit
 /// *anywhere* in the 64 bytes is detected — there is no window a corruption
-/// can land in and be called clean. `store::fault::a_single_bit_flip_in_any_
-/// header_byte_is_detected` walks all 512 of them.
+/// can land in and be called clean. All 512 of them are walked by
+/// `store::fault::a_single_bit_flip_in_any_header_byte_is_detected`.
 fn covered(slot: &[u8]) -> impl Iterator<Item = u8> + '_ {
     slot.iter()
         .take(OFF_CRC)

--- a/crates/store/src/header.rs
+++ b/crates/store/src/header.rs
@@ -1,0 +1,654 @@
+//! The two-slot header, and the commit that is one write of one unit.
+//!
+//! # What was wrong
+//!
+//! `docs/05-decisions.md` D-0004 makes the commit counter the authority and
+//! publishes it last, so a torn *record* is unobservable. That argument is
+//! sound and it survives here unchanged. What it does not cover is a torn
+//! *header*: publishing a commit meant writing `n_valid`, then
+//! `last_ts_micros`, then `header_crc` as three separate stores. A crash
+//! between any two of them left a header whose checksum did not match its own
+//! counter — and a header that fails its checksum condemns the **whole file**,
+//! not the tail. The counter made the last record safe and the header unsafe.
+//!
+//! # The shape that fixes it
+//!
+//! A header **slot** is 64 bytes carrying every field *and* the checksum over
+//! them. A file holds [`Layout::slot_count`] slots at
+//! [`crate::format::SLOT_STRIDE`] spacing, and commit *g* is written to slot
+//! `g % slot_count`. Consecutive commits therefore never write the same slot,
+//! and a reader takes the valid slot with the highest generation **that the
+//! file's bytes actually support**.
+//!
+//! ```text
+//! byte 0          16384          32768
+//!   ├── slot 0 ─────┼── slot 1 ────┤   generation 4 → slot 0
+//!    generation 4     generation 3     generation 5 → slot 1
+//! ```
+//!
+//! A crash can land in exactly one of three places, and none of them is a
+//! self-inconsistent header:
+//!
+//! | Crash point | What survives | What a reader sees |
+//! |---|---|---|
+//! | before the slot write | both slots whole | generation *g−1*: the records committed before |
+//! | during the slot write | the *other* slot whole | generation *g−1*, because a partial slot fails its own checksum |
+//! | after the slot write | both slots whole | generation *g*: the new records |
+//!
+//! The reader never sees a count that was not committed — only *g−1* or *g*.
+//! `store::fault::a_torn_header_commit_never_reports_an_uncommitted_count`
+//! writes every one of the 65 possible prefixes of a commit image and asserts
+//! exactly that.
+//!
+//! The fourth row of that table is the one that was missing: a slot that is
+//! **whole but unsupported**, because the records it counts never reached the
+//! disk. [`Header::read_region`] falls back to the previous generation for
+//! that case too, instead of condemning the file — see
+//! `store::fault::kill_between_write_and_commit`.
+//!
+//! # Why not the alternatives
+//!
+//! **One aligned word holding counter, timestamp and checksum.** Arithmetically
+//! impossible: those are 8 + 8 + 4 bytes and a machine word is 8. Making them
+//! fit means truncating the timestamp, which is a fabrication in the one field
+//! a range reject depends on.
+//!
+//! **The counter as the only authority, everything else derived.** It still
+//! needs one 8-byte store to be atomic across a power loss, which is a
+//! property of the device, not of this program — "in practice atomic" is not a
+//! measurement. It also derives `last_ts_micros` by reading record
+//! `n_valid − 1`, which cannot be trusted until its block checksum is
+//! verified, which needs a header. A dependency loop on the open path.
+//!
+//! # The three assumptions, named rather than assumed
+//!
+//! An earlier version of this module claimed two slots assume "only that a
+//! write to slot A cannot damage slot B … they are disjoint byte ranges, so
+//! that is true on any device". **That was false.** Storage does not fail at
+//! byte granularity; it fails at a block or a page, and two slots 64 bytes
+//! apart share one of those. The three assumptions the crash table really
+//! rests on are:
+//!
+//! 1. **A write to one slot cannot damage another.** Now structural:
+//!    [`crate::format::SLOT_STRIDE`] is 16384 bytes, which is at least the
+//!    device block *and* the page size measured on both hosts this repository
+//!    builds on. Residual limit: a failure coarser than 16384 bytes takes both
+//!    slots, and no arrangement inside one file survives that.
+//! 2. **The appended records are durable before the slot write.** Now carried
+//!    by the type: [`Commit::durable_through`] is the byte offset a writer
+//!    must have flushed before it issues the slot write. This crate performs
+//!    no I/O and cannot issue the barrier itself, so it states the offset
+//!    instead of leaving the requirement in prose. When the requirement is
+//!    broken anyway, [`Header::read_region`] falls back to the previous
+//!    generation rather than handing back uncommitted bytes, and
+//!    [`crate::block`] is what detects the records that were lost.
+//! 3. **Exactly one writer per file.** Two writers reading the same generation
+//!    produce the same slot at the same offset and the same record range.
+//!    Nothing in this crate can enforce that — an exclusive lock is I/O — so
+//!    it is a documented precondition of [`Header::commit`], the lock file has
+//!    a name in the path type ([`crate::path::FileKind::Lock`]), and the gap
+//!    is reported as a limit rather than implied away.
+//!
+//! # It is still a read-only mapping plus `pwrite`
+//!
+//! Nothing here writes. [`Header::commit`] returns a [`Commit`] — one offset
+//! and one 64-byte buffer — which a writer hands to a single positional write.
+//! A writable mapping remains banned: it raises `SIGBUS` on a full disk, and a
+//! signal cannot be caught. **There is no API in this module that can update
+//! two header fields in two writes**, because a `Commit` carries one offset
+//! and one buffer and there is no other way to produce header bytes.
+//!
+//! [`Header::decode`] takes its own 64-byte copy of a slot before it checksums
+//! anything, so a caller may hand it a `MAP_SHARED` mapping that a writer is
+//! concurrently `pwrite`-ing: the checksum covers exactly the bytes the
+//! returned `Header` is built from, and a copy that caught a write mid-flight
+//! fails that checksum rather than returning half of each.
+
+use crate::crc::crc32c;
+use crate::format::{FLAG_CHECKSUMS, FormatError, MAGIC_FAMILY, MAX_SLOTS, SLOT_LEN, SLOT_STRIDE};
+use crate::layout::Layout;
+
+/// Byte offset of `magic` within a slot.
+const OFF_MAGIC: usize = 0;
+/// Byte offset of `format_version` within a slot.
+const OFF_VERSION: usize = 8;
+/// Byte offset of `record_stride` within a slot.
+const OFF_STRIDE: usize = 10;
+/// Byte offset of `flags` within a slot.
+const OFF_FLAGS: usize = 12;
+/// Byte offset of `generation` within a slot.
+const OFF_GENERATION: usize = 16;
+/// Byte offset of `n_valid` within a slot.
+const OFF_N_VALID: usize = 24;
+/// Byte offset of `first_ts_micros` within a slot.
+const OFF_FIRST_TS: usize = 32;
+/// Byte offset of `last_ts_micros` within a slot.
+const OFF_LAST_TS: usize = 40;
+/// Byte offset of `symbol_id` within a slot.
+const OFF_SYMBOL_ID: usize = 48;
+/// Byte offset of `timeframe_secs` within a slot.
+const OFF_TIMEFRAME: usize = 52;
+/// Byte offset of the slot checksum.
+const OFF_CRC: usize = 56;
+/// Byte offset of the reserved tail, which is zero and stays zero.
+const OFF_RESERVED: usize = 60;
+
+const _: () = assert!(OFF_RESERVED < SLOT_LEN);
+const _: () = assert!(OFF_CRC + 4 == OFF_RESERVED);
+
+/// [`crate::format::SLOT_STRIDE`] as a `usize`, for slicing a region.
+///
+/// Written as a literal in both widths rather than converted, so there is no
+/// cast to deny and no fallible conversion whose failure arm no test could
+/// ever reach. The assertion is what keeps the two honest.
+const SLOT_STRIDE_LEN: usize = 16_384;
+const _: () = assert!(SLOT_STRIDE == 16_384 && SLOT_STRIDE_LEN == 16_384);
+
+/// [`Layout::CURRENT`]'s record stride, in the width the slot stores it.
+///
+/// Written as a literal in both widths for the same reason. A future
+/// `CURRENT` with a different stride is a compile error here.
+const CURRENT_STRIDE: u16 = 56;
+const _: () = assert!(CURRENT_STRIDE == 56 && Layout::CURRENT.record_stride() == 56);
+
+/// One header slot's fields.
+///
+/// `n_valid` is the commit counter — `docs/05-decisions.md` D-0004. A reader
+/// treats records `0..n_valid` as the whole file, so a half-written record at
+/// the tail is not merely unlikely, it is **unobservable**. `generation`
+/// extends that guarantee to the header itself: it says which slot is the
+/// newest, so a half-written *header* is unobservable too.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Header {
+    /// Format version. Selects the layout; never assumed.
+    pub format_version: u16,
+    /// Bytes per record, as this file declares them.
+    pub record_stride: u16,
+    /// Bit 0: block checksums present.
+    pub flags: u32,
+    /// Which commit this slot holds. Higher wins.
+    pub generation: u64,
+    /// The commit counter: how many records are readable.
+    pub n_valid: u64,
+    /// Timestamp of record 0, for a cheap range reject.
+    ///
+    /// Meaningful only when `n_valid > 0`. [`Header::advance`] sets it from
+    /// the first batch appended to an empty file and never moves it again, so
+    /// a range reject over `[first_ts_micros, last_ts_micros]` describes the
+    /// records that are actually there.
+    pub first_ts_micros: i64,
+    /// Timestamp of record `n_valid - 1`. Meaningful only when `n_valid > 0`.
+    pub last_ts_micros: i64,
+    /// Resolved from the path; a cross-check, never the index.
+    pub symbol_id: u32,
+    /// Seconds per bar. 60 for one minute.
+    pub timeframe_secs: u32,
+}
+
+/// One header write: one offset, one buffer, one `pwrite`.
+///
+/// The type is the guarantee. A commit cannot be expressed as several field
+/// updates because there is nowhere to put the second one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Commit {
+    /// Which slot this belongs in — `generation % slot_count`.
+    pub slot: u64,
+    /// The byte offset to write at.
+    pub offset: u64,
+    /// Exactly the bytes to write, checksum included.
+    pub bytes: [u8; SLOT_LEN],
+    /// The byte offset through which record data must already be durable.
+    ///
+    /// `header_len + n_valid · stride` — the end of the last record this
+    /// commit publishes. Issuing the slot write before the bytes below this
+    /// offset are on stable storage publishes a counter over data that may not
+    /// exist; the header page is re-dirtied on every commit and is therefore
+    /// the hottest writeback candidate in the file, so the reordering is the
+    /// likely case rather than the exotic one.
+    ///
+    /// This crate performs no I/O and cannot issue the barrier. It states the
+    /// offset so a writer cannot claim it did not know which one to flush.
+    pub durable_through: u64,
+    /// The header state this commit publishes.
+    pub header: Header,
+}
+
+impl Header {
+    /// A fresh header for an empty file: generation 0, no records.
+    ///
+    /// The caller writes [`Header::commit`] into a zero-filled header region.
+    /// Every other slot stays zero, which fails the magic check and is
+    /// therefore not a candidate — an empty slot and a corrupt one are the
+    /// same thing to a reader, and both are safe.
+    #[must_use]
+    pub const fn genesis(symbol_id: u32, timeframe_secs: u32, flags: u32) -> Self {
+        Self {
+            format_version: Layout::CURRENT.version(),
+            record_stride: CURRENT_STRIDE,
+            flags,
+            generation: 0,
+            n_valid: 0,
+            first_ts_micros: 0,
+            last_ts_micros: 0,
+            symbol_id,
+            timeframe_secs,
+        }
+    }
+
+    /// Whether this file carries per-block checksums.
+    ///
+    /// A file without them cannot have a block verified at all, and
+    /// [`crate::block::verify`] says so rather than returning "fine".
+    #[must_use]
+    pub const fn checksums_present(&self) -> bool {
+        self.flags & FLAG_CHECKSUMS != 0
+    }
+
+    /// The header that publishing `appended` more records produces.
+    ///
+    /// Advances the generation and the counter together, because they are
+    /// written together, and carries the batch's timestamps into the range the
+    /// header advertises. `first_ts_micros` is taken from the **first** batch
+    /// appended to an empty file and never moved afterwards; every later batch
+    /// only moves `last_ts_micros`. Before this, no method in this crate set
+    /// `first_ts_micros` at all, so every header it could commit claimed
+    /// record 0 sat at the Unix epoch and a range reject built on it accepted
+    /// every file that has ever existed.
+    ///
+    /// When `appended` is zero there is no batch to describe: the counter and
+    /// both timestamps are carried forward unchanged and the two timestamp
+    /// arguments are not read. That is a re-publish of the same state under a
+    /// new generation, which is idempotent and safe.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::GenerationExhausted`] or [`FormatError::CounterOverflow`]
+    /// — both refusals, never wraps. A wrapped generation makes the *oldest*
+    /// slot win and silently un-commits records.
+    ///
+    /// [`FormatError::TimestampsOutOfOrder`] when the batch's own timestamps
+    /// run backwards, or when it begins at or before the last timestamp
+    /// already committed. Bars are append-only in time, and a re-pull landing
+    /// on top of newer data is well-formed bytes that no checksum can catch
+    /// afterwards.
+    pub const fn advance(
+        &self,
+        appended: u64,
+        first_ts_micros: i64,
+        last_ts_micros: i64,
+    ) -> Result<Self, FormatError> {
+        let (generation, n_valid) = match (
+            self.generation.checked_add(1),
+            self.n_valid.checked_add(appended),
+        ) {
+            (None, _) => return Err(FormatError::GenerationExhausted),
+            (Some(_), None) => return Err(FormatError::CounterOverflow),
+            (Some(generation), Some(n_valid)) => (generation, n_valid),
+        };
+        if appended == 0 {
+            return Ok(Self {
+                generation,
+                ..*self
+            });
+        }
+        if last_ts_micros < first_ts_micros {
+            return Err(FormatError::TimestampsOutOfOrder {
+                previous: first_ts_micros,
+                next: last_ts_micros,
+            });
+        }
+        if self.n_valid > 0 && first_ts_micros <= self.last_ts_micros {
+            return Err(FormatError::TimestampsOutOfOrder {
+                previous: self.last_ts_micros,
+                next: first_ts_micros,
+            });
+        }
+        let first = if self.n_valid == 0 {
+            first_ts_micros
+        } else {
+            self.first_ts_micros
+        };
+        Ok(Self {
+            generation,
+            n_valid,
+            first_ts_micros: first,
+            last_ts_micros,
+            ..*self
+        })
+    }
+
+    /// The single write that publishes this header.
+    ///
+    /// # Preconditions the caller owns
+    ///
+    /// 1. **One writer per file.** Two writers that read the same generation
+    ///    produce the same slot, the same offset and the same record range;
+    ///    whichever lands last wins, and a crash during the second destroys
+    ///    the slot that held the only copy of the previous commit. Take an
+    ///    exclusive lock on [`crate::path::FileKind::Lock`] first. This crate
+    ///    performs no I/O and cannot check it.
+    /// 2. **Flush first.** Every byte below [`Commit::durable_through`] must
+    ///    be on stable storage before this write is issued.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::UnknownVersion`] or [`FormatError::RetiredVersion`] if
+    /// this header names a version this build cannot write,
+    /// [`FormatError::StrideMismatch`] if it names a stride its own version
+    /// does not define, or [`FormatError::OffsetOverflow`] if the counter puts
+    /// the end of the data past `u64`.
+    pub fn commit(&self) -> Result<Commit, FormatError> {
+        let layout = Layout::for_version(self.format_version)?;
+        if u64::from(self.record_stride) != layout.record_stride() {
+            return Err(FormatError::StrideMismatch(self.record_stride));
+        }
+        Ok(Commit {
+            slot: self.generation % layout.slot_count(),
+            offset: layout.slot_offset(self.generation),
+            bytes: self.image(layout.magic()),
+            durable_through: layout.offset_of(self.n_valid)?,
+            header: *self,
+        })
+    }
+
+    /// Checks this header against a known file length.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::StrideMismatch`] for a stride its version does not
+    /// define, [`FormatError::TooShortForHeader`] for a file that cannot hold
+    /// the header region, [`FormatError::CounterExceedsFile`] for a counter
+    /// claiming more records than the bytes can contain — trusting the counter
+    /// over the length reads past the end and returns whatever was there — or
+    /// [`FormatError::TimestampsOutOfOrder`] for a non-empty file whose
+    /// advertised range runs backwards.
+    pub fn validate(&self, layout: Layout, file_len: u64) -> Result<(), FormatError> {
+        if u64::from(self.record_stride) != layout.record_stride() {
+            return Err(FormatError::StrideMismatch(self.record_stride));
+        }
+        if file_len < layout.header_len() {
+            return Err(FormatError::TooShortForHeader);
+        }
+        if self.n_valid > layout.capacity_for(file_len) {
+            return Err(FormatError::CounterExceedsFile);
+        }
+        if self.n_valid > 0 && self.last_ts_micros < self.first_ts_micros {
+            return Err(FormatError::TimestampsOutOfOrder {
+                previous: self.first_ts_micros,
+                next: self.last_ts_micros,
+            });
+        }
+        Ok(())
+    }
+
+    /// Decodes one slot, checksum and all.
+    ///
+    /// The slot is copied into a 64-byte array **once**, before anything is
+    /// checked, and every field is then read from that copy. That is what
+    /// makes it safe over a `MAP_SHARED` mapping a writer is `pwrite`-ing: the
+    /// checksum verifies exactly the bytes the returned `Header` carries. Were
+    /// the buffer re-read after the checksum passed, a write landing in
+    /// between would produce a header no checksum ever covered — and with
+    /// `#![forbid(unsafe_code)]` there is no fence available to order plain
+    /// loads, so the copy is the fix rather than a mitigation.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::SlotTooShort`], [`FormatError::NotABarFile`],
+    /// [`FormatError::UnknownVersion`], [`FormatError::RetiredVersion`],
+    /// [`FormatError::MagicVersionMismatch`], [`FormatError::SlotChecksum`] or
+    /// [`FormatError::StrideMismatch`] — checked in that order, so the most
+    /// basic disagreement is the one reported.
+    pub fn decode(slot: &[u8]) -> Result<Self, FormatError> {
+        Self::decode_parts(slot).map(|(header, _)| header)
+    }
+
+    /// [`Header::decode`], keeping the layout it already resolved.
+    ///
+    /// [`Header::read_region`] needs both, and re-resolving the version would
+    /// add an error path no test could reach — the version was accepted three
+    /// lines earlier.
+    fn decode_parts(slot: &[u8]) -> Result<(Self, Layout), FormatError> {
+        if slot.len() < SLOT_LEN {
+            return Err(FormatError::SlotTooShort { len: slot.len() });
+        }
+        // The one observation of the caller's bytes. Everything below reads
+        // this array; nothing below touches `slot` again.
+        let mut image = [0u8; SLOT_LEN];
+        for (dst, src) in image.iter_mut().zip(slot.iter()) {
+            *dst = *src;
+        }
+
+        let magic: [u8; 8] = le_bytes(&image, OFF_MAGIC);
+        if magic
+            .iter()
+            .take(MAGIC_FAMILY.len())
+            .ne(MAGIC_FAMILY.iter())
+        {
+            return Err(FormatError::NotABarFile);
+        }
+        let format_version = u16::from_le_bytes(le_bytes(&image, OFF_VERSION));
+        let layout = Layout::for_version(format_version)?;
+        if magic != layout.magic() {
+            return Err(FormatError::MagicVersionMismatch(format_version));
+        }
+        let stored = u32::from_le_bytes(le_bytes(&image, OFF_CRC));
+        let computed = crc32c(covered(&image));
+        if stored != computed {
+            return Err(FormatError::SlotChecksum { stored, computed });
+        }
+        let record_stride = u16::from_le_bytes(le_bytes(&image, OFF_STRIDE));
+        if u64::from(record_stride) != layout.record_stride() {
+            return Err(FormatError::StrideMismatch(record_stride));
+        }
+        Ok((
+            Self {
+                format_version,
+                record_stride,
+                flags: u32::from_le_bytes(le_bytes(&image, OFF_FLAGS)),
+                generation: u64::from_le_bytes(le_bytes(&image, OFF_GENERATION)),
+                n_valid: u64::from_le_bytes(le_bytes(&image, OFF_N_VALID)),
+                first_ts_micros: i64::from_le_bytes(le_bytes(&image, OFF_FIRST_TS)),
+                last_ts_micros: i64::from_le_bytes(le_bytes(&image, OFF_LAST_TS)),
+                symbol_id: u32::from_le_bytes(le_bytes(&image, OFF_SYMBOL_ID)),
+                timeframe_secs: u32::from_le_bytes(le_bytes(&image, OFF_TIMEFRAME)),
+            },
+            layout,
+        ))
+    }
+
+    /// Reads the whole header region and returns the committed state.
+    ///
+    /// Each of the first [`crate::format::MAX_SLOTS`] slot positions is
+    /// decoded independently — each carries its own magic, version and
+    /// checksum — and the valid one with the highest generation that the
+    /// file's length supports wins. A slot that is empty, stale, half-written,
+    /// corrupt or in the wrong position is simply not a candidate.
+    ///
+    /// Two things it deliberately does **not** do:
+    ///
+    /// * It does not scan past [`crate::format::MAX_SLOTS`] positions. The
+    ///   region a caller passes may be a whole read-only mapping, and every
+    ///   aligned run of record bytes would otherwise audition as a header.
+    /// * It does not condemn the file when the newest slot fails its check
+    ///   against the file length. That is the crash where the header became
+    ///   durable before the records it counts, and the previous generation is
+    ///   sitting intact in the other slot; returning an error there loses a
+    ///   month of bars to recover a tail.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::HeaderRegionTooShort`] when the region is smaller than
+    /// the version's header region — a short region would otherwise return
+    /// whichever older commit happened to fit, silently losing every record
+    /// committed since. [`FormatError::NoValidHeader`] when no slot decodes
+    /// and none gave a specific reason: every copy of the header is damaged,
+    /// and anything else this function could return would be a guess. When a
+    /// slot did give a specific reason — an unknown or retired version, a
+    /// stride disagreement, a failed checksum, or a commit found in the wrong
+    /// slot — that reason is reported instead, because "the header is
+    /// unreadable" is a false diagnosis of an intact file from another
+    /// version. When slots decode but none survives [`Header::validate`], the
+    /// newest one's refusal is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use store::{format::FormatError, header::Header};
+    /// // An empty file: a zeroed header region, then the genesis commit.
+    /// let mut region = vec![0u8; 32_768];
+    /// let genesis = Header::genesis(1, 60, 0).commit()?;
+    /// assert_eq!(genesis.offset, 0);
+    /// assert_eq!(genesis.durable_through, 32_768);
+    /// region
+    ///     .iter_mut()
+    ///     .zip(genesis.bytes)
+    ///     .for_each(|(dst, src)| *dst = src);
+    ///
+    /// let read = Header::read_region(&region, 32_768)?;
+    /// assert_eq!(read.n_valid, 0);
+    /// assert_eq!(read.generation, 0);
+    /// # Ok::<(), FormatError>(())
+    /// ```
+    pub fn read_region(region: &[u8], file_len: u64) -> Result<Self, FormatError> {
+        let (mut header, mut layout) = best_candidate(region, None)?;
+
+        let slots = whole_slots(region);
+        if slots < layout.slot_count() {
+            return Err(FormatError::HeaderRegionTooShort {
+                slots,
+                need: layout.slot_count(),
+            });
+        }
+
+        loop {
+            match header.validate(layout, file_len) {
+                Ok(()) => return Ok(header),
+                Err(refusal) => match best_candidate(region, Some(header.generation)) {
+                    Ok((older, older_layout)) => {
+                        header = older;
+                        layout = older_layout;
+                    }
+                    Err(_) => return Err(refusal),
+                },
+            }
+        }
+    }
+
+    /// The 64-byte slot image for this header, checksum computed.
+    fn image(&self, magic: [u8; 8]) -> [u8; SLOT_LEN] {
+        let mut out = [0u8; SLOT_LEN];
+        let body = magic
+            .into_iter()
+            .chain(self.format_version.to_le_bytes())
+            .chain(self.record_stride.to_le_bytes())
+            .chain(self.flags.to_le_bytes())
+            .chain(self.generation.to_le_bytes())
+            .chain(self.n_valid.to_le_bytes())
+            .chain(self.first_ts_micros.to_le_bytes())
+            .chain(self.last_ts_micros.to_le_bytes())
+            .chain(self.symbol_id.to_le_bytes())
+            .chain(self.timeframe_secs.to_le_bytes());
+        for (dst, src) in out.iter_mut().zip(body) {
+            *dst = src;
+        }
+        let crc = crc32c(covered(&out));
+        for (dst, src) in out.iter_mut().skip(OFF_CRC).zip(crc.to_le_bytes()) {
+            *dst = src;
+        }
+        out
+    }
+}
+
+/// The best-positioned decoded slot whose generation is below `below`.
+///
+/// `below` is exclusive and `None` means no bound, so the caller can ask again
+/// for the next-newest commit after the newest one failed its check. Because
+/// slot position is `generation % slot_count`, two positionally-valid slots
+/// can never share a generation, and the bound therefore strictly shrinks the
+/// candidate set on every call.
+///
+/// The error it reports when there is no candidate is the most *specific*
+/// refusal any slot produced. A slot that is merely blank fails the magic
+/// check, which says nothing; a slot naming a retired version, a wrong stride
+/// or a failed checksum says everything, and reporting the blank one instead
+/// would diagnose an intact file from another version as a destroyed header.
+fn best_candidate(region: &[u8], below: Option<u64>) -> Result<(Header, Layout), FormatError> {
+    let mut fault: Option<FormatError> = None;
+    let mut best: Option<(Header, Layout)> = None;
+
+    for (index, chunk) in (0u64..).zip(region.chunks(SLOT_STRIDE_LEN).take(MAX_SLOTS)) {
+        match Header::decode_parts(chunk) {
+            Err(refusal) => {
+                if is_specific(refusal) {
+                    fault.get_or_insert(refusal);
+                }
+            }
+            Ok((header, layout)) => {
+                let expected = header.generation % layout.slot_count();
+                if index == expected {
+                    if below.is_none_or(|limit| header.generation < limit)
+                        && best.is_none_or(|(seen, _)| header.generation > seen.generation)
+                    {
+                        best = Some((header, layout));
+                    }
+                } else {
+                    fault.get_or_insert(FormatError::SlotPositionMismatch {
+                        expected,
+                        found: index,
+                    });
+                }
+            }
+        }
+    }
+
+    best.ok_or(fault.unwrap_or(FormatError::NoValidHeader))
+}
+
+/// Whether a refusal says something about the file, or only that a slot is not
+/// a header at all.
+const fn is_specific(refusal: FormatError) -> bool {
+    !matches!(
+        refusal,
+        FormatError::NotABarFile | FormatError::SlotTooShort { .. }
+    )
+}
+
+/// How many whole slot positions the region holds, capped at the family bound.
+///
+/// Counted by folding rather than `count()` so the answer is a `u64` without a
+/// `usize` cast this workspace would deny, and bounded by
+/// [`crate::format::MAX_SLOTS`] so the fold cannot overflow.
+fn whole_slots(region: &[u8]) -> u64 {
+    region
+        .chunks_exact(SLOT_STRIDE_LEN)
+        .take(MAX_SLOTS)
+        .fold(0u64, |seen, _| seen + 1)
+}
+
+/// Every byte of a slot except the four the checksum itself occupies.
+///
+/// Covering the reserved tail as well as the fields means a flipped bit
+/// *anywhere* in the 64 bytes is detected — there is no window a corruption
+/// can land in and be called clean. `store::fault::a_single_bit_flip_in_any_
+/// header_byte_is_detected` walks all 512 of them.
+fn covered(slot: &[u8]) -> impl Iterator<Item = u8> + '_ {
+    slot.iter()
+        .take(OFF_CRC)
+        .chain(slot.iter().skip(OFF_RESERVED).take(SLOT_LEN - OFF_RESERVED))
+        .copied()
+}
+
+/// Reads `N` little-endian bytes at `offset`.
+///
+/// Index-free by construction — this workspace denies slice indexing, and a
+/// header decoder is exactly the place a panicking index would eventually be
+/// reached by a corrupt file. Callers check `slot.len() >= SLOT_LEN` first, so
+/// no read is ever short.
+fn le_bytes<const N: usize>(slot: &[u8], offset: usize) -> [u8; N] {
+    let mut out = [0u8; N];
+    for (dst, src) in out.iter_mut().zip(slot.iter().skip(offset)) {
+        *dst = *src;
+    }
+    out
+}

--- a/crates/store/src/layout.rs
+++ b/crates/store/src/layout.rs
@@ -383,12 +383,15 @@ impl Layout {
         }
         // `block < blocks` and `blocks <= n_valid.div_ceil(rpb)`, so the
         // product is at most `n_valid` rounded down and cannot overflow.
-        let before = block * self.records_per_block;
-        let rest = n_valid - before;
-        if rest > self.records_per_block {
-            Ok(self.records_per_block)
+        let remaining = n_valid - block * self.records_per_block;
+        // Asked as "is this the tail block?" rather than "does the remainder
+        // exceed a block?" — the two agree, but the second is a comparison
+        // whose boundary case makes both arms return the same number, so no
+        // test could distinguish it from its own mutation.
+        if block + 1 == blocks {
+            Ok(remaining)
         } else {
-            Ok(rest)
+            Ok(self.records_per_block)
         }
     }
 

--- a/crates/store/src/layout.rs
+++ b/crates/store/src/layout.rs
@@ -1,0 +1,586 @@
+//! One version's geometry, and the dispatch that selects it.
+//!
+//! # The stride is not a global
+//!
+//! `docs/02-store-format.md` says "a format change mints a **new version** and
+//! old files stay readable at their own stride". That sentence was prose: the
+//! read path used one stride constant and dispatched on nothing, so a version
+//! it did not know would either have been read at the current stride or not at
+//! all. Both are wrong. Reading a version-2 file at version 1's stride returns
+//! fields lifted from the wrong offsets — plausible integers, silently wrong,
+//! which is the exact failure `docs/00-charter.md` prohibition 6 exists to
+//! forbid.
+//!
+//! Every geometric question is therefore a method on a [`Layout`], and the
+//! only way to obtain a `Layout` is [`Layout::for_version`], which refuses an
+//! unknown version **by number** and a retired one by name.
+//!
+//! # Adding version 3
+//!
+//! Add a row to [`Layout::KNOWN`], **built by [`Layout::declared`]**. That is
+//! the whole change, and it is the reason `declared` exists: a hand-written
+//! struct literal would bypass every guard [`Layout::declare`] applies, and
+//! `slot_count >= 2` is not a style rule — it is the entire crash-atomicity
+//! guarantee. `declared` is a `const fn` whose assertions are compile errors,
+//! so a degenerate row cannot be written down at all.
+//!
+//! Resolution is a search of that table for a matching `version`, so a new row
+//! cannot alter what an existing row resolves to — proven by
+//! `store::unit::a_known_version_keeps_its_stride_after_a_new_one_exists`,
+//! which runs the production resolver against a table that already contains a
+//! second version.
+//!
+//! # A record never straddles a checksum block
+//!
+//! `docs/02-store-format.md` §6 checksums a block at a time, and the earlier
+//! byte-addressed 4096-byte block did not divide the 56-byte stride: 4096/56
+//! is 73.14, so a record could begin in one block and end in the next. Record
+//! 145 was the cited case — 8 of its bytes in one block, 48 in the next — and
+//! verifying it against either block alone checks part of a record and calls
+//! the whole of it good.
+//!
+//! The block is therefore counted in **records**, not bytes:
+//! [`Layout::records_per_block`] whole records, so [`Layout::block_len`] is a
+//! whole multiple of the stride and a straddle is arithmetically impossible.
+//! `store::geometry::no_record_straddles_a_block` walks the first 5,000
+//! indices and proves it, record 145 included.
+//!
+//! ## Why not a padded 4096-byte block
+//!
+//! `docs/05-decisions.md` D-0005 said "one checksum per 4 KiB block", and
+//! `docs/02-store-format.md` §6 described it as "73 whole records with 8 bytes
+//! of slack" — a *padded* block, which also never straddles. It was not taken,
+//! and the reason is arithmetic rather than taste: padding the block means
+//! block *b* starts at `header_len + b·4096` while record `73b` starts at
+//! `header_len + 73b·56 = header_len + b·4088`. The two only agree if the
+//! record array carries the same 8 bytes of padding every 73 records, and then
+//! the address of record *i* stops being `header_len + i·56` and becomes
+//! `header_len + (i/73)·4096 + (i%73)·56` — a division and two multiplies
+//! instead of a multiply and an add. `CLAUDE.md` §3 rule 4 asks for a constant
+//! per-operation cost, and this is still constant, but it is a strictly worse
+//! constant bought with nothing: the 8 bytes are wasted either way.
+//! `store::geometry::a_padded_four_kib_block_would_cost_a_division` is that
+//! comparison as a test.
+
+use crate::format::{
+    BLOCK_LEN, FORMAT_VERSION, FormatError, HEADER_LEN, MAGIC, MAGIC_FAMILY, MAX_SLOT_COUNT,
+    RECORD_STRIDE, RECORDS_PER_BLOCK, RETIRED_VERSIONS, SLOT_COUNT, SLOT_STRIDE,
+};
+
+/// Whether `version` is one this build knows of and refuses to decode.
+///
+/// Destructures [`RETIRED_VERSIONS`] rather than scanning it, so retiring a
+/// second version is a compile error here instead of a silently unchecked
+/// number.
+const fn version_is_retired(version: u16) -> bool {
+    let [first] = RETIRED_VERSIONS;
+    version == first
+}
+
+/// The geometry of one format version.
+///
+/// Fields are private: a `Layout` with a zero `records_per_block` would make
+/// [`Layout::block_of`] a division fault, and a `Layout` whose magic did not
+/// match its version would defeat the cross-check in
+/// [`crate::header::Header::decode`]. Both are unrepresentable outside this
+/// module — and inside it, [`Layout::declared`] makes them compile errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Layout {
+    version: u16,
+    magic: [u8; 8],
+    slot_count: u64,
+    record_stride: u64,
+    records_per_block: u64,
+}
+
+impl Layout {
+    /// Version 2 — the format `docs/02-store-format.md` describes.
+    ///
+    /// Built through [`Layout::declared`], not written as a literal, so it is
+    /// checked by the same rule every other row is.
+    pub const V2: Self = Self::declared(
+        FORMAT_VERSION_2,
+        MAGIC,
+        SLOT_COUNT,
+        RECORD_STRIDE,
+        RECORDS_PER_BLOCK,
+    );
+
+    /// Every version this build can read, in ascending order.
+    ///
+    /// Adding a version is adding a row built by [`Layout::declared`]. Nothing
+    /// else in this module names a version number, so a new row cannot change
+    /// how an old one resolves.
+    pub const KNOWN: &'static [Self] = &[Self::V2];
+
+    /// The version this build writes. Older versions are read, never written.
+    pub const CURRENT: Self = Self::V2;
+
+    /// Declares a format version's geometry at compile time.
+    ///
+    /// This is how a row of [`Layout::KNOWN`] is written. It applies exactly
+    /// the rule [`Layout::declare`] applies, but as a `const` assertion, so a
+    /// degenerate row does not compile rather than failing at a call site that
+    /// may never run.
+    ///
+    /// # Panics
+    ///
+    /// At **compile time**, when the geometry is one no file could have. The
+    /// message does not name the field, because a `const` panic cannot format
+    /// one; [`Layout::declare`] does, and
+    /// `store::unit::a_degenerate_layout_is_refused_at_declaration` walks every
+    /// field through it.
+    #[must_use]
+    pub const fn declared(
+        version: u16,
+        magic: [u8; 8],
+        slot_count: u64,
+        record_stride: u64,
+        records_per_block: u64,
+    ) -> Self {
+        assert!(
+            degenerate_field(version, magic, slot_count, record_stride, records_per_block)
+                .is_none(),
+            "a Layout row is not a geometry a file can have; see Layout::declare",
+        );
+        Self {
+            version,
+            magic,
+            slot_count,
+            record_stride,
+            records_per_block,
+        }
+    }
+
+    /// Declares a format version's geometry, refusing a degenerate one.
+    ///
+    /// The fallible twin of [`Layout::declared`], for a geometry that is not a
+    /// compile-time constant —
+    /// `store::unit::a_known_version_keeps_its_stride_after_a_new_one_exists`
+    /// builds its hypothetical next version through this door, so that test
+    /// drives the same [`Layout::resolve`] the read path drives rather than a
+    /// paraphrase of it.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::DegenerateLayout`] naming the field, for a retired or
+    /// zero version, a zero stride, a zero records-per-block (which would make
+    /// [`Layout::block_of`] a division fault), a slot count below 2 or above
+    /// [`crate::format::MAX_SLOT_COUNT`], a block length that overflows `u64`,
+    /// or a magic outside [`crate::format::MAGIC_FAMILY`].
+    pub const fn declare(
+        version: u16,
+        magic: [u8; 8],
+        slot_count: u64,
+        record_stride: u64,
+        records_per_block: u64,
+    ) -> Result<Self, FormatError> {
+        match degenerate_field(version, magic, slot_count, record_stride, records_per_block) {
+            Some(field) => Err(FormatError::DegenerateLayout { field }),
+            None => Ok(Self {
+                version,
+                magic,
+                slot_count,
+                record_stride,
+                records_per_block,
+            }),
+        }
+    }
+
+    /// The layout for `version`, or a refusal naming the version.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::RetiredVersion`] for a version this build knows of and
+    /// cannot decode, or [`FormatError::UnknownVersion`] carrying the version
+    /// it saw. There is no fallback to [`Layout::CURRENT`]: a version this
+    /// build does not know has a layout this build cannot infer, and inferring
+    /// it wrongly returns plausible nonsense rather than an error.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use store::{format::FormatError, layout::Layout};
+    /// assert_eq!(Layout::for_version(2)?.record_stride(), 56);
+    /// assert_eq!(Layout::for_version(9), Err(FormatError::UnknownVersion(9)));
+    /// // Version 1 existed and is not decodable by this build. It is named as
+    /// // retired rather than reported as unknown or, worse, read at version
+    /// // 2's offsets.
+    /// assert_eq!(Layout::for_version(1), Err(FormatError::RetiredVersion(1)));
+    /// # Ok::<(), FormatError>(())
+    /// ```
+    pub fn for_version(version: u16) -> Result<Self, FormatError> {
+        Self::resolve(Self::KNOWN, version)
+    }
+
+    /// Resolves `version` against an explicit table.
+    ///
+    /// [`Layout::for_version`] is this function applied to [`Layout::KNOWN`].
+    /// It is public so a test can prove the additive property against a table
+    /// that already holds a second version, running the same code the read
+    /// path runs rather than a paraphrase of it.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::RetiredVersion`] or [`FormatError::UnknownVersion`]. The
+    /// retirement is checked before the table, so a caller cannot resurrect a
+    /// retired version by putting a row in its own table.
+    pub fn resolve(table: &[Self], version: u16) -> Result<Self, FormatError> {
+        if version_is_retired(version) {
+            return Err(FormatError::RetiredVersion(version));
+        }
+        table
+            .iter()
+            .copied()
+            .find(|layout| layout.version == version)
+            .ok_or(FormatError::UnknownVersion(version))
+    }
+
+    /// This layout's version number.
+    #[must_use]
+    pub const fn version(self) -> u16 {
+        self.version
+    }
+
+    /// The eight magic bytes a file of this version begins with.
+    #[must_use]
+    pub const fn magic(self) -> [u8; 8] {
+        self.magic
+    }
+
+    /// How many header slots this version keeps.
+    #[must_use]
+    pub const fn slot_count(self) -> u64 {
+        self.slot_count
+    }
+
+    /// Bytes from one header slot to the next.
+    ///
+    /// A family constant, not a per-version one — see
+    /// [`crate::format::SLOT_STRIDE`] for why it is a whole failure unit.
+    #[must_use]
+    pub const fn slot_stride(self) -> u64 {
+        SLOT_STRIDE
+    }
+
+    /// Bytes of header region before record 0.
+    ///
+    /// Cannot overflow: [`Layout::declare`] caps `slot_count` at
+    /// [`crate::format::MAX_SLOT_COUNT`].
+    #[must_use]
+    pub const fn header_len(self) -> u64 {
+        self.slot_count * SLOT_STRIDE
+    }
+
+    /// Bytes per record.
+    #[must_use]
+    pub const fn record_stride(self) -> u64 {
+        self.record_stride
+    }
+
+    /// Whole records covered by one checksum block.
+    #[must_use]
+    pub const fn records_per_block(self) -> u64 {
+        self.records_per_block
+    }
+
+    /// Bytes per checksum block — always a whole multiple of the stride.
+    ///
+    /// This is the block's **nominal** length. The last block of a file holds
+    /// only as many records as the commit counter covers; see
+    /// [`Layout::covered_byte_range`], which is the range a checksum is
+    /// actually taken over.
+    #[must_use]
+    pub const fn block_len(self) -> u64 {
+        self.record_stride * self.records_per_block
+    }
+
+    /// The byte offset of record `index`.
+    ///
+    /// This is the whole performance claim in one line: an add, a multiply, a
+    /// load, independent of file size.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::OffsetOverflow`] if the offset would exceed `u64`. A
+    /// wrapped offset would address a different, valid-looking record.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use store::{format::FormatError, layout::Layout};
+    /// let v2 = Layout::V2;
+    /// assert_eq!(v2.offset_of(0)?, 32_768);
+    /// assert_eq!(v2.offset_of(1)?, 32_824);
+    /// assert_eq!(v2.offset_of(400_000)?, 22_432_768);
+    /// # Ok::<(), FormatError>(())
+    /// ```
+    pub const fn offset_of(self, index: u64) -> Result<u64, FormatError> {
+        match index.checked_mul(self.record_stride) {
+            Some(scaled) => match scaled.checked_add(self.header_len()) {
+                Some(offset) => Ok(offset),
+                None => Err(FormatError::OffsetOverflow),
+            },
+            None => Err(FormatError::OffsetOverflow),
+        }
+    }
+
+    /// The half-open byte range `[start, end)` that record `index` occupies.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::OffsetOverflow`] if either end would exceed `u64`.
+    pub const fn record_byte_range(self, index: u64) -> Result<(u64, u64), FormatError> {
+        match self.offset_of(index) {
+            Ok(start) => match start.checked_add(self.record_stride) {
+                Some(end) => Ok((start, end)),
+                None => Err(FormatError::OffsetOverflow),
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Which checksum block holds record `index`. Every byte of it.
+    ///
+    /// Infallible and exact: the block is counted in records, so this is one
+    /// division and the answer is a single block, never a range. A caller can
+    /// therefore verify a record by reading one checksum — the property that
+    /// makes `docs/02-store-format.md` §6's "verification is O(1) per read"
+    /// true rather than approximately true.
+    #[must_use]
+    pub const fn block_of(self, index: u64) -> u64 {
+        index / self.records_per_block
+    }
+
+    /// How many blocks a commit counter of `n_valid` covers.
+    ///
+    /// The last of them is partial unless `n_valid` is a whole multiple of
+    /// [`Layout::records_per_block`].
+    #[must_use]
+    pub const fn blocks_for(self, n_valid: u64) -> u64 {
+        let whole = n_valid / self.records_per_block;
+        if n_valid.is_multiple_of(self.records_per_block) {
+            whole
+        } else {
+            whole + 1
+        }
+    }
+
+    /// How many committed records live in `block`.
+    ///
+    /// [`Layout::records_per_block`] for every block but the last, and the
+    /// remainder for the last.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::BlockNotCommitted`] for a block past the counter.
+    /// Answering "zero" instead would let a caller checksum nothing and
+    /// report the result as a verified block.
+    pub const fn records_in_block(self, block: u64, n_valid: u64) -> Result<u64, FormatError> {
+        let blocks = self.blocks_for(n_valid);
+        if block >= blocks {
+            return Err(FormatError::BlockNotCommitted { block, blocks });
+        }
+        // `block < blocks` and `blocks <= n_valid.div_ceil(rpb)`, so the
+        // product is at most `n_valid` rounded down and cannot overflow.
+        let before = block * self.records_per_block;
+        let rest = n_valid - before;
+        if rest > self.records_per_block {
+            Ok(self.records_per_block)
+        } else {
+            Ok(rest)
+        }
+    }
+
+    /// The half-open byte range `[start, end)` a checksum for `block` covers.
+    ///
+    /// **This, not [`Layout::block_byte_range`], is the checksum domain.** The
+    /// tail block of a file holds only the records the commit counter covers,
+    /// so its nominal range ends past EOF for every file whose record count is
+    /// not a whole multiple of [`Layout::records_per_block`] — 72 of every 73
+    /// states a file passes through.
+    ///
+    /// Because the domain is a function of `n_valid`, the same block's
+    /// checksum means something different before and after an append that
+    /// lands in it: the writer recomputes the tail block's checksum on every
+    /// commit that touches it, and a reader verifies against the `n_valid` it
+    /// read from the header. Both sides derive the length from the same
+    /// counter, which is what makes the answer reproducible rather than
+    /// timing-dependent.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::BlockNotCommitted`] for a block past the counter, or
+    /// [`FormatError::OffsetOverflow`] if either end would exceed `u64`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use store::{format::FormatError, layout::Layout};
+    /// let v2 = Layout::V2;
+    /// // One record committed: the tail block covers 56 bytes, not 4088.
+    /// assert_eq!(v2.covered_byte_range(0, 1)?, (32_768, 32_824));
+    /// // A whole block: nominal and covered agree.
+    /// assert_eq!(v2.covered_byte_range(0, 73)?, v2.block_byte_range(0)?);
+    /// # Ok::<(), FormatError>(())
+    /// ```
+    pub const fn covered_byte_range(
+        self,
+        block: u64,
+        n_valid: u64,
+    ) -> Result<(u64, u64), FormatError> {
+        let records = match self.records_in_block(block, n_valid) {
+            Ok(records) => records,
+            Err(e) => return Err(e),
+        };
+        let start = match block.checked_mul(self.block_len()) {
+            Some(scaled) => match scaled.checked_add(self.header_len()) {
+                Some(start) => start,
+                None => return Err(FormatError::OffsetOverflow),
+            },
+            None => return Err(FormatError::OffsetOverflow),
+        };
+        // `records <= records_per_block`, so this product is at most
+        // `block_len`, which `declare` already proved fits. Written without a
+        // `checked_mul` on purpose: the failure arm would be unreachable, and
+        // an arm no input can reach is an arm no test can close.
+        let len = records * self.record_stride;
+        match start.checked_add(len) {
+            Some(end) => Ok((start, end)),
+            None => Err(FormatError::OffsetOverflow),
+        }
+    }
+
+    /// The half-open byte range `[start, end)` block `block` nominally covers.
+    ///
+    /// Nominal means *if the block were full*. For the tail block of a real
+    /// file this names bytes that are not in the file; use
+    /// [`Layout::covered_byte_range`] to checksum, and this only to reason
+    /// about the geometry.
+    ///
+    /// # Errors
+    ///
+    /// [`FormatError::OffsetOverflow`] if either end would exceed `u64`.
+    pub const fn block_byte_range(self, block: u64) -> Result<(u64, u64), FormatError> {
+        let len = self.block_len();
+        match block.checked_mul(len) {
+            Some(scaled) => match scaled.checked_add(self.header_len()) {
+                Some(start) => match start.checked_add(len) {
+                    Some(end) => Ok((start, end)),
+                    None => Err(FormatError::OffsetOverflow),
+                },
+                None => Err(FormatError::OffsetOverflow),
+            },
+            None => Err(FormatError::OffsetOverflow),
+        }
+    }
+
+    /// The byte offset of the slot a commit at `generation` is written to.
+    ///
+    /// Writes alternate, so the slot holding the previous commit is never the
+    /// slot being written — which is the whole of the crash argument in
+    /// [`crate::header`]. The spacing is [`crate::format::SLOT_STRIDE`], so
+    /// the slot being written and the slot holding the previous commit are in
+    /// different device blocks and different pages.
+    #[must_use]
+    pub const fn slot_offset(self, generation: u64) -> u64 {
+        (generation % self.slot_count) * SLOT_STRIDE
+    }
+
+    /// How many whole records the file can hold, ignoring the counter.
+    ///
+    /// Saturating rather than branching on `file_len < header_len`: a file
+    /// with no room for a header holds no records, which is the same answer
+    /// the branch gave, and a branch whose two arms agree at the boundary is
+    /// a branch no test can distinguish. `ragged_tail_bytes` is where a file
+    /// too short to hold a header is reported, and it does branch.
+    #[must_use]
+    pub const fn capacity_for(self, file_len: u64) -> u64 {
+        file_len.saturating_sub(self.header_len()) / self.record_stride
+    }
+
+    /// Bytes past the last whole record.
+    ///
+    /// A non-zero remainder means the file was interrupted mid-record.
+    /// `docs/02-store-format.md` §7 truncates to the last whole record and
+    /// logs the discarded byte count — loudly, never by ignoring it.
+    #[must_use]
+    pub const fn ragged_tail_bytes(self, file_len: u64) -> u64 {
+        if file_len < self.header_len() {
+            file_len
+        } else {
+            (file_len - self.header_len()) % self.record_stride
+        }
+    }
+}
+
+/// Version 2's number, named so [`Layout::V2`] does not import a constant that
+/// reads as "whatever version this build writes".
+///
+/// If version 3 is ever minted, [`crate::format::FORMAT_VERSION`] becomes 3
+/// and `Layout::V2` must keep saying 2. A row that read the moving constant
+/// would silently renumber an existing geometry — `CLAUDE.md` §3 rule 8.
+const FORMAT_VERSION_2: u16 = 2;
+
+const _: () = assert!(FORMAT_VERSION_2 == 2);
+const _: () = assert!(Layout::CURRENT.version() == FORMAT_VERSION);
+
+/// The first field of a declaration that is not a geometry a file can have.
+///
+/// One function so [`Layout::declared`] and [`Layout::declare`] cannot drift:
+/// a guard added here is a compile error for the const rows and an `Err` for
+/// the fallible door, in the same commit.
+const fn degenerate_field(
+    version: u16,
+    magic: [u8; 8],
+    slot_count: u64,
+    record_stride: u64,
+    records_per_block: u64,
+) -> Option<&'static str> {
+    if version == 0 || version_is_retired(version) {
+        return Some("version");
+    }
+    if record_stride == 0 {
+        return Some("record_stride");
+    }
+    if records_per_block == 0 {
+        return Some("records_per_block");
+    }
+    if record_stride.checked_mul(records_per_block).is_none() {
+        return Some("block_len");
+    }
+    if !magic_is_family(magic) {
+        return Some("magic");
+    }
+    // Two slots is the minimum that lets a commit be written without
+    // overwriting the only surviving copy of the previous one, and
+    // MAX_SLOT_COUNT is the most a reader will look at before it knows the
+    // version -- a row above it would put a slot where nothing looks.
+    if slot_count < 2 || slot_count > MAX_SLOT_COUNT {
+        return Some("slot_count");
+    }
+    None
+}
+
+/// Whether `magic`'s first seven bytes are [`MAGIC_FAMILY`].
+///
+/// Destructured rather than iterated because this runs in `const` context,
+/// where an iterator is not available and an index would be a denied lint.
+const fn magic_is_family(magic: [u8; 8]) -> bool {
+    let [m0, m1, m2, m3, m4, m5, m6, _] = magic;
+    let [f0, f1, f2, f3, f4, f5, f6] = MAGIC_FAMILY;
+    m0 == f0 && m1 == f1 && m2 == f2 && m3 == f3 && m4 == f4 && m5 == f5 && m6 == f6
+}
+
+const _: () = assert!(Layout::V2.block_len() == BLOCK_LEN);
+const _: () = assert!(Layout::V2.header_len() == HEADER_LEN);
+const _: () = assert!(
+    Layout::V2
+        .block_len()
+        .is_multiple_of(Layout::V2.record_stride())
+);
+const _: () = assert!(Layout::V2.records_per_block() > 0);
+const _: () = assert!(Layout::V2.slot_count() > 1);
+const _: () = assert!(Layout::V2.slot_count() <= MAX_SLOT_COUNT);
+const _: () = assert!(Layout::V2.slot_offset(0) == 0);
+const _: () = assert!(Layout::V2.slot_offset(1) == SLOT_STRIDE);

--- a/crates/store/src/lib.rs
+++ b/crates/store/src/lib.rs
@@ -1,0 +1,52 @@
+//! The fixed-stride bar file: bytes on disk, addressed by arithmetic.
+//!
+//! `docs/02-store-format.md` is the authority for every byte here.
+//!
+//! # What is here
+//!
+//! | Module | Owns |
+//! |---|---|
+//! | [`crc`] | CRC-32C, the one checksum this store computes |
+//! | [`mod@format`] | the record, the shared constants, and every error |
+//! | [`layout`] | one version's geometry, and the dispatch that selects it |
+//! | [`header`] | the two-slot header and the single-write commit |
+//! | [`block`] | the per-block checksum, over the committed prefix |
+//! | [`path`] | the only way a store path is built |
+//!
+//! # Six properties the types enforce rather than document
+//!
+//! 1. **A record never straddles a checksum block.** The block length is a
+//!    whole multiple of the record stride, so verifying a record reads exactly
+//!    one block's checksum — never one of the two blocks its bytes fell into.
+//!    See [`layout`].
+//! 2. **The stride is never a global constant on the read path.** It comes
+//!    from [`layout::Layout`], which comes from the file's own
+//!    `format_version`. An unrecognised version is refused by number, and a
+//!    retired one by name; nothing falls back to the current stride. See
+//!    [`layout::Layout::for_version`].
+//! 3. **A geometry is never mutated in place.** The header region, the field
+//!    offsets, the checksum and the block length all changed, so this is
+//!    format **version 2** with magic `BRUTEXB2`. Version 1's number is
+//!    retired, never reused — `CLAUDE.md` §3 rule 8. See
+//!    [`format::RETIRED_VERSIONS`].
+//! 4. **A header update is one write of one self-checked unit.** There is no
+//!    API that can update the counter, the timestamp and the checksum
+//!    separately, because [`header::Commit`] carries one offset and one
+//!    buffer. See [`header`].
+//! 5. **Redundant header slots sit in different failure units.** Storage does
+//!    not fail at byte granularity, so the two slots are a whole page apart
+//!    rather than adjacent. See [`format::SLOT_STRIDE`].
+//! 6. **A vendor cannot write outside its own prefix, lexically.** The first
+//!    path segment is a `Vendor`, not a string, and every other segment is
+//!    checked and case-canonical before a path exists. What that does *not*
+//!    cover — a symlink — is stated in [`path::StorePath::to_path_buf`]
+//!    rather than implied away.
+
+#![forbid(unsafe_code)]
+
+pub mod block;
+pub mod crc;
+pub mod format;
+pub mod header;
+pub mod layout;
+pub mod path;

--- a/crates/store/src/path.rs
+++ b/crates/store/src/path.rs
@@ -108,35 +108,37 @@ pub const MAX_TIMEFRAME_LEN: usize = 4;
 /// destructuring in `longest_vendor` a compile error rather than a silent
 /// drift — which matters, because `crates/core` is not this crate's to watch.
 ///
-/// A `const` block rather than a helper function: a `const fn` is compiled as
-/// a function that nothing ever calls at run time, so coverage reports it as
-/// dead for ever, and `CLAUDE.md` §9 asks for 100% on every touched crate.
-pub const MAX_VENDOR_LEN: usize = {
-    let [groww, dhan] = Vendor::ALL;
-    let (a, b) = (groww.as_str().len(), dhan.as_str().len());
-    if a > b { a } else { b }
-};
+/// It is written down and then **checked against the table**, rather than
+/// computed from it. A computed maximum would silently widen [`MAX_LEN`] the
+/// day a longer vendor appeared; the assertion below is a compile error
+/// instead, at the moment `Vendor::ALL` changes — and `crates/core` is not
+/// this crate's to watch. Adding a vendor also changes the table's length,
+/// which makes the destructuring itself a compile error.
+///
+/// `store::unit::every_vendor_is_a_legal_segment` proves the bound is reached,
+/// so it is tight rather than merely sufficient.
+pub const MAX_VENDOR_LEN: usize = 5;
 
+const _: () = {
+    let [groww, dhan] = Vendor::ALL;
+    assert!(groww.as_str().len() <= MAX_VENDOR_LEN);
+    assert!(dhan.as_str().len() <= MAX_VENDOR_LEN);
+};
 const _: () = assert!(MAX_VENDOR_LEN <= MAX_SEGMENT_LEN);
 
 /// The longest file extension, dot included.
 ///
-/// Derived from [`FileKind::ALL`] by destructuring, so a new sibling file with
-/// a longer extension is a compile error here rather than a path that quietly
-/// exceeds [`MAX_LEN`].
-pub const MAX_EXTENSION_LEN: usize = {
+/// Checked against [`FileKind::ALL`] the same way and for the same reason: a
+/// new sibling file with a longer extension is a compile error here rather
+/// than a path that quietly exceeds [`MAX_LEN`].
+pub const MAX_EXTENSION_LEN: usize = 5;
+
+const _: () = {
     let [bars, checksums, overlay, lock] = FileKind::ALL;
-    let mut best = bars.extension().len();
-    if checksums.extension().len() > best {
-        best = checksums.extension().len();
-    }
-    if overlay.extension().len() > best {
-        best = overlay.extension().len();
-    }
-    if lock.extension().len() > best {
-        best = lock.extension().len();
-    }
-    best
+    assert!(bars.extension().len() <= MAX_EXTENSION_LEN);
+    assert!(checksums.extension().len() <= MAX_EXTENSION_LEN);
+    assert!(overlay.extension().len() <= MAX_EXTENSION_LEN);
+    assert!(lock.extension().len() <= MAX_EXTENSION_LEN);
 };
 
 /// The length of a rendered path, root excluded, when every segment is at its

--- a/crates/store/src/path.rs
+++ b/crates/store/src/path.rs
@@ -1,0 +1,676 @@
+//! The only way a store path is built.
+//!
+//! `docs/05-decisions.md` D-0019 locks the shape:
+//!
+//! ```text
+//! bars/<vendor>/<exchange>/<segment>/<symbol>/<timeframe>/<yyyy-mm>.bin
+//! bars/groww/NSE/INDEX/NIFTY/1min/2024-06.bin
+//! bars/dhan/NSE/INDEX/NIFTY/1min/2024-06.bin
+//! ```
+//!
+//! The vendor is the **first** segment so a vendor can be added, re-pulled or
+//! deleted by touching one directory and nothing else. That was prose and a
+//! directory naming habit; `docs/04-invariants.md` X-12 ("each vendor writes
+//! only under its own path prefix") named a test that did not exist, and
+//! nothing in code held the property up.
+//!
+//! # What the type enforces
+//!
+//! * The first segment is a [`Vendor`], not a string. A `&str` there could
+//!   name any vendor, or none: code holding `Vendor::Groww` could write into
+//!   `bars/dhan/…` and nothing would refuse it, and D-0019 deliberately keeps
+//!   no provenance field inside the file, so it would be indistinguishable
+//!   afterwards. `CLAUDE.md` §6's reasoning applies exactly — a parameter that
+//!   can be set can be set wrongly and silently.
+//! * The vendor segment is written first, always, by the one renderer.
+//! * Every remaining segment is checked before a [`StorePath`] exists at all,
+//!   so a path that could leave its vendor prefix is unconstructible rather
+//!   than unlikely. A separator, a `..`, a leading `/`, or an empty segment is
+//!   refused **by name** — see [`PathError`].
+//! * Segments are **case-canonical**: the vendor is lower case because
+//!   `Vendor::as_str` is, and the exchange, segment and symbol are upper case
+//!   because `brutex_core`'s types are. A non-canonical segment is refused,
+//!   not folded.
+//!
+//! # Why case is refused rather than tolerated
+//!
+//! Measured: on this repository's development machine (APFS, case-insensitive)
+//! `bars/groww/…` and `bars/GROWW/…` are **one** file, so writing the second
+//! destroys the first — one vendor overwriting another through the very API
+//! that exists to make that impossible. On the CI runner (ext4,
+//! case-sensitive) the same two inputs are **two** directory trees, silently
+//! splitting one vendor's history in half. Same code, two different silent
+//! failures, chosen by the host. That is the identical argument that rejected
+//! a host-dependent block length, applied to the path — `CLAUDE.md` §3 rule 5.
+//!
+//! `brutex_core::symbol::Symbol::new` already upper-cases so `nifty` and
+//! `NIFTY` cannot become two instruments; [`StorePath::new`] taking a raw
+//! `&str` was a public door around that normalisation.
+//!
+//! # What it does **not** enforce
+//!
+//! [`StorePath::to_path_buf`] guarantees a **lexical** property. No component
+//! is `..`, none is absolute, so the rendered path cannot climb out of
+//! `root/bars/<vendor>/` *as text*. A symlink at any component defeats that,
+//! and nothing in this crate resolves or refuses one — a `bars/groww` symlink
+//! pointing at `bars/dhan` sends every groww write into dhan's files while
+//! satisfying every assertion the isolation test makes. Closing it needs
+//! `openat` with `O_NOFOLLOW` per component in a writer that does not exist
+//! yet. Stated here rather than implied away.
+//!
+//! `store::unit::vendor_prefix_isolated` is the test X-12 names.
+//!
+//! # Cost
+//!
+//! Construction is a bounded scan of at most [`MAX_SEGMENT_LEN`] bytes per
+//! segment over a fixed number of segments — constant, independent of how many
+//! instruments, vendors or months exist. It allocates nothing:
+//! [`StorePath`] borrows its segments and [`std::fmt::Display`] writes them
+//! straight into the caller's sink. [`StorePath::to_path_buf`] is the one
+//! allocating entry point, and it takes two bounded allocations — counted
+//! there, not rounded down to a nicer number.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use brutex_core::instrument::{InstrumentKey, Kind};
+use brutex_core::symbol::SYMBOL_CAPACITY;
+use brutex_core::vendor::Vendor;
+
+/// The directory every bar file lives under.
+pub const STORE_ROOT: &str = "bars";
+
+/// The longest a single path segment may be.
+///
+/// Matches `brutex_core::symbol::SYMBOL_CAPACITY`, because the symbol is the
+/// longest segment and a store path that could not hold a legal symbol would
+/// be a second, quieter limit on what can be stored. The assertion below is
+/// the whole of that promise: raising `SYMBOL_CAPACITY` without raising this
+/// is a compile error, not a refusal discovered by a `for_key` call on the one
+/// symbol long enough to trip it.
+pub const MAX_SEGMENT_LEN: usize = 24;
+
+const _: () = assert!(MAX_SEGMENT_LEN == SYMBOL_CAPACITY);
+
+/// The longest a timeframe segment can be.
+///
+/// The timeframe is not caller text — it is one of [`Timeframe::KNOWN`], so
+/// its bound is the longest name in that table rather than
+/// [`MAX_SEGMENT_LEN`]. `store::unit::a_maximal_path_fits_the_declared_bound`
+/// checks the table against it.
+pub const MAX_TIMEFRAME_LEN: usize = 4;
+
+/// The longest vendor segment.
+///
+/// Derived from `Vendor::ALL` rather than written down: a vendor with a longer
+/// name would otherwise widen the longest legal path without widening the
+/// bound. Adding a vendor changes `Vendor::ALL`'s length, which makes the
+/// destructuring in `longest_vendor` a compile error rather than a silent
+/// drift — which matters, because `crates/core` is not this crate's to watch.
+///
+/// A `const` block rather than a helper function: a `const fn` is compiled as
+/// a function that nothing ever calls at run time, so coverage reports it as
+/// dead for ever, and `CLAUDE.md` §9 asks for 100% on every touched crate.
+pub const MAX_VENDOR_LEN: usize = {
+    let [groww, dhan] = Vendor::ALL;
+    let (a, b) = (groww.as_str().len(), dhan.as_str().len());
+    if a > b { a } else { b }
+};
+
+const _: () = assert!(MAX_VENDOR_LEN <= MAX_SEGMENT_LEN);
+
+/// The longest file extension, dot included.
+///
+/// Derived from [`FileKind::ALL`] by destructuring, so a new sibling file with
+/// a longer extension is a compile error here rather than a path that quietly
+/// exceeds [`MAX_LEN`].
+pub const MAX_EXTENSION_LEN: usize = {
+    let [bars, checksums, overlay, lock] = FileKind::ALL;
+    let mut best = bars.extension().len();
+    if checksums.extension().len() > best {
+        best = checksums.extension().len();
+    }
+    if overlay.extension().len() > best {
+        best = overlay.extension().len();
+    }
+    if lock.extension().len() > best {
+        best = lock.extension().len();
+    }
+    best
+};
+
+/// The length of a rendered path, root excluded, when every segment is at its
+/// cap.
+///
+/// Tight, not merely sufficient: the longest legal path is exactly this many
+/// bytes, and `store::unit::a_maximal_path_fits_the_declared_bound` asserts
+/// the equality by building one. A bound with slack in it is a bound nobody
+/// notices going wrong.
+pub const MAX_LEN: usize = STORE_ROOT.len()
+    + 1 + MAX_VENDOR_LEN          // "/groww"
+    + 3 * (1 + MAX_SEGMENT_LEN)   // exchange, segment, symbol
+    + 1 + MAX_TIMEFRAME_LEN       // "/1min"
+    + 1 + 7                       // "/yyyy-mm"
+    + MAX_EXTENSION_LEN;
+
+/// Which case a segment is canonically written in.
+///
+/// Not a preference: it is which of `brutex_core`'s types renders that
+/// segment. `Vendor::as_str` is lower case, `Exchange::as_str`,
+/// `Segment::as_str` and `Symbol` are upper case.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SegmentCase {
+    /// ASCII letters must be lower case, as `Vendor::as_str` renders them.
+    Lower,
+    /// ASCII letters must be upper case, as `Symbol` renders them.
+    Upper,
+}
+
+/// Why a path was refused.
+///
+/// Every variant names the offending field, because "invalid path" sends the
+/// operator to guess which of six segments was wrong.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum PathError {
+    /// A segment was empty. An empty segment collapses two directory levels
+    /// into one and silently files data somewhere else.
+    EmptySegment {
+        /// Which segment.
+        field: &'static str,
+    },
+    /// A segment was `.` or `..`.
+    ///
+    /// `..` is the escape: one of them leaves the vendor prefix, two leave the
+    /// store. Refused by name rather than by the byte rule below so the reason
+    /// is legible in the error.
+    Traversal {
+        /// Which segment.
+        field: &'static str,
+    },
+    /// A segment held a byte outside the allowed set.
+    ///
+    /// The set is ASCII letters, digits, `-`, `_` and `&` — the same set
+    /// `brutex_core::symbol::Symbol` admits. A separator (`/` or `\`) lands
+    /// here, which is also what refuses an absolute path: it begins with one.
+    IllegalByte {
+        /// Which segment.
+        field: &'static str,
+        /// The byte that was refused.
+        byte: u8,
+    },
+    /// A segment held a letter in the wrong case.
+    ///
+    /// Refused rather than folded, and refused rather than accepted: two
+    /// segments differing only in case are two files on a case-sensitive
+    /// filesystem and one file on a case-insensitive one, so tolerating them
+    /// makes the on-disk result depend on the host.
+    NotCanonicalCase {
+        /// Which segment.
+        field: &'static str,
+        /// The letter that was in the wrong case.
+        byte: u8,
+    },
+    /// A segment was longer than [`MAX_SEGMENT_LEN`].
+    SegmentTooLong {
+        /// Which segment.
+        field: &'static str,
+        /// How long it was.
+        len: usize,
+    },
+    /// No timeframe of that length is defined.
+    ///
+    /// `docs/05-decisions.md` D-0015: minute bars only, until a minute-level
+    /// result earns the upgrade. A new timeframe is a new row in
+    /// [`Timeframe::KNOWN`], not a string a caller invents.
+    UnknownTimeframe {
+        /// The length asked for, in seconds.
+        secs: u32,
+    },
+    /// A month outside `1..=12`.
+    MonthOutOfRange {
+        /// The month asked for.
+        month: u8,
+    },
+    /// A year outside `1970..=9999`.
+    ///
+    /// Below 1970 no bar can exist — timestamps are microseconds since the
+    /// Unix epoch. Above 9999 the four-digit rendering would lie.
+    YearOutOfRange {
+        /// The year asked for.
+        year: u16,
+    },
+    /// The instrument needs a contract name, which this builder does not form.
+    ///
+    /// D-0019 files a future or an option under its **contract**, not its
+    /// underlying — `NIFTY` alone would put every expiry in one directory.
+    /// Forming a contract segment needs the expiry and strike rendering that
+    /// belongs beside `InstrumentKey`, and it does not exist yet. Refused by
+    /// name rather than filed under the underlying, which would silently merge
+    /// distinct series.
+    ContractPathUnsupported,
+}
+
+impl fmt::Display for PathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::EmptySegment { field } => write!(f, "path segment {field} is empty"),
+            Self::Traversal { field } => {
+                write!(f, "path segment {field} is a traversal and would escape")
+            }
+            Self::IllegalByte { field, byte } => {
+                write!(f, "path segment {field} holds byte {byte:#04x}")
+            }
+            Self::NotCanonicalCase { field, byte } => {
+                write!(
+                    f,
+                    "path segment {field} holds byte {byte:#04x} in the wrong case"
+                )
+            }
+            Self::SegmentTooLong { field, len } => {
+                write!(
+                    f,
+                    "path segment {field} is {len} bytes, max {MAX_SEGMENT_LEN}"
+                )
+            }
+            Self::UnknownTimeframe { secs } => write!(f, "no timeframe of {secs} seconds"),
+            Self::MonthOutOfRange { month } => write!(f, "month {month} is not 1..=12"),
+            Self::YearOutOfRange { year } => write!(f, "year {year} is not 1970..=9999"),
+            Self::ContractPathUnsupported => {
+                f.write_str("a futures or options path needs a contract segment")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PathError {}
+
+/// A bar length, as both a number of seconds and a path segment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Timeframe {
+    secs: u32,
+    name: &'static str,
+}
+
+impl Timeframe {
+    /// One-minute bars — the only timeframe D-0015 admits.
+    pub const MINUTE_1: Self = Self {
+        secs: 60,
+        name: "1min",
+    };
+
+    /// Every timeframe this build stores.
+    pub const KNOWN: &'static [Self] = &[Self::MINUTE_1];
+
+    /// The timeframe of `secs` seconds.
+    ///
+    /// # Errors
+    ///
+    /// [`PathError::UnknownTimeframe`] naming the length. There is no
+    /// derived-name fallback: a directory called `300s` that no reader looks
+    /// for is data written into a hole.
+    pub fn from_secs(secs: u32) -> Result<Self, PathError> {
+        Self::KNOWN
+            .iter()
+            .copied()
+            .find(|tf| tf.secs == secs)
+            .ok_or(PathError::UnknownTimeframe { secs })
+    }
+
+    /// Seconds per bar. Matches `Header::timeframe_secs`.
+    #[must_use]
+    pub const fn secs(self) -> u32 {
+        self.secs
+    }
+
+    /// The path segment.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        self.name
+    }
+}
+
+/// The month a bar file covers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct YearMonth {
+    year: u16,
+    month: u8,
+}
+
+impl YearMonth {
+    /// Builds a month.
+    ///
+    /// # Errors
+    ///
+    /// [`PathError::YearOutOfRange`] outside `1970..=9999`, or
+    /// [`PathError::MonthOutOfRange`] outside `1..=12`.
+    pub const fn new(year: u16, month: u8) -> Result<Self, PathError> {
+        if year < 1970 || year > 9999 {
+            return Err(PathError::YearOutOfRange { year });
+        }
+        if month == 0 || month > 12 {
+            return Err(PathError::MonthOutOfRange { month });
+        }
+        Ok(Self { year, month })
+    }
+
+    /// The year.
+    #[must_use]
+    pub const fn year(self) -> u16 {
+        self.year
+    }
+
+    /// The month, `1..=12`.
+    #[must_use]
+    pub const fn month(self) -> u8 {
+        self.month
+    }
+}
+
+impl fmt::Display for YearMonth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:04}-{:02}", self.year, self.month)
+    }
+}
+
+/// Which of a month's sibling files this path names.
+///
+/// `docs/02-store-format.md` §6, §8 and §9. The overlay is a separate file at
+/// its own stride precisely so the base record stays 56 bytes forever.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum FileKind {
+    /// The bar records.
+    Bars,
+    /// The sidecar block checksums — one per [`crate::layout::Layout`] block,
+    /// at the same block index. See [`crate::block`].
+    Checksums,
+    /// Computed overlay fields, at their own stride.
+    Overlay,
+    /// The advisory lock a writer holds for the month.
+    ///
+    /// `docs/02-store-format.md` §9: "One writer per file, enforced by an
+    /// advisory lock, and the lock is a leaf — never held while acquiring
+    /// another." [`crate::header::Header::commit`]'s crash argument is
+    /// conditioned on exactly one writer, so the lock needs a name that is
+    /// derived the same way every other sibling is, rather than invented at
+    /// the call site by string concatenation.
+    Lock,
+}
+
+impl FileKind {
+    /// Every sibling file a month has.
+    pub const ALL: [Self; 4] = [Self::Bars, Self::Checksums, Self::Overlay, Self::Lock];
+
+    /// The file extension, dot included.
+    #[must_use]
+    pub const fn extension(self) -> &'static str {
+        match self {
+            Self::Bars => ".bin",
+            Self::Checksums => ".crc",
+            Self::Overlay => ".ovl",
+            Self::Lock => ".lock",
+        }
+    }
+}
+
+/// The pieces a store path is built from.
+///
+/// A struct rather than eight positional arguments: `exchange` and `segment`
+/// are both short uppercase strings, and swapping them at a call site would
+/// build a valid-looking path to the wrong place with nothing to catch it.
+#[derive(Debug, Clone, Copy)]
+pub struct PathParts<'a> {
+    /// The vendor. Becomes the first segment under [`STORE_ROOT`].
+    ///
+    /// A [`Vendor`], not a string: X-12 says each vendor writes only under its
+    /// own prefix, and a `&str` cannot carry that.
+    pub vendor: Vendor,
+    /// The exchange, e.g. `NSE`. Upper case.
+    pub exchange: &'a str,
+    /// The exchange segment, e.g. `INDEX`. Upper case.
+    pub segment: &'a str,
+    /// The symbol or contract, e.g. `NIFTY`. Upper case.
+    pub symbol: &'a str,
+    /// The bar length.
+    pub timeframe: Timeframe,
+    /// The month the file covers.
+    pub month: YearMonth,
+    /// Which sibling file.
+    pub file: FileKind,
+}
+
+/// A validated store path. The only thing that renders one.
+///
+/// Borrows its segments, so building one allocates nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct StorePath<'a> {
+    vendor: Vendor,
+    exchange: &'a str,
+    segment: &'a str,
+    symbol: &'a str,
+    timeframe: Timeframe,
+    month: YearMonth,
+    file: FileKind,
+}
+
+impl<'a> StorePath<'a> {
+    /// Validates the parts and fixes the vendor as the first segment.
+    ///
+    /// The vendor is not re-checked: it is a [`Vendor`], a closed set of
+    /// lower-case literals, and `store::unit::every_vendor_is_a_legal_segment`
+    /// drives this module's own [`check_segment`] over all of them. A runtime
+    /// check would carry a refusal arm no input could reach.
+    ///
+    /// # Errors
+    ///
+    /// [`PathError`] naming the first segment that is empty, a traversal,
+    /// over-long, in the wrong case, or holds a byte outside the allowed set.
+    /// An absolute path and a nested path both land on the separator byte.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use brutex_core::vendor::Vendor;
+    /// # use store::path::{FileKind, PathError, PathParts, StorePath, Timeframe, YearMonth};
+    /// let path = StorePath::new(PathParts {
+    ///     vendor: Vendor::Groww,
+    ///     exchange: "NSE",
+    ///     segment: "INDEX",
+    ///     symbol: "NIFTY",
+    ///     timeframe: Timeframe::MINUTE_1,
+    ///     month: YearMonth::new(2024, 6)?,
+    ///     file: FileKind::Bars,
+    /// })?;
+    /// assert_eq!(path.to_string(), "bars/groww/NSE/INDEX/NIFTY/1min/2024-06.bin");
+    ///
+    /// let base = PathParts {
+    ///     vendor: Vendor::Groww,
+    ///     exchange: "NSE",
+    ///     segment: "INDEX",
+    ///     symbol: "NIFTY",
+    ///     timeframe: Timeframe::MINUTE_1,
+    ///     month: YearMonth::new(2024, 6)?,
+    ///     file: FileKind::Bars,
+    /// };
+    ///
+    /// // A symbol that tries to climb out is refused, not sanitised.
+    /// assert!(StorePath::new(PathParts { symbol: "../dhan", ..base }).is_err());
+    ///
+    /// // And so is one that differs from the canonical form only in case,
+    /// // because "nifty" and "NIFTY" are two files on ext4 and one on APFS.
+    /// assert_eq!(
+    ///     StorePath::new(PathParts { symbol: "nifty", ..base }),
+    ///     Err(PathError::NotCanonicalCase { field: "symbol", byte: b'n' }),
+    /// );
+    /// # Ok::<(), PathError>(())
+    /// ```
+    pub fn new(parts: PathParts<'a>) -> Result<Self, PathError> {
+        check_segment("exchange", parts.exchange, SegmentCase::Upper)?;
+        check_segment("segment", parts.segment, SegmentCase::Upper)?;
+        check_segment("symbol", parts.symbol, SegmentCase::Upper)?;
+        Ok(Self {
+            vendor: parts.vendor,
+            exchange: parts.exchange,
+            segment: parts.segment,
+            symbol: parts.symbol,
+            timeframe: parts.timeframe,
+            month: parts.month,
+            file: parts.file,
+        })
+    }
+
+    /// The path for one vendor's copy of one instrument.
+    ///
+    /// Takes the canonical identity from `crates/core` rather than three loose
+    /// strings, so the exchange, segment and symbol cannot disagree with the
+    /// key they came from.
+    ///
+    /// # Errors
+    ///
+    /// [`PathError::ContractPathUnsupported`] for a future or an option, which
+    /// D-0019 files under a contract segment this builder does not form. Plus
+    /// anything [`StorePath::new`] refuses.
+    pub fn for_key(
+        vendor: Vendor,
+        key: &'a InstrumentKey,
+        timeframe: Timeframe,
+        month: YearMonth,
+        file: FileKind,
+    ) -> Result<Self, PathError> {
+        match key.kind {
+            Kind::Index | Kind::Equity => Self::new(PathParts {
+                vendor,
+                exchange: key.exchange.as_str(),
+                segment: key.segment.as_str(),
+                symbol: key.underlying.as_str(),
+                timeframe,
+                month,
+                file,
+            }),
+            _ => Err(PathError::ContractPathUnsupported),
+        }
+    }
+
+    /// The vendor this path belongs to.
+    #[must_use]
+    pub const fn vendor(self) -> Vendor {
+        self.vendor
+    }
+
+    /// The vendor segment — the first segment under [`STORE_ROOT`].
+    #[must_use]
+    pub const fn vendor_segment(self) -> &'static str {
+        self.vendor.as_str()
+    }
+
+    /// The bar length.
+    #[must_use]
+    pub const fn timeframe(self) -> Timeframe {
+        self.timeframe
+    }
+
+    /// The month.
+    #[must_use]
+    pub const fn month(self) -> YearMonth {
+        self.month
+    }
+
+    /// Which sibling file.
+    #[must_use]
+    pub const fn file(self) -> FileKind {
+        self.file
+    }
+
+    /// The path under `root`.
+    ///
+    /// Two allocations, both bounded: the rendered relative path, and the
+    /// buffer it is joined into — reserved up front from [`MAX_LEN`] so
+    /// neither grows. Not one: `root` is an `OsStr`, which is not required to
+    /// be UTF-8, so the relative path cannot be rendered straight into it
+    /// through `fmt::Write`. Counted honestly rather than rounded down.
+    ///
+    /// # What this guarantees, exactly
+    ///
+    /// **Lexically**, no component is `.` or `..` and none is absolute, so the
+    /// rendered text cannot name anything outside `root/bars/<vendor>/`.
+    ///
+    /// **On a filesystem, it guarantees nothing.** A symlink at any component
+    /// redirects the whole subtree: with `root/bars/groww` linked to
+    /// `root/bars/dhan`, a write through a groww path lands in dhan's file
+    /// while still satisfying `starts_with(root/bars/groww)` and holding no
+    /// `Component::ParentDir`. This crate does not resolve or refuse links —
+    /// that needs `openat` with `O_NOFOLLOW` per component, in a writer that
+    /// does not exist yet, halting loudly and naming the linked component. The
+    /// earlier wording here claimed the filesystem property outright, which
+    /// was a failure hidden behind a claim.
+    #[must_use]
+    pub fn to_path_buf(self, root: &Path) -> PathBuf {
+        let mut out = PathBuf::with_capacity(root.as_os_str().len() + 1 + MAX_LEN);
+        out.push(root);
+        out.push(self.to_string());
+        out
+    }
+}
+
+impl fmt::Display for StorePath<'_> {
+    /// The one renderer. The vendor is written before anything that varies.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}/{}/{}/{}/{}/{}/{}{}",
+            STORE_ROOT,
+            self.vendor.as_str(),
+            self.exchange,
+            self.segment,
+            self.symbol,
+            self.timeframe.as_str(),
+            self.month,
+            self.file.extension(),
+        )
+    }
+}
+
+/// Refuses anything that is not a plain, self-contained, canonically-cased
+/// directory name.
+///
+/// Public so the vendor table can be driven through the same function
+/// [`StorePath::new`] uses, rather than through a paraphrase of it in a test.
+///
+/// The illegal-byte scan runs over the whole segment **before** the case scan,
+/// so a segment that is both mis-cased and an escape attempt is reported as
+/// the escape. A traversal is the security-relevant fact; the case is a
+/// reproducibility one.
+///
+/// # Errors
+///
+/// [`PathError::EmptySegment`], [`PathError::SegmentTooLong`],
+/// [`PathError::Traversal`], [`PathError::IllegalByte`] or
+/// [`PathError::NotCanonicalCase`], checked in that order.
+pub fn check_segment(field: &'static str, text: &str, case: SegmentCase) -> Result<(), PathError> {
+    if text.is_empty() {
+        return Err(PathError::EmptySegment { field });
+    }
+    if text.len() > MAX_SEGMENT_LEN {
+        return Err(PathError::SegmentTooLong {
+            field,
+            len: text.len(),
+        });
+    }
+    if text == "." || text == ".." {
+        return Err(PathError::Traversal { field });
+    }
+    if let Some(byte) = text
+        .bytes()
+        .find(|b| !matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'&'))
+    {
+        return Err(PathError::IllegalByte { field, byte });
+    }
+    let wrong_case = match case {
+        SegmentCase::Lower => text.bytes().find(u8::is_ascii_uppercase),
+        SegmentCase::Upper => text.bytes().find(u8::is_ascii_lowercase),
+    };
+    match wrong_case {
+        Some(byte) => Err(PathError::NotCanonicalCase { field, byte }),
+        None => Ok(()),
+    }
+}

--- a/crates/store/tests/fault.rs
+++ b/crates/store/tests/fault.rs
@@ -1,0 +1,677 @@
+//! Crash and corruption behaviour of the header: `store::fault::*`.
+//!
+//! The defect these tests exist for: publishing a commit wrote `n_valid`,
+//! `last_ts_micros` and `header_crc` as three separate stores. A crash between
+//! any two left a header whose checksum disagreed with its own counter, and a
+//! header that fails its checksum condemns the **whole file** rather than the
+//! tail. D-0004's guarantee that a torn record is unobservable did not extend
+//! to a torn header.
+//!
+//! The second defect: the reader took the highest-generation slot, checked
+//! only that one, and returned an error for the whole file when it failed —
+//! reproducing the outcome the design exists to abolish, with the check moved
+//! from the checksum to the file length. The intact previous commit sat in the
+//! other slot and was never consulted.
+//!
+//! What is exercised here is the 32768-byte header region of a file image, not
+//! a file: this crate performs no I/O yet. Every byte tested is a byte that
+//! would be on disk, and the write under test is the single `pwrite` a writer
+//! will issue, so the crash window is modelled exactly. **No test here kills a
+//! real process or cuts real power**, and the 65 prefixes walked below are 65
+//! points of a much larger space of partial outcomes.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+
+use store::block;
+use store::format::{Bar, FLAG_CHECKSUMS, FormatError, HEADER_LEN, RECORD_STRIDE, SLOT_LEN};
+use store::header::{Commit, Header};
+use store::layout::Layout;
+use store::path::FileKind;
+
+/// Bytes of header region in a version-2 file.
+const REGION_LEN: usize = 32_768;
+/// Bytes from one header slot to the next, as a `usize`.
+const SLOT_STRIDE_LEN: usize = 16_384;
+
+/// The open of the first bar of 2024-06-03, in microseconds.
+const T0: i64 = 1_717_386_300_000_000;
+/// One minute, in microseconds.
+const MINUTE: i64 = 60_000_000;
+
+/// The first and last timestamps of `count` one-minute bars starting at index
+/// `from`.
+const fn batch(from: i64, count: i64) -> (i64, i64) {
+    (T0 + from * MINUTE, T0 + (from + count - 1) * MINUTE)
+}
+
+/// Applies the first `prefix` bytes of a commit — a write torn at that point.
+fn apply(region: &mut [u8], commit: &Commit, prefix: usize) {
+    let at = usize::try_from(commit.offset).expect("offset is in range");
+    region
+        .iter_mut()
+        .skip(at)
+        .zip(commit.bytes.iter().take(prefix))
+        .for_each(|(dst, src)| *dst = *src);
+}
+
+/// A region with three commits already published, and the header of the last.
+///
+/// Generation 0 → slot 0 (empty), 1 → slot 1 (100 records), 2 → slot 0 (150).
+/// So slot 0 holds generation 2 and slot 1 holds generation 1: the previous
+/// commit is intact in the slot the next commit will not touch.
+fn three_commits() -> (Vec<u8>, Header) {
+    let mut region = vec![0u8; REGION_LEN];
+
+    let genesis = Header::genesis(7, 60, FLAG_CHECKSUMS);
+    apply(&mut region, &genesis.commit().expect("v2"), SLOT_LEN);
+
+    let (first_from, first_to) = batch(0, 100);
+    let first = genesis.advance(100, first_from, first_to).expect("fits");
+    apply(&mut region, &first.commit().expect("v2"), SLOT_LEN);
+
+    let (second_from, second_to) = batch(100, 50);
+    let second = first.advance(50, second_from, second_to).expect("fits");
+    apply(&mut region, &second.commit().expect("v2"), SLOT_LEN);
+
+    let read = Header::read_region(&region, file_len(200)).expect("three whole commits");
+    assert_eq!(read, second);
+    assert_eq!(read.generation, 2);
+    assert_eq!(read.n_valid, 150);
+    // The range the header advertises is the range the records occupy -- the
+    // field that no method used to set at all.
+    assert_eq!(read.first_ts_micros, T0);
+    assert_eq!(read.last_ts_micros, second_to);
+    (region, second)
+}
+
+/// A file length that can hold `records` records.
+const fn file_len(records: u64) -> u64 {
+    HEADER_LEN + records * RECORD_STRIDE
+}
+
+/// One bar's 56 bytes, little-endian, in field order.
+fn bar_bytes(bar: &Bar) -> Vec<u8> {
+    [
+        bar.ts_micros,
+        bar.open,
+        bar.high,
+        bar.low,
+        bar.close,
+        bar.volume,
+        bar.open_interest,
+    ]
+    .iter()
+    .flat_map(|field| field.to_le_bytes())
+    .collect()
+}
+
+#[test]
+fn a_torn_header_commit_never_reports_an_uncommitted_count() {
+    let (committed, previous) = three_commits();
+    let (from, to) = batch(150, 25);
+    let next = previous.advance(25, from, to).expect("fits");
+    let commit = next.commit().expect("v2");
+
+    // Generation 3 goes to slot 1, which holds generation 1 -- never slot 0,
+    // which holds the newest committed state. That is the whole argument, and
+    // the two slots are a whole page apart so the write cannot reach slot 0.
+    assert_eq!(commit.slot, 1);
+    assert_eq!(commit.offset, 16_384);
+
+    let mut published_from = None;
+    for prefix in 0..=SLOT_LEN {
+        let mut region = committed.clone();
+        apply(&mut region, &commit, prefix);
+
+        let read = Header::read_region(&region, file_len(200))
+            .unwrap_or_else(|e| panic!("a torn write at byte {prefix} lost the file: {e}"));
+
+        // The reader sees the new commit exactly when the slot it landed in
+        // holds the whole image, and the previous one otherwise. There is no
+        // third answer -- no count that was never committed, and no header
+        // whose counter and checksum disagree.
+        let landed_whole = region[SLOT_STRIDE_LEN..SLOT_STRIDE_LEN + SLOT_LEN] == commit.bytes[..];
+        if landed_whole {
+            assert_eq!(read, next, "whole image at prefix {prefix}");
+            assert_eq!(read.n_valid, 175);
+            published_from.get_or_insert(prefix);
+        } else {
+            assert_eq!(read, previous, "partial image at prefix {prefix}");
+            assert_eq!(read.n_valid, 150);
+            assert_eq!(read.generation, 2);
+        }
+        assert!(
+            read.n_valid == 150 || read.n_valid == 175,
+            "prefix {prefix} produced a count nobody committed: {}",
+            read.n_valid,
+        );
+    }
+
+    // The checksum sits at bytes 56..60 and the four bytes after it are
+    // reserved zeros, which the previous image also held -- so the commit
+    // becomes durable the moment its checksum is down, at 60 bytes, and not
+    // before.
+    assert_eq!(published_from, Some(60));
+}
+
+#[test]
+fn commit_counter_publishes_last() {
+    // docs/04-invariants.md S-03: a reader never observes a record beyond
+    // n_valid. The counter is published last, so the reader's horizon is
+    // always exactly what some completed commit published -- never a byte
+    // further, whatever is already sitting on the disk past it.
+    let v2 = Layout::V2;
+    let (committed, previous) = three_commits();
+    let previous_commit = previous.commit().expect("v2");
+    let (from, to) = batch(150, 25);
+    let next = previous.advance(25, from, to).expect("fits");
+    let commit = next.commit().expect("v2");
+
+    // Step 1 of docs/02 §5 writes the records at the offset the OLD counter
+    // names, so they are past the horizon the whole time they are landing.
+    assert_eq!(v2.offset_of(previous.n_valid), Ok(file_len(150)));
+    assert_eq!(previous_commit.durable_through, file_len(150));
+    assert_eq!(commit.durable_through, file_len(175));
+
+    for prefix in 0..=SLOT_LEN {
+        let mut region = committed.clone();
+        apply(&mut region, &commit, prefix);
+        // The file is long enough for all 175 records the whole time: the
+        // bytes are there, and the counter is still what decides.
+        let read = Header::read_region(&region, file_len(175)).expect("never lost");
+        let horizon = v2.offset_of(read.n_valid).expect("fits");
+        let published = if read.n_valid == next.n_valid {
+            commit.durable_through
+        } else {
+            previous_commit.durable_through
+        };
+        assert_eq!(
+            horizon, published,
+            "at prefix {prefix} the reader's horizon was not a published one",
+        );
+    }
+}
+
+#[test]
+fn kill_between_write_and_commit() {
+    // docs/04-invariants.md S-04. The writer pwrites 25 records and then the
+    // header slot; power is lost in between, with the header page reaching the
+    // platter first -- which is the LIKELY ordering, because page 0 is
+    // re-dirtied on every commit and is the hottest writeback candidate in the
+    // file.
+    let v2 = Layout::V2;
+    let (committed, previous) = three_commits();
+    let (from, to) = batch(150, 25);
+    let next = previous.advance(25, from, to).expect("fits");
+    let commit = next.commit().expect("v2");
+
+    // The commit names the offset the records must have reached first, so a
+    // writer cannot claim it did not know which barrier to take.
+    assert_eq!(commit.durable_through, file_len(175));
+
+    let mut region = committed.clone();
+    apply(&mut region, &commit, SLOT_LEN);
+
+    // Case A -- the records never extended the file. The header is whole and
+    // says 175; the bytes say 150. The reader returns generation 2. It does
+    // NOT condemn the file, which is what losing a month to save a tail looks
+    // like, and it does not return 25 records of whatever was there.
+    let read = Header::read_region(&region, file_len(150)).expect("the previous commit survives");
+    assert_eq!(read, previous);
+    assert_eq!((read.generation, read.n_valid), (2, 150));
+
+    // Case B -- the file WAS extended and the extent reads as zeros. The
+    // length supports the count, so the counter alone cannot catch it.
+    let read = Header::read_region(&region, file_len(175)).expect("the header is whole");
+    assert_eq!(read.n_valid, 175);
+
+    // And an all-zero record passes every structural check a record has: it
+    // is a legal flat bar, and its open interest is a REAL zero rather than
+    // the null sentinel, so a spot-index file would quietly acquire
+    // derivative-shaped records.
+    let ghost = Bar::default();
+    assert!(ghost.ohlc_is_sane());
+    assert!(!ghost.oi_is_null());
+    assert_eq!(ghost.oi(), Some(0));
+
+    // The block checksum is the only thing that can say those bytes are not
+    // the bytes that were committed. Record 174 lives in block 2, which under
+    // a counter of 175 covers 29 records.
+    let tail = v2.block_of(174);
+    assert_eq!(tail, 2);
+    assert_eq!(v2.records_in_block(tail, 175), Ok(29));
+
+    let written = vec![0x5Au8; 29 * 56];
+    let sealed = block::seal(v2, 175, tail, &written).expect("the writer sealed it");
+    assert_eq!(block::verify(&read, v2, tail, &written, sealed), Ok(()));
+
+    let lost = vec![0u8; written.len()];
+    let computed = block::seal(v2, 175, tail, &lost).expect("same length");
+    assert_eq!(
+        block::verify(&read, v2, tail, &lost, sealed),
+        Err(FormatError::BlockChecksum {
+            block: tail,
+            stored: sealed,
+            computed,
+        }),
+        "a lost write must be named, not read as 29 flat bars",
+    );
+}
+
+#[test]
+fn bitflip_detected() {
+    // docs/04-invariants.md S-06. A flipped bit in a raw i64 price yields a
+    // DIFFERENT, PLAUSIBLE price -- there is no parse to fail and no structure
+    // to violate. Every bit of every byte of a block, walked.
+    let v2 = Layout::V2;
+    let (from, to) = batch(0, 2);
+    let header = Header::genesis(7, 60, FLAG_CHECKSUMS)
+        .advance(2, from, to)
+        .expect("fits");
+
+    let real = Bar {
+        ts_micros: T0,
+        open: 2_333_870,
+        high: 2_333_870,
+        low: 2_308_370,
+        close: 2_310_955,
+        volume: 0,
+        open_interest: i64::MIN,
+    };
+    let next = Bar {
+        ts_micros: T0 + MINUTE,
+        ..real
+    };
+    let mut bytes = bar_bytes(&real);
+    bytes.extend(bar_bytes(&next));
+    assert_eq!(bytes.len(), 112);
+
+    let sealed = block::seal(v2, header.n_valid, 0, &bytes).expect("one partial block");
+    assert_eq!(block::verify(&header, v2, 0, &bytes, sealed), Ok(()));
+
+    for byte in 0..bytes.len() {
+        for bit in 0..8u32 {
+            let mut damaged = bytes.clone();
+            damaged[byte] ^= 1u8 << bit;
+            let refusal = block::verify(&header, v2, 0, &damaged, sealed);
+            assert!(
+                matches!(refusal, Err(FormatError::BlockChecksum { block: 0, .. })),
+                "bit {bit} of byte {byte} was not detected: {refusal:?}",
+            );
+        }
+    }
+
+    // A file that declares no checksums cannot have a block verified, and
+    // says so rather than answering "fine".
+    let unchecked = Header { flags: 0, ..header };
+    assert!(!unchecked.checksums_present());
+    assert_eq!(
+        block::verify(&unchecked, v2, 0, &bytes, sealed),
+        Err(FormatError::ChecksumsAbsent),
+    );
+
+    // And a block offered at a length the geometry does not give it is
+    // refused rather than trimmed to fit.
+    assert_eq!(
+        block::seal(v2, header.n_valid, 0, &bytes[..111]),
+        Err(FormatError::BlockLengthMismatch {
+            block: 0,
+            len: 111,
+            need: 112,
+        }),
+    );
+}
+
+#[test]
+fn a_single_bit_flip_in_any_header_byte_is_detected() {
+    let (committed, _) = three_commits();
+
+    // Slot 0 holds generation 2 -- the newest commit. Damage it anywhere and
+    // the reader must fall back to generation 1, never to a mixture.
+    for byte in 0..SLOT_LEN {
+        for bit in 0..8u32 {
+            let mut region = committed.clone();
+            region[byte] ^= 1u8 << bit;
+
+            let read = Header::read_region(&region, file_len(200)).unwrap_or_else(|e| {
+                panic!("bit {bit} of byte {byte} took the whole file down: {e}")
+            });
+            assert_eq!(
+                read.generation, 1,
+                "bit {bit} of byte {byte} was not detected",
+            );
+            assert_eq!(read.n_valid, 100);
+        }
+    }
+}
+
+#[test]
+fn a_damaged_slot_is_not_repaired_by_a_second_write_to_the_same_slot() {
+    // Two commits in a row cannot land in the same slot, so the corrupted copy
+    // of the newest state is never the only copy.
+    let (_, header) = three_commits();
+    let mut generation = header;
+    let mut slots = Vec::new();
+    for step in 0..8i64 {
+        let (from, to) = batch(150 + step, 1);
+        generation = generation.advance(1, from, to).expect("fits");
+        slots.push(generation.commit().expect("v2").slot);
+    }
+    assert_eq!(slots, vec![1, 0, 1, 0, 1, 0, 1, 0]);
+    for pair in slots.windows(2) {
+        assert_ne!(pair[0], pair[1], "consecutive commits shared a slot");
+    }
+}
+
+#[test]
+fn a_second_writer_at_the_same_generation_collides_on_one_slot() {
+    // The crash table is conditioned on exactly one writer, and this crate
+    // cannot enforce that: an exclusive lock is I/O. Measured rather than
+    // assumed, so the precondition documented on Header::commit is not
+    // decoration and the limit is not a guess.
+    let (_, header) = three_commits();
+    let (a_from, a_to) = batch(150, 25);
+    let (b_from, b_to) = batch(150, 40);
+    let a = header
+        .advance(25, a_from, a_to)
+        .expect("fits")
+        .commit()
+        .expect("v2");
+    let b = header
+        .advance(40, b_from, b_to)
+        .expect("fits")
+        .commit()
+        .expect("v2");
+
+    assert_eq!(
+        a.slot, b.slot,
+        "two writers from one generation take one slot"
+    );
+    assert_eq!(a.offset, b.offset);
+    assert_ne!(a.header.n_valid, b.header.n_valid);
+    assert_ne!(a.bytes, b.bytes);
+    // Their record writes begin at the same byte, too.
+    assert_eq!(Layout::V2.offset_of(header.n_valid), Ok(file_len(150)));
+    assert_eq!(a.durable_through, file_len(175));
+    assert_eq!(b.durable_through, file_len(190));
+
+    // The lock that has to prevent it is a named sibling of the month, formed
+    // by the one path renderer rather than invented at a call site.
+    assert_eq!(FileKind::Lock.extension(), ".lock");
+}
+
+#[test]
+fn a_commit_names_the_bytes_that_must_be_durable_first() {
+    let genesis = Header::genesis(7, 60, FLAG_CHECKSUMS);
+    assert_eq!(genesis.commit().expect("v2").durable_through, file_len(0));
+
+    let (from, to) = batch(0, 100);
+    let after = genesis.advance(100, from, to).expect("fits");
+    assert_eq!(after.commit().expect("v2").durable_through, file_len(100));
+
+    // A counter whose data would end past u64 is refused rather than wrapped:
+    // a wrapped barrier names a byte offset that is inside the file.
+    let absurd = Header {
+        n_valid: u64::MAX,
+        ..genesis
+    };
+    assert_eq!(absurd.commit(), Err(FormatError::OffsetOverflow));
+}
+
+#[test]
+fn both_slots_damaged_refuses_rather_than_guessing() {
+    // Every copy of the header is gone. There is no state to fall back to that
+    // would not be invented, so this refuses and says so.
+    assert_eq!(
+        Header::read_region(&vec![0u8; REGION_LEN], file_len(200)),
+        Err(FormatError::NoValidHeader),
+    );
+
+    let (mut region, _) = three_commits();
+    region[0] ^= 0xFF;
+    region[SLOT_STRIDE_LEN] ^= 0xFF;
+    assert_eq!(
+        Header::read_region(&region, file_len(200)),
+        Err(FormatError::NoValidHeader),
+    );
+
+    // A region too short to hold one slot is the same answer.
+    assert_eq!(
+        Header::read_region(&[0u8; 8], file_len(200)),
+        Err(FormatError::NoValidHeader),
+    );
+}
+
+#[test]
+fn a_short_header_region_is_refused_rather_than_answered_from_a_stale_slot() {
+    // Handing read_region less than the header region used to return whichever
+    // commit happened to fit -- generation 2 with 150 records, and Ok, with
+    // the 25 records committed since simply gone. It slipped the position
+    // guard whenever the surviving slot's generation was even, so half the
+    // time.
+    let (region, _) = three_commits();
+
+    assert_eq!(
+        Header::read_region(&region[..SLOT_STRIDE_LEN], file_len(200)),
+        Err(FormatError::HeaderRegionTooShort { slots: 1, need: 2 }),
+    );
+    assert_eq!(
+        Header::read_region(&region[..SLOT_LEN], file_len(200)),
+        Err(FormatError::HeaderRegionTooShort { slots: 0, need: 2 }),
+    );
+    assert!(Header::read_region(&region, file_len(200)).is_ok());
+}
+
+#[test]
+fn record_bytes_never_audition_as_a_header_slot() {
+    // The region a caller passes may be the whole read-only mapping, which is
+    // the usage the module endorses. Without a bound, every aligned run of
+    // record bytes that happened to begin BRUTEXB would be a candidate.
+    let (committed, header) = three_commits();
+    let (from, to) = batch(150, 900);
+    let impostor = header
+        .advance(900, from, to)
+        .expect("fits")
+        .commit()
+        .expect("v2");
+    assert_eq!(impostor.header.generation, 3, "a HIGHER generation");
+
+    let mut file = vec![0u8; REGION_LEN + 4 * SLOT_STRIDE_LEN];
+    file[..REGION_LEN].copy_from_slice(&committed);
+    // Placed in the record area, one slot stride past the header region.
+    file[REGION_LEN..REGION_LEN + SLOT_LEN].copy_from_slice(&impostor.bytes);
+
+    let read = Header::read_region(&file, file_len(2_000)).expect("the header region is intact");
+    assert_eq!((read.generation, read.n_valid), (2, 150));
+
+    // And when the header region really is blank, the answer is "no header
+    // survived" -- not a position complaint about bytes that were never
+    // header at all, which would condemn a file for the wrong reason.
+    let mut blank = vec![0u8; REGION_LEN + 4 * SLOT_STRIDE_LEN];
+    blank[REGION_LEN..REGION_LEN + SLOT_LEN].copy_from_slice(&impostor.bytes);
+    assert_eq!(
+        Header::read_region(&blank, file_len(2_000)),
+        Err(FormatError::NoValidHeader),
+    );
+}
+
+#[test]
+fn a_commit_found_in_the_wrong_slot_is_refused() {
+    // A writer that puts a commit in the wrong slot overwrites the only
+    // surviving copy of the previous one. That is a bug, not a state to
+    // tolerate, so it is named.
+    let mut region = vec![0u8; REGION_LEN];
+    let genesis = Header::genesis(7, 60, FLAG_CHECKSUMS);
+    apply(&mut region, &genesis.commit().expect("v2"), SLOT_LEN);
+
+    let (from, to) = batch(0, 100);
+    let first = genesis.advance(100, from, to).expect("fits");
+    let commit = first.commit().expect("v2");
+    assert_eq!(commit.slot, 1);
+
+    // Same bytes, wrong slot.
+    region
+        .iter_mut()
+        .zip(commit.bytes)
+        .for_each(|(dst, src)| *dst = src);
+    assert_eq!(
+        Header::read_region(&region, file_len(200)),
+        Err(FormatError::SlotPositionMismatch {
+            expected: 1,
+            found: 0,
+        }),
+    );
+}
+
+#[test]
+fn a_counter_claiming_more_than_the_file_holds_falls_back_to_the_last_supported_commit() {
+    // Trusting the counter over the length reads past the end and returns
+    // whatever bytes were there -- plausible integers, silently wrong. But
+    // refusing the WHOLE FILE for it loses a month of bars to a tail that a
+    // perfectly self-consistent previous commit already describes.
+    let (mut region, header) = three_commits();
+    let (from, to) = batch(150, 1_000_000);
+    let overreach = header.advance(1_000_000, from, to).expect("fits");
+    apply(&mut region, &overreach.commit().expect("v2"), SLOT_LEN);
+
+    let read = Header::read_region(&region, file_len(200)).expect("generation 2 is intact");
+    assert_eq!(read, header);
+    assert_eq!((read.generation, read.n_valid), (2, 150));
+
+    // When the file is long enough, the newest commit is what is returned --
+    // the fallback is a fallback, not a ceiling.
+    assert_eq!(
+        Header::read_region(&region, file_len(1_000_150)).expect("supported"),
+        overreach,
+    );
+
+    // And when NO slot is supported, the refusal is returned rather than a
+    // fabricated success or a misleading NoValidHeader.
+    assert_eq!(
+        Header::read_region(&region, file_len(10)),
+        Err(FormatError::CounterExceedsFile),
+    );
+}
+
+#[test]
+fn a_file_too_short_for_its_header_region_is_refused() {
+    let (region, _) = three_commits();
+    assert_eq!(
+        Header::read_region(&region, HEADER_LEN - 1),
+        Err(FormatError::TooShortForHeader),
+    );
+    assert_eq!(
+        Header::read_region(&region, HEADER_LEN),
+        Err(FormatError::CounterExceedsFile),
+        "the header region fits, the 150 records do not",
+    );
+}
+
+#[test]
+fn the_counter_and_the_generation_refuse_to_wrap() {
+    // A wrapped generation makes the OLDEST slot win, which silently
+    // un-commits every record published since. A wrapped counter hides
+    // records. Both are refusals.
+    let exhausted = Header {
+        generation: u64::MAX,
+        ..Header::genesis(7, 60, FLAG_CHECKSUMS)
+    };
+    assert_eq!(
+        exhausted.advance(1, T0, T0),
+        Err(FormatError::GenerationExhausted),
+    );
+
+    let full = Header {
+        n_valid: u64::MAX,
+        ..Header::genesis(7, 60, FLAG_CHECKSUMS)
+    };
+    assert_eq!(full.advance(1, T0, T0), Err(FormatError::CounterOverflow));
+    assert!(
+        full.advance(0, 0, 0).is_ok(),
+        "appending nothing is not an overflow"
+    );
+}
+
+#[test]
+fn a_batch_that_does_not_follow_the_committed_records_is_refused() {
+    // A re-pull landing on top of newer data is well-formed bytes that no
+    // checksum can catch afterwards, so it is caught here or never.
+    let (_, header) = three_commits();
+    assert_eq!(header.n_valid, 150);
+
+    // Backwards within the batch itself.
+    let (from, to) = batch(150, 25);
+    assert_eq!(
+        header.advance(25, to, from),
+        Err(FormatError::TimestampsOutOfOrder {
+            previous: to,
+            next: from,
+        }),
+    );
+
+    // Beginning exactly on the last committed bar, which would duplicate it.
+    assert_eq!(
+        header.advance(1, header.last_ts_micros, header.last_ts_micros),
+        Err(FormatError::TimestampsOutOfOrder {
+            previous: header.last_ts_micros,
+            next: header.last_ts_micros,
+        }),
+    );
+
+    // Beginning before it.
+    let (older_from, older_to) = batch(100, 5);
+    assert_eq!(
+        header.advance(5, older_from, older_to),
+        Err(FormatError::TimestampsOutOfOrder {
+            previous: header.last_ts_micros,
+            next: older_from,
+        }),
+    );
+
+    // The next minute is fine, and it moves only the last timestamp.
+    let (next_from, next_to) = batch(150, 25);
+    let after = header.advance(25, next_from, next_to).expect("follows");
+    assert_eq!(after.first_ts_micros, T0, "record 0 never moves");
+    assert_eq!(after.last_ts_micros, next_to);
+    assert_eq!(after.n_valid, 175);
+
+    // An empty commit carries both timestamps forward untouched.
+    let republished = header.advance(0, 0, 0).expect("no records is not an error");
+    assert_eq!(republished.first_ts_micros, header.first_ts_micros);
+    assert_eq!(republished.last_ts_micros, header.last_ts_micros);
+    assert_eq!(republished.n_valid, header.n_valid);
+    assert_eq!(republished.generation, header.generation + 1);
+}
+
+#[test]
+fn a_header_whose_advertised_range_runs_backwards_is_refused() {
+    // Only a hand-written struct can reach this state, because `advance`
+    // refuses to produce it -- but a hand-written struct is exactly what a
+    // corrupt file decodes into once its checksum happens to agree.
+    let backwards = Header {
+        n_valid: 10,
+        first_ts_micros: T0 + MINUTE,
+        last_ts_micros: T0,
+        ..Header::genesis(7, 60, FLAG_CHECKSUMS)
+    };
+    assert_eq!(
+        backwards.validate(Layout::V2, file_len(10)),
+        Err(FormatError::TimestampsOutOfOrder {
+            previous: T0 + MINUTE,
+            next: T0,
+        }),
+    );
+
+    // An empty file says nothing about its range, so nothing is checked.
+    let empty = Header {
+        first_ts_micros: T0 + MINUTE,
+        last_ts_micros: T0,
+        ..Header::genesis(7, 60, FLAG_CHECKSUMS)
+    };
+    assert_eq!(empty.validate(Layout::V2, file_len(10)), Ok(()));
+}

--- a/crates/store/tests/fault.rs
+++ b/crates/store/tests/fault.rs
@@ -556,6 +556,21 @@ fn a_counter_claiming_more_than_the_file_holds_falls_back_to_the_last_supported_
         Header::read_region(&region, file_len(10)),
         Err(FormatError::CounterExceedsFile),
     );
+
+    // The same answer when there is only ONE slot left to fall back from:
+    // damage slot 0 so generation 2 is gone, leaving generation 3 alone and
+    // unsupported. The refusal is still the counter's, not "no header".
+    region[0] ^= 0xFF;
+    assert_eq!(
+        Header::read_region(&region, file_len(200)),
+        Err(FormatError::CounterExceedsFile),
+    );
+    assert_eq!(
+        Header::read_region(&region, file_len(1_000_150))
+            .expect("the surviving slot is supported")
+            .n_valid,
+        1_000_150,
+    );
 }
 
 #[test]

--- a/crates/store/tests/fault.rs
+++ b/crates/store/tests/fault.rs
@@ -559,6 +559,36 @@ fn a_counter_claiming_more_than_the_file_holds_falls_back_to_the_last_supported_
 }
 
 #[test]
+fn ragged_tail_truncates_loudly() {
+    // docs/04-invariants.md S-07, and docs/02 §7. A file whose length does not
+    // divide by the stride was interrupted mid-record. The remainder is
+    // reported so it can be logged with a byte count -- never ignored, never
+    // rounded away, and never counted as a record.
+    let v2 = Layout::V2;
+    for whole in 0..5u64 {
+        let clean = file_len(whole);
+        assert_eq!(v2.ragged_tail_bytes(clean), 0, "{whole} whole records");
+        assert_eq!(v2.capacity_for(clean), whole);
+        for torn in 1..RECORD_STRIDE {
+            assert_eq!(
+                v2.ragged_tail_bytes(clean + torn),
+                torn,
+                "{torn} bytes into record {whole}",
+            );
+            assert_eq!(
+                v2.capacity_for(clean + torn),
+                whole,
+                "the torn record must not be counted",
+            );
+        }
+    }
+    // A file shorter than a header region is all tail.
+    assert_eq!(v2.ragged_tail_bytes(30), 30);
+    assert_eq!(v2.capacity_for(30), 0);
+    assert_eq!(v2.ragged_tail_bytes(HEADER_LEN - 1), HEADER_LEN - 1);
+}
+
+#[test]
 fn a_file_too_short_for_its_header_region_is_refused() {
     let (region, _) = three_commits();
     assert_eq!(
@@ -640,6 +670,22 @@ fn a_batch_that_does_not_follow_the_committed_records_is_refused() {
     assert_eq!(after.last_ts_micros, next_to);
     assert_eq!(after.n_valid, 175);
 
+    // An EMPTY file has nothing for a batch to follow, so the ordering guard
+    // does not apply to it -- not even when the header still carries a stale
+    // last timestamp ahead of the batch. A guard that fired here would refuse
+    // the first append to every new file.
+    let empty = Header {
+        last_ts_micros: T0 + 999 * MINUTE,
+        ..Header::genesis(7, 60, FLAG_CHECKSUMS)
+    };
+    assert_eq!(empty.n_valid, 0);
+    let opened = empty
+        .advance(1, T0, T0)
+        .expect("an empty file follows nothing");
+    assert_eq!(opened.first_ts_micros, T0);
+    assert_eq!(opened.last_ts_micros, T0);
+    assert_eq!(opened.n_valid, 1);
+
     // An empty commit carries both timestamps forward untouched.
     let republished = header.advance(0, 0, 0).expect("no records is not an error");
     assert_eq!(republished.first_ts_micros, header.first_ts_micros);
@@ -666,6 +712,17 @@ fn a_header_whose_advertised_range_runs_backwards_is_refused() {
             next: T0,
         }),
     );
+
+    // A single record: first and last name the same instant, which is a range
+    // that does not run backwards. Refusing it would condemn every file that
+    // holds exactly one bar.
+    let one = Header {
+        n_valid: 1,
+        first_ts_micros: T0,
+        last_ts_micros: T0,
+        ..Header::genesis(7, 60, FLAG_CHECKSUMS)
+    };
+    assert_eq!(one.validate(Layout::V2, file_len(1)), Ok(()));
 
     // An empty file says nothing about its range, so nothing is checked.
     let empty = Header {

--- a/crates/store/tests/geometry.rs
+++ b/crates/store/tests/geometry.rs
@@ -1,0 +1,378 @@
+//! Record and block geometry: `store::geometry::*`.
+//!
+//! The defect these tests exist for: the checksum block was 4096 bytes and the
+//! record stride is 56, and 56 does not divide 4096. A record could begin in
+//! one block and end in the next, so verifying it against the block
+//! `block_of` returned checked *part* of a record and pronounced the whole of
+//! it good.
+//!
+//! The second defect: the partial tail block was not modelled anywhere, so the
+//! only API that named a block's bytes named bytes past EOF for 72 of every 73
+//! states a file passes through.
+
+// A test that asserts nothing is banned, and a test that cannot fail loudly is
+// a test that asserts nothing. These allow the harness to panic on a broken
+// invariant instead of threading `Result` through every assertion.
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+
+use store::format::{BLOCK_LEN, FormatError, HEADER_LEN, RECORD_STRIDE, RECORDS_PER_BLOCK};
+use store::layout::Layout;
+
+/// How many indices to walk. Enough to cross 68 blocks and, under the old
+/// geometry, 68 block boundaries.
+const WALK: u64 = 5_000;
+
+// ---------------------------------------------------------------------------
+// The geometry that was wrong, reproduced so the fix is measured against it
+// rather than against a description of it.
+// ---------------------------------------------------------------------------
+
+/// Version 1's header length, before the two-slot header.
+const OLD_HEADER_LEN: u64 = 64;
+/// The byte-addressed checksum block that did not divide the stride.
+const OLD_BLOCK_LEN: u64 = 4096;
+
+/// Whether record `index` straddled two blocks under the old geometry.
+fn old_geometry_straddles(index: u64) -> bool {
+    let start = OLD_HEADER_LEN + index * RECORD_STRIDE;
+    let last = start + RECORD_STRIDE - 1;
+    start / OLD_BLOCK_LEN != last / OLD_BLOCK_LEN
+}
+
+#[test]
+fn the_old_geometry_straddled_and_record_145_is_the_cited_case() {
+    // 4096 / 56 = 73.14..., so a record boundary and a block boundary coincide
+    // only once every seven blocks.
+    assert_ne!(OLD_BLOCK_LEN % RECORD_STRIDE, 0, "this is the whole defect");
+
+    // Record 145 began at 64 + 145*56 = 8184, eight bytes before the 8192
+    // boundary, and ran to 8239. Eight bytes in one block, forty-eight in the
+    // next.
+    let start = OLD_HEADER_LEN + 145 * RECORD_STRIDE;
+    assert_eq!(start, 8_184);
+    assert_eq!(start / OLD_BLOCK_LEN, 1);
+    assert_eq!((start + RECORD_STRIDE - 1) / OLD_BLOCK_LEN, 2);
+    assert_eq!(2 * OLD_BLOCK_LEN - start, 8, "bytes left in block 1");
+    assert_eq!(RECORD_STRIDE - 8, 48, "bytes carried into block 2");
+    assert!(old_geometry_straddles(145));
+
+    // And it was not a rare accident: 23 of the first 2,000 records did it.
+    let straddlers = (0..2_000).filter(|&i| old_geometry_straddles(i)).count();
+    assert_eq!(straddlers, 23, "the audit counted 23; so does this");
+}
+
+#[test]
+fn no_record_straddles_a_block() {
+    let v2 = Layout::V2;
+
+    // The property, for every index a month file could hold and well beyond.
+    for index in 0..WALK {
+        let (start, end) = v2.record_byte_range(index).expect("fits");
+        let block = v2.block_of(index);
+        let (block_start, block_end) = v2.block_byte_range(block).expect("fits");
+
+        assert!(
+            start >= block_start && end <= block_end,
+            "record {index} occupies [{start}, {end}) but block {block} covers \
+             [{block_start}, {block_end}) -- verifying it would check part of it",
+        );
+
+        // Not merely inside *a* block: inside the block `block_of` names, and
+        // no byte of it in the neighbours.
+        if block > 0 {
+            let (_, previous_end) = v2.block_byte_range(block - 1).expect("fits");
+            assert!(start >= previous_end, "record {index} reaches back a block");
+        }
+        let (next_start, _) = v2.block_byte_range(block + 1).expect("fits");
+        assert!(
+            end <= next_start,
+            "record {index} reaches into the next block"
+        );
+    }
+
+    // The previously-cited case, spelled out. Under the new geometry record 145
+    // is the last record of block 1 and ends exactly on the block boundary.
+    let (start, end) = v2.record_byte_range(145).expect("fits");
+    assert_eq!(v2.block_of(145), 1);
+    assert_eq!(
+        v2.block_byte_range(1).expect("fits"),
+        (HEADER_LEN + BLOCK_LEN, HEADER_LEN + 2 * BLOCK_LEN),
+    );
+    assert_eq!((start, end), (40_888, 40_944));
+    assert_eq!(end, HEADER_LEN + 2 * BLOCK_LEN);
+    assert!(old_geometry_straddles(145), "it used to straddle");
+
+    // Zero straddlers, against 23 in the first 2,000 before.
+    let straddlers = (0..WALK)
+        .filter(|&index| {
+            let (start, end) = v2.record_byte_range(index).expect("fits");
+            let (block_start, block_end) = v2.block_byte_range(v2.block_of(index)).expect("fits");
+            start < block_start || end > block_end
+        })
+        .count();
+    assert_eq!(straddlers, 0);
+}
+
+#[test]
+fn the_block_is_counted_in_records_not_in_pages() {
+    // The block length is a property of the FORMAT, not of the host. This
+    // machine pages at 16384 bytes and the CI runner pages at 4096; a block
+    // sized to either would make the same file verify differently on the two,
+    // which breaks byte-for-byte reproducibility for a cache-locality guess.
+    //
+    // The only length that is a whole multiple of the stride AND of both page
+    // sizes is lcm(56, 16384) = 114688 bytes -- 2048 records, 28x larger than
+    // this block, so verifying one record would checksum 112 KiB. That is the
+    // measurement that settles it: tracking the page size is not free, it is
+    // expensive, and it buys a property the format does not need.
+    assert_eq!(BLOCK_LEN % RECORD_STRIDE, 0, "a record cannot be split");
+    assert_eq!(BLOCK_LEN / RECORD_STRIDE, RECORDS_PER_BLOCK);
+    assert_eq!(BLOCK_LEN, 4_088);
+    assert_ne!(BLOCK_LEN, 4_096, "not the CI runner's page");
+    assert_ne!(BLOCK_LEN, 16_384, "not this machine's page");
+
+    // lcm(56, 16384): the size page-tracking would actually cost.
+    let lcm = 56 * 16_384 / 8;
+    assert_eq!(lcm, 114_688);
+    assert_eq!(lcm % 4_096, 0);
+    assert_eq!(lcm / RECORD_STRIDE, 2_048);
+    assert_eq!(lcm / BLOCK_LEN, 28);
+}
+
+#[test]
+fn a_padded_four_kib_block_would_cost_a_division() {
+    // The alternative docs/02 §6 actually described -- "a 4 KiB block holds 73
+    // whole records with 8 bytes of slack" -- is a PADDED block, and a padded
+    // block never straddles either. So the reason it was not taken has to be
+    // stated rather than assumed, or D-0005 was overturned without an
+    // argument.
+    const PADDED_BLOCK: u64 = 4_096;
+    assert_eq!(
+        PADDED_BLOCK - RECORDS_PER_BLOCK * RECORD_STRIDE,
+        8,
+        "the slack the document describes",
+    );
+
+    // A block is a range of the file, so padding the block pads the record
+    // array: block b starts at header + b*4096 while record 73b sits at
+    // header + b*4088. The gap is 8 bytes per block, and it is real bytes.
+    for block in 1..64u64 {
+        let padded_start = HEADER_LEN + block * PADDED_BLOCK;
+        let packed_start = HEADER_LEN + block * BLOCK_LEN;
+        assert_eq!(padded_start - packed_start, block * 8);
+    }
+
+    // With the padding present, the address of record i stops being a multiply
+    // and an add. That is the cost, and it is the reason: CLAUDE.md §3 rule 4
+    // asks for a constant per-operation cost, and this is a strictly worse
+    // constant bought with nothing -- the 8 bytes are wasted either way.
+    let padded_offset = |i: u64| {
+        HEADER_LEN
+            + (i / RECORDS_PER_BLOCK) * PADDED_BLOCK
+            + (i % RECORDS_PER_BLOCK) * RECORD_STRIDE
+    };
+    let v2 = Layout::V2;
+    assert_eq!(padded_offset(0), v2.offset_of(0).expect("fits"));
+    assert_eq!(padded_offset(72), v2.offset_of(72).expect("fits"));
+    for block in 1..64u64 {
+        let first = block * RECORDS_PER_BLOCK;
+        assert_eq!(
+            padded_offset(first) - v2.offset_of(first).expect("fits"),
+            block * 8,
+            "the padded form drifts by a whole slack per block",
+        );
+    }
+
+    // And the waste is identical, so the padded form buys nothing at all: 8
+    // bytes of every 4096 either way, because the packed block simply stops
+    // 8 bytes earlier.
+    assert_eq!(PADDED_BLOCK - BLOCK_LEN, 8);
+}
+
+#[test]
+fn the_tail_block_covers_only_the_committed_records() {
+    // The partial tail block, which was modelled nowhere. `block_byte_range`
+    // is nominal and names bytes past EOF for nearly every file state;
+    // `covered_byte_range` is the checksum domain and never does.
+    let v2 = Layout::V2;
+
+    // A file with exactly one record. The nominal block ends 4032 bytes past
+    // the end of the file.
+    let one_record = HEADER_LEN + RECORD_STRIDE;
+    assert_eq!(
+        v2.block_byte_range(0),
+        Ok((HEADER_LEN, HEADER_LEN + BLOCK_LEN))
+    );
+    assert_eq!(HEADER_LEN + BLOCK_LEN - one_record, 4_032, "past EOF");
+    assert_eq!(v2.covered_byte_range(0, 1), Ok((HEADER_LEN, one_record)));
+
+    // Across every record count a month file passes through: the covered range
+    // ends exactly at EOF, and every block before the tail is whole.
+    let mut nominal_past_eof = 0u64;
+    for n_valid in 1..=730u64 {
+        let eof = HEADER_LEN + n_valid * RECORD_STRIDE;
+        let blocks = v2.blocks_for(n_valid);
+        let tail = blocks - 1;
+
+        let (_, covered_end) = v2.covered_byte_range(tail, n_valid).expect("fits");
+        assert_eq!(covered_end, eof, "tail block of {n_valid} records");
+
+        let (_, nominal_end) = v2.block_byte_range(tail).expect("fits");
+        if nominal_end > eof {
+            nominal_past_eof += 1;
+        }
+
+        for block in 0..tail {
+            assert_eq!(v2.records_in_block(block, n_valid), Ok(RECORDS_PER_BLOCK));
+            assert_eq!(
+                v2.covered_byte_range(block, n_valid),
+                v2.block_byte_range(block),
+                "a whole block's covered range is its nominal range",
+            );
+        }
+        assert_eq!(
+            v2.records_in_block(tail, n_valid),
+            Ok(n_valid - tail * RECORDS_PER_BLOCK),
+        );
+    }
+    // 72 of every 73 states -- every state except the instant an append lands
+    // exactly on a block boundary.
+    assert_eq!(nominal_past_eof, 720);
+    assert_eq!(730 - 730 / RECORDS_PER_BLOCK, 720);
+}
+
+#[test]
+fn a_block_past_the_counter_is_refused_rather_than_answered() {
+    // Answering "zero bytes" would let a caller checksum nothing and report
+    // the result as a verified block.
+    let v2 = Layout::V2;
+    assert_eq!(v2.blocks_for(0), 0);
+    assert_eq!(v2.blocks_for(1), 1);
+    assert_eq!(v2.blocks_for(RECORDS_PER_BLOCK), 1);
+    assert_eq!(v2.blocks_for(RECORDS_PER_BLOCK + 1), 2);
+
+    assert_eq!(
+        v2.covered_byte_range(0, 0),
+        Err(FormatError::BlockNotCommitted {
+            block: 0,
+            blocks: 0
+        }),
+    );
+    assert_eq!(
+        v2.records_in_block(1, RECORDS_PER_BLOCK),
+        Err(FormatError::BlockNotCommitted {
+            block: 1,
+            blocks: 1
+        }),
+    );
+    assert_eq!(
+        v2.covered_byte_range(9, 10),
+        Err(FormatError::BlockNotCommitted {
+            block: 9,
+            blocks: 1
+        }),
+    );
+}
+
+#[test]
+fn a_full_blocks_covered_range_is_its_nominal_range_wherever_it_is_representable() {
+    // The relationship at the top of u64, where it could stop holding.
+    let v2 = Layout::V2;
+    let last_block = (u64::MAX - HEADER_LEN - BLOCK_LEN) / BLOCK_LEN;
+
+    for block in [0u64, 1, 73, 1_000, last_block] {
+        let nominal = v2.block_byte_range(block).expect("representable");
+        let n_valid = (block + 1) * RECORDS_PER_BLOCK;
+        assert_eq!(
+            v2.covered_byte_range(block, n_valid),
+            Ok(nominal),
+            "block {block} full",
+        );
+    }
+
+    // Past it, both refuse rather than wrapping into a different, plausible
+    // block.
+    assert_eq!(
+        v2.block_byte_range(last_block + 1),
+        Err(FormatError::OffsetOverflow),
+    );
+    assert_eq!(
+        v2.covered_byte_range(last_block + 1, u64::MAX),
+        Err(FormatError::OffsetOverflow),
+    );
+}
+
+#[test]
+fn addressing_is_arithmetic_and_flat() {
+    let v2 = Layout::V2;
+    // Bar 400,000 costs the same as bar 0: a multiply and an add.
+    assert_eq!(v2.offset_of(0).expect("fits"), HEADER_LEN);
+    assert_eq!(v2.offset_of(1).expect("fits"), HEADER_LEN + RECORD_STRIDE);
+    assert_eq!(v2.offset_of(400_000).expect("fits"), 22_432_768);
+    for index in 0..WALK {
+        let here = v2.offset_of(index).expect("fits");
+        let next = v2.offset_of(index + 1).expect("fits");
+        assert_eq!(next - here, RECORD_STRIDE, "step at {index}");
+    }
+}
+
+#[test]
+fn a_block_index_names_seventy_three_consecutive_records() {
+    let v2 = Layout::V2;
+    assert_eq!(v2.block_of(0), 0);
+    assert_eq!(v2.block_of(72), 0, "the last record of block 0");
+    assert_eq!(v2.block_of(73), 1, "the first record of block 1");
+    assert_eq!(v2.block_of(145), 1, "the last record of block 1");
+    assert_eq!(v2.block_of(146), 2);
+
+    // Every block holds exactly RECORDS_PER_BLOCK indices, with no index in
+    // two blocks and none in none.
+    for block in 0..68u64 {
+        let members = (0..WALK).filter(|&i| v2.block_of(i) == block).count();
+        assert_eq!(u64::try_from(members), Ok(RECORDS_PER_BLOCK));
+    }
+}
+
+#[test]
+fn the_header_slots_do_not_share_a_failure_unit() {
+    // The two-slot header is only redundant if a write to one slot cannot
+    // damage the other, and storage fails at a block or a page, never at a
+    // byte. Both hosts this repository builds on report a 4096-byte device
+    // block; this machine pages at 16384 and the CI runner at 4096.
+    let v2 = Layout::V2;
+    let slot0 = v2.slot_offset(0);
+    let slot1 = v2.slot_offset(1);
+    assert_eq!(slot0, 0);
+    assert_eq!(slot1, 16_384);
+
+    for unit in [512u64, 4_096, 16_384] {
+        assert_ne!(
+            slot0 / unit,
+            slot1 / unit,
+            "the slots share one {unit}-byte failure unit",
+        );
+    }
+
+    // Under the geometry this replaced -- slots at 0 and 64 -- they shared
+    // every one of those units, which is what made the redundancy nominal and
+    // the "disjoint byte ranges, so that is true on any device" argument
+    // false.
+    let old_spacing = [0u64, 64];
+    for unit in [512u64, 4_096, 16_384] {
+        assert_eq!(
+            old_spacing[0] / unit,
+            old_spacing[1] / unit,
+            "the old spacing shared a {unit}-byte unit",
+        );
+    }
+
+    // And the header region is exactly the slots, with nothing unaddressed.
+    assert_eq!(v2.header_len(), v2.slot_count() * v2.slot_stride());
+    assert_eq!(v2.header_len(), HEADER_LEN);
+    assert_eq!(v2.slot_offset(2), slot0, "commit 2 returns to slot 0");
+}

--- a/crates/store/tests/unit.rs
+++ b/crates/store/tests/unit.rs
@@ -332,6 +332,21 @@ fn a_degenerate_layout_is_refused_at_declaration() {
         bad("magic"),
         "a magic outside the family is not this format",
     );
+    // Every one of the seven family bytes, on its own. A check that only ever
+    // sees a magic differing in several places cannot tell "all seven must
+    // match" from "any one of them may".
+    for position in 0..7usize {
+        let mut magic = *b"BRUTEXB3";
+        magic[position] ^= 0x20; // still ASCII, differs in exactly one byte
+        assert_eq!(
+            Layout::declare(3, magic, 2, 56, 73),
+            bad("magic"),
+            "family byte {position} was not required to match",
+        );
+    }
+    // The eighth byte is the version's own, not the family's, so it is free.
+    assert!(Layout::declare(3, *b"BRUTEXB3", 2, 56, 73).is_ok());
+    assert!(Layout::declare(3, *b"BRUTEXBZ", 2, 56, 73).is_ok());
     assert_eq!(
         Layout::declare(3, MAGIC, 1, 56, 73),
         bad("slot_count"),

--- a/crates/store/tests/unit.rs
+++ b/crates/store/tests/unit.rs
@@ -465,35 +465,6 @@ fn capacity_and_ragged_tail_agree_with_the_bytes() {
 }
 
 #[test]
-fn ragged_tail_truncates_loudly() {
-    // S-07 and docs/02 §7. A file whose length does not divide by the stride
-    // was interrupted mid-record. The remainder is reported so it can be
-    // logged with a byte count -- never ignored, never rounded away.
-    let v2 = Layout::V2;
-    for whole in 0..5u64 {
-        let clean = HEADER_LEN + whole * RECORD_STRIDE;
-        assert_eq!(v2.ragged_tail_bytes(clean), 0, "{whole} whole records");
-        assert_eq!(v2.capacity_for(clean), whole);
-        for torn in 1..RECORD_STRIDE {
-            assert_eq!(
-                v2.ragged_tail_bytes(clean + torn),
-                torn,
-                "{torn} bytes of a record {whole}",
-            );
-            assert_eq!(
-                v2.capacity_for(clean + torn),
-                whole,
-                "the torn record is not counted",
-            );
-        }
-    }
-    // A file shorter than a header region is all tail.
-    assert_eq!(v2.ragged_tail_bytes(30), 30);
-    assert_eq!(v2.capacity_for(30), 0);
-    assert_eq!(v2.ragged_tail_bytes(HEADER_LEN - 1), HEADER_LEN - 1);
-}
-
-#[test]
 fn commits_alternate_between_the_slots() {
     let v2 = Layout::V2;
     assert_eq!(v2.slot_offset(0), 0);
@@ -777,6 +748,48 @@ fn a_genesis_header_describes_an_empty_file() {
     assert_eq!(second.first_ts_micros, 99, "record 0 never moves");
     assert_eq!(second.last_ts_micros, 420);
     assert_eq!(second.n_valid, 5);
+}
+
+// ===========================================================================
+// The block checksum
+// ===========================================================================
+
+#[test]
+fn a_block_outside_the_commit_is_refused_by_both_doors() {
+    // The geometry refuses before a byte is hashed, and `verify` propagates
+    // that refusal rather than swallowing it into "the checksum did not
+    // match" -- two different problems that would send an operator to two
+    // different places.
+    let v2 = Layout::V2;
+    let header = Header::genesis(7, 60, FLAG_CHECKSUMS)
+        .advance(1, 100, 100)
+        .expect("fits");
+    let record = [7u8; 56];
+    let past = Err(FormatError::BlockNotCommitted {
+        block: 1,
+        blocks: 1,
+    });
+
+    assert_eq!(block::seal(v2, header.n_valid, 1, &record), past);
+    assert_eq!(block::verify(&header, v2, 1, &record, 0), past.map(|_| ()));
+    assert_eq!(
+        block::verify(&header, v2, 0, &record[..55], 0),
+        Err(FormatError::BlockLengthMismatch {
+            block: 0,
+            len: 55,
+            need: 56,
+        }),
+    );
+
+    // And the happy path, so this is not only a list of refusals: one record
+    // committed, one block, and the seal is what verify accepts.
+    let sealed = block::seal(v2, header.n_valid, 0, &record).expect("one record, one block");
+    assert_eq!(block::verify(&header, v2, 0, &record, sealed), Ok(()));
+    assert_eq!(
+        block::seal(v2, header.n_valid, 0, &record),
+        Ok(sealed),
+        "sealing is idempotent, byte for byte",
+    );
 }
 
 // ===========================================================================

--- a/crates/store/tests/unit.rs
+++ b/crates/store/tests/unit.rs
@@ -1,0 +1,1398 @@
+//! Unit behaviour of the store crate: `store::unit::*`.
+
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use brutex_core::instrument::{Exchange, Expiry, InstrumentKey, Kind, OptionSide, Segment};
+use brutex_core::price::Paisa;
+use brutex_core::symbol::{SYMBOL_CAPACITY, Symbol};
+use brutex_core::vendor::Vendor;
+
+use store::block;
+use store::crc::{CHECK_VALUE, crc32c};
+use store::format::{
+    BLOCK_LEN, Bar, FLAG_CHECKSUMS, FORMAT_VERSION, FormatError, HEADER_LEN, MAGIC, MAGIC_FAMILY,
+    MAX_SLOT_COUNT, OI_NULL, RECORD_STRIDE, RECORDS_PER_BLOCK, RETIRED_VERSIONS, SLOT_COUNT,
+    SLOT_LEN, SLOT_STRIDE,
+};
+use store::header::Header;
+use store::layout::Layout;
+use store::path::{
+    FileKind, MAX_EXTENSION_LEN, MAX_LEN, MAX_SEGMENT_LEN, MAX_TIMEFRAME_LEN, MAX_VENDOR_LEN,
+    PathError, PathParts, STORE_ROOT, SegmentCase, StorePath, Timeframe, YearMonth, check_segment,
+};
+
+// ===========================================================================
+// The checksum
+// ===========================================================================
+
+#[test]
+fn the_crc_matches_the_published_check_value() {
+    // The check value is published beside the polynomial; this compares the
+    // implementation against it, not the other way round.
+    assert_eq!(crc32c(*b"123456789"), CHECK_VALUE);
+    assert_eq!(CHECK_VALUE, 0xE306_9283);
+    // The empty input is the initial value inverted, and one byte differs from
+    // it -- so the loop body runs and is not skipped.
+    assert_eq!(crc32c([]), 0);
+    assert_ne!(crc32c([0u8]), 0);
+    assert_ne!(crc32c([0u8]), crc32c([1u8]));
+}
+
+// ===========================================================================
+// The record
+// ===========================================================================
+
+#[test]
+fn the_record_is_exactly_the_documented_shape() {
+    // S-01. Compile-time assertions carry this; the numbers are written out
+    // here so the invariant table has a named test beside it.
+    assert_eq!(size_of::<Bar>(), 56);
+    assert_eq!(align_of::<Bar>(), 8);
+    assert_eq!(u64::try_from(size_of::<Bar>()), Ok(RECORD_STRIDE));
+    assert_eq!(&MAGIC, b"BRUTEXB2");
+    assert_eq!(&MAGIC[..7], &MAGIC_FAMILY[..]);
+    assert_eq!(FORMAT_VERSION, 2);
+    assert_eq!(FLAG_CHECKSUMS, 1);
+}
+
+#[test]
+fn the_geometry_is_version_two_and_version_one_is_retired_not_reused() {
+    // CLAUDE.md §3 rule 8: store format versions are never mutated in place.
+    // The header region, every field offset, the checksum width, the checksum
+    // domain and the block length all changed, so this is a new version --
+    // not an edit to version 1 wearing version 1's magic.
+    assert_eq!(FORMAT_VERSION, 2);
+    assert_eq!(&MAGIC, b"BRUTEXB2");
+    assert_ne!(&MAGIC, b"BRUTEXB1");
+    assert_eq!(RETIRED_VERSIONS, [1]);
+    assert_eq!(Layout::for_version(1), Err(FormatError::RetiredVersion(1)));
+
+    // Every geometric number that moved, stated against version 1's.
+    assert_eq!((64u64, HEADER_LEN), (64, 32_768), "header region");
+    assert_eq!((1u64, SLOT_COUNT), (1, 2), "header slots");
+    assert_eq!((4_096u64, BLOCK_LEN), (4_096, 4_088), "checksum block");
+    assert_eq!(RECORD_STRIDE, 56, "the one number that did NOT move");
+}
+
+#[test]
+fn oi_sentinel_distinct() {
+    // S-08. Spot indices store the sentinel; a derivative may store a real
+    // zero. Conflating them makes the two series indistinguishable on the one
+    // field that tells them apart.
+    let spot = Bar {
+        open_interest: OI_NULL,
+        ..Bar::default()
+    };
+    let derivative = Bar {
+        open_interest: 0,
+        ..Bar::default()
+    };
+    assert!(spot.oi_is_null());
+    assert!(!derivative.oi_is_null());
+    assert_eq!(spot.oi(), None);
+    assert_eq!(derivative.oi(), Some(0));
+    assert_ne!(spot, derivative);
+    assert_eq!(OI_NULL, i64::MIN);
+    assert!(format!("{spot:?}").contains("open_interest"));
+
+    // And the default record -- the one a lost write leaves behind -- carries
+    // a REAL zero, not the sentinel. That is why a block checksum is the only
+    // thing that can tell a flat bar from an extent that was never written.
+    assert!(!Bar::default().oi_is_null());
+    assert!(Bar::default().ohlc_is_sane());
+}
+
+#[test]
+fn ohlc_sanity_accepts_real_bars_and_rejects_impossible_ones() {
+    // The real first bar of 2024-06-03 from the lake, in paisa.
+    let real = Bar {
+        ts_micros: 1_717_386_300_000_000,
+        open: 2_333_870,
+        high: 2_333_870,
+        low: 2_308_370,
+        close: 2_310_955,
+        volume: 0,
+        open_interest: OI_NULL,
+    };
+    assert!(real.ohlc_is_sane());
+    assert_eq!(real.close_price(), Paisa::from_raw(2_310_955));
+
+    // A flat bar is legal: high == low == open == close.
+    assert!(Bar::default().ohlc_is_sane());
+
+    // Each of the five comparisons, failed on its own.
+    assert!(!Bar { high: 1, ..real }.ohlc_is_sane(), "high below open");
+    assert!(
+        !Bar {
+            high: 2_308_369,
+            open: 0,
+            close: 0,
+            ..real
+        }
+        .ohlc_is_sane(),
+        "high below low",
+    );
+    assert!(
+        !Bar {
+            close: 9_999_999,
+            ..real
+        }
+        .ohlc_is_sane(),
+        "high below close",
+    );
+    assert!(
+        !Bar {
+            low: 9_999_999,
+            ..real
+        }
+        .ohlc_is_sane(),
+        "low above open",
+    );
+    assert!(
+        !Bar {
+            open: 2_310_954,
+            low: 2_310_955,
+            ..real
+        }
+        .ohlc_is_sane(),
+        "low above close",
+    );
+}
+
+// ===========================================================================
+// Version dispatch
+// ===========================================================================
+
+#[test]
+fn the_constants_are_the_current_versions_layout() {
+    let v2 = Layout::V2;
+    assert_eq!(v2.version(), FORMAT_VERSION);
+    assert_eq!(v2.magic(), MAGIC);
+    assert_eq!(v2.header_len(), HEADER_LEN);
+    assert_eq!(v2.slot_count(), SLOT_COUNT);
+    assert_eq!(v2.slot_stride(), SLOT_STRIDE);
+    assert_eq!(v2.record_stride(), RECORD_STRIDE);
+    assert_eq!(v2.records_per_block(), RECORDS_PER_BLOCK);
+    assert_eq!(v2.block_len(), BLOCK_LEN);
+    assert_eq!(Layout::CURRENT, v2);
+    assert_eq!(Layout::KNOWN, &[v2]);
+    const { assert!(SLOT_COUNT <= MAX_SLOT_COUNT) }
+
+    // The header region is exactly `slot_count` slots at SLOT_STRIDE spacing,
+    // checked rather than cast, and each slot's fields fit in SLOT_LEN.
+    assert_eq!(SLOT_COUNT * SLOT_STRIDE, HEADER_LEN);
+    assert_eq!(u64::try_from(SLOT_LEN), Ok(64));
+    assert!(u64::try_from(SLOT_LEN).expect("fits") < SLOT_STRIDE);
+
+    // And the const row agrees with the declared form, byte for byte.
+    assert_eq!(
+        Layout::declare(2, MAGIC, SLOT_COUNT, RECORD_STRIDE, RECORDS_PER_BLOCK),
+        Ok(v2),
+    );
+}
+
+#[test]
+fn every_known_row_is_one_declare_would_admit() {
+    // `Layout::KNOWN` is const rows, and `declare`'s guards are only reachable
+    // from outside the module -- so a hand-written row could have bypassed
+    // every one of them, including `slot_count >= 2`, which IS the crash
+    // guarantee. `declared` makes that a compile error; this makes it a test
+    // failure too, so neither door is the only one.
+    for row in Layout::KNOWN {
+        assert_eq!(
+            Layout::declare(
+                row.version(),
+                row.magic(),
+                row.slot_count(),
+                row.record_stride(),
+                row.records_per_block(),
+            ),
+            Ok(*row),
+            "a KNOWN row must be a geometry `declare` admits",
+        );
+        assert!(row.slot_count() >= 2, "one slot cannot be updated safely");
+        assert!(row.slot_count() <= MAX_SLOT_COUNT);
+        assert!(row.records_per_block() > 0, "block_of would divide by zero");
+        assert_eq!(row.block_len() % row.record_stride(), 0);
+        assert_eq!(row.header_len(), row.slot_count() * row.slot_stride());
+    }
+
+    // The two doors agree on a geometry neither of them has seen.
+    assert_eq!(
+        Layout::declare(3, *b"BRUTEXB3", 2, 72, 57),
+        Ok(Layout::declared(3, *b"BRUTEXB3", 2, 72, 57)),
+    );
+}
+
+#[test]
+fn unknown_version_refuses() {
+    // S-09. A future version has its own layout; guessing at it would read
+    // fields from the wrong offsets and return plausible nonsense.
+    for version in [0u16, 3, 9, 255, u16::MAX] {
+        let refusal = Layout::for_version(version);
+        assert_eq!(refusal, Err(FormatError::UnknownVersion(version)));
+        let rendered = refusal.unwrap_err().to_string();
+        assert!(
+            rendered.contains(&version.to_string()),
+            "the refusal must name the version it saw, got {rendered:?}",
+        );
+    }
+    // A retired version is a different answer from an unknown one: unknown
+    // means the file is newer than the build, retired means it is older.
+    let retired = Layout::for_version(1).unwrap_err();
+    assert_eq!(retired, FormatError::RetiredVersion(1));
+    assert!(retired.to_string().contains("retired"));
+    assert_ne!(
+        retired.to_string(),
+        FormatError::UnknownVersion(1).to_string()
+    );
+
+    // Every version in the table resolves, and nothing else does.
+    for layout in Layout::KNOWN {
+        assert_eq!(Layout::for_version(layout.version()), Ok(*layout));
+    }
+    assert_eq!(Layout::for_version(2).map(Layout::record_stride), Ok(56));
+}
+
+#[test]
+fn a_known_version_keeps_its_stride_after_a_new_one_exists() {
+    // A hypothetical version 3 at a different stride and a different block
+    // size, declared through the same door a real one would be, and resolved
+    // by the same function the read path calls.
+    let v3 = Layout::declare(3, *b"BRUTEXB3", 2, 72, 57).expect("a legal geometry");
+    let table = [Layout::V2, v3];
+
+    // Version 2 is untouched: same stride, same header length, same blocks.
+    let v2 = Layout::resolve(&table, 2).expect("still there");
+    assert_eq!(v2, Layout::V2);
+    assert_eq!(v2.record_stride(), 56);
+    assert_eq!(v2.header_len(), 32_768);
+    assert_eq!(v2.records_per_block(), 73);
+    assert_eq!(v2.offset_of(145), Ok(40_888));
+
+    // And version 3 is read at its own stride, not at version 2's.
+    let read3 = Layout::resolve(&table, 3).expect("declared above");
+    assert_eq!(read3.record_stride(), 72);
+    assert_eq!(read3.block_len(), 72 * 57);
+    assert_eq!(read3.offset_of(145), Ok(32_768 + 145 * 72));
+    assert_ne!(read3.offset_of(145), v2.offset_of(145));
+
+    // A version in neither table entry is still refused by number.
+    assert_eq!(
+        Layout::resolve(&table, 4),
+        Err(FormatError::UnknownVersion(4)),
+    );
+    // The production table does not silently gain the hypothetical version.
+    assert_eq!(
+        Layout::for_version(3),
+        Err(FormatError::UnknownVersion(3)),
+        "KNOWN is the only table the read path consults",
+    );
+    // And a retired version cannot be resurrected by a caller's own table:
+    // the retirement is checked before the table is searched.
+    assert_eq!(
+        Layout::resolve(&table, 1),
+        Err(FormatError::RetiredVersion(1)),
+    );
+}
+
+#[test]
+fn a_degenerate_layout_is_refused_at_declaration() {
+    let bad = |field| Err(FormatError::DegenerateLayout { field });
+    assert_eq!(
+        Layout::declare(0, MAGIC, 2, 56, 73),
+        bad("version"),
+        "zero is not a version a file can name",
+    );
+    assert_eq!(
+        Layout::declare(1, *b"BRUTEXB1", 2, 56, 73),
+        bad("version"),
+        "a retired number is never reused for a new geometry",
+    );
+    assert_eq!(Layout::declare(3, MAGIC, 2, 0, 73), bad("record_stride"));
+    assert_eq!(
+        Layout::declare(3, MAGIC, 2, 56, 0),
+        bad("records_per_block")
+    );
+    assert_eq!(
+        Layout::declare(3, MAGIC, 2, u64::MAX, 2),
+        bad("block_len"),
+        "a block length that does not fit u64 is not a geometry",
+    );
+    assert_eq!(
+        Layout::declare(3, *b"NOTBRUTE", 2, 56, 73),
+        bad("magic"),
+        "a magic outside the family is not this format",
+    );
+    assert_eq!(
+        Layout::declare(3, MAGIC, 1, 56, 73),
+        bad("slot_count"),
+        "one slot cannot be updated without overwriting the previous commit",
+    );
+    assert_eq!(
+        Layout::declare(3, MAGIC, 0, 56, 73),
+        bad("slot_count"),
+        "no slot at all is not a header",
+    );
+    assert_eq!(
+        Layout::declare(3, MAGIC, MAX_SLOT_COUNT + 1, 56, 73),
+        bad("slot_count"),
+        "a slot past the family bound is a slot no reader looks at",
+    );
+    assert_eq!(
+        Layout::declare(3, MAGIC, u64::MAX, 56, 73),
+        bad("slot_count"),
+    );
+    assert_eq!(
+        Layout::declare(3, MAGIC, 2, 56, 73).map(Layout::version),
+        Ok(3)
+    );
+}
+
+// ===========================================================================
+// Geometry arithmetic that the geometry suite does not reach
+// ===========================================================================
+
+#[test]
+fn an_overflowing_index_is_refused_not_wrapped() {
+    // A wrapped offset addresses a DIFFERENT, valid-looking record. That is
+    // worse than an error, so it must never happen silently.
+    let v2 = Layout::V2;
+    assert_eq!(v2.offset_of(u64::MAX), Err(FormatError::OffsetOverflow));
+
+    // The multiply survives but the header add does not.
+    let biggest_product = u64::MAX / RECORD_STRIDE;
+    assert!(biggest_product.checked_mul(RECORD_STRIDE).is_some());
+    assert_eq!(
+        v2.offset_of(biggest_product),
+        Err(FormatError::OffsetOverflow)
+    );
+
+    // The exact boundary: the largest index whose offset still fits.
+    let last_ok = (u64::MAX - HEADER_LEN) / RECORD_STRIDE;
+    assert!(v2.offset_of(last_ok).is_ok());
+    assert_eq!(v2.offset_of(last_ok + 1), Err(FormatError::OffsetOverflow));
+
+    // A record whose start fits but whose end does not.
+    assert!(v2.record_byte_range(last_ok).is_err());
+    assert_eq!(
+        v2.record_byte_range(u64::MAX),
+        Err(FormatError::OffsetOverflow),
+    );
+    assert_eq!(
+        v2.record_byte_range(0),
+        Ok((HEADER_LEN, HEADER_LEN + RECORD_STRIDE))
+    );
+}
+
+#[test]
+fn an_overflowing_block_is_refused_not_wrapped() {
+    let v2 = Layout::V2;
+    assert_eq!(
+        v2.block_byte_range(0),
+        Ok((HEADER_LEN, HEADER_LEN + BLOCK_LEN))
+    );
+
+    // Each of the three ways a block range can leave u64, nominal and
+    // covered, so no arm is an arm nothing reaches.
+    assert_eq!(
+        v2.block_byte_range(u64::MAX),
+        Err(FormatError::OffsetOverflow),
+        "the block index times the block length overflows",
+    );
+    assert_eq!(
+        v2.covered_byte_range(u64::MAX / RECORDS_PER_BLOCK, u64::MAX),
+        Err(FormatError::OffsetOverflow),
+        "committed, and still the product overflows",
+    );
+
+    let past_header = u64::MAX / BLOCK_LEN;
+    assert!(past_header.checked_mul(BLOCK_LEN).is_some());
+    assert_eq!(
+        v2.block_byte_range(past_header),
+        Err(FormatError::OffsetOverflow),
+        "the product fits but adding the header does not",
+    );
+    assert_eq!(
+        v2.covered_byte_range(past_header, u64::MAX),
+        Err(FormatError::OffsetOverflow),
+    );
+
+    let last_block = (u64::MAX - HEADER_LEN - BLOCK_LEN) / BLOCK_LEN;
+    assert!(v2.block_byte_range(last_block).is_ok());
+    assert_eq!(
+        v2.block_byte_range(last_block + 1),
+        Err(FormatError::OffsetOverflow),
+        "the start fits but the end does not",
+    );
+    assert_eq!(
+        v2.covered_byte_range(last_block + 1, u64::MAX),
+        Err(FormatError::OffsetOverflow),
+    );
+
+    // A one-byte block reaches the same arms from the other side.
+    let thin = Layout::declare(3, *b"BRUTEXB3", 2, 1, 1).expect("a legal geometry");
+    assert_eq!(thin.block_len(), 1);
+    assert_eq!(thin.block_byte_range(0), Ok((HEADER_LEN, HEADER_LEN + 1)));
+    assert_eq!(
+        thin.block_byte_range(u64::MAX),
+        Err(FormatError::OffsetOverflow),
+    );
+    assert_eq!(
+        thin.block_byte_range(u64::MAX - HEADER_LEN),
+        Err(FormatError::OffsetOverflow),
+        "the start fits exactly and the end does not",
+    );
+}
+
+#[test]
+fn capacity_and_ragged_tail_agree_with_the_bytes() {
+    let v2 = Layout::V2;
+    assert_eq!(v2.capacity_for(0), 0);
+    assert_eq!(v2.capacity_for(HEADER_LEN - 1), 0);
+    assert_eq!(v2.capacity_for(HEADER_LEN), 0);
+    assert_eq!(v2.capacity_for(HEADER_LEN + 55), 0);
+    assert_eq!(v2.capacity_for(HEADER_LEN + 56), 1);
+    assert_eq!(v2.capacity_for(HEADER_LEN + 56 * 100), 100);
+}
+
+#[test]
+fn ragged_tail_truncates_loudly() {
+    // S-07 and docs/02 §7. A file whose length does not divide by the stride
+    // was interrupted mid-record. The remainder is reported so it can be
+    // logged with a byte count -- never ignored, never rounded away.
+    let v2 = Layout::V2;
+    for whole in 0..5u64 {
+        let clean = HEADER_LEN + whole * RECORD_STRIDE;
+        assert_eq!(v2.ragged_tail_bytes(clean), 0, "{whole} whole records");
+        assert_eq!(v2.capacity_for(clean), whole);
+        for torn in 1..RECORD_STRIDE {
+            assert_eq!(
+                v2.ragged_tail_bytes(clean + torn),
+                torn,
+                "{torn} bytes of a record {whole}",
+            );
+            assert_eq!(
+                v2.capacity_for(clean + torn),
+                whole,
+                "the torn record is not counted",
+            );
+        }
+    }
+    // A file shorter than a header region is all tail.
+    assert_eq!(v2.ragged_tail_bytes(30), 30);
+    assert_eq!(v2.capacity_for(30), 0);
+    assert_eq!(v2.ragged_tail_bytes(HEADER_LEN - 1), HEADER_LEN - 1);
+}
+
+#[test]
+fn commits_alternate_between_the_slots() {
+    let v2 = Layout::V2;
+    assert_eq!(v2.slot_offset(0), 0);
+    assert_eq!(v2.slot_offset(1), SLOT_STRIDE);
+    assert_eq!(v2.slot_offset(2), 0);
+    assert_eq!(v2.slot_offset(u64::MAX), SLOT_STRIDE);
+}
+
+// ===========================================================================
+// The header slot
+// ===========================================================================
+
+/// Recomputes a slot's checksum after a byte has been patched.
+///
+/// The checksum covers every byte of the slot except the four it occupies, so
+/// this is the same two ranges the decoder reads.
+fn reseal(slot: &mut [u8; SLOT_LEN]) {
+    let crc = crc32c(
+        slot.iter()
+            .take(56)
+            .chain(slot.iter().skip(60))
+            .copied()
+            .collect::<Vec<u8>>(),
+    );
+    slot[56..60].copy_from_slice(&crc.to_le_bytes());
+}
+
+fn genesis_slot() -> [u8; SLOT_LEN] {
+    Header::genesis(7, 60, FLAG_CHECKSUMS)
+        .commit()
+        .expect("v2")
+        .bytes
+}
+
+#[test]
+fn a_slot_round_trips_every_field_at_its_documented_offset() {
+    let header = Header {
+        flags: FLAG_CHECKSUMS,
+        generation: 0x0102_0304_0506_0708,
+        n_valid: 4_242,
+        first_ts_micros: 1_717_386_300_000_000,
+        last_ts_micros: 1_717_389_300_000_000,
+        symbol_id: 0x1234_5678,
+        timeframe_secs: 60,
+        ..Header::genesis(0, 0, 0)
+    };
+    let commit = header.commit().expect("v2");
+    assert_eq!(Header::decode(&commit.bytes), Ok(header));
+    assert_eq!(commit.header, header);
+
+    // The bytes, at the offsets docs/02-store-format.md gives them.
+    let b = &commit.bytes;
+    assert_eq!(&b[0..8], &MAGIC[..]);
+    assert_eq!(u16::from_le_bytes([b[8], b[9]]), 2, "format_version");
+    assert_eq!(u16::from_le_bytes([b[10], b[11]]), 56, "record_stride");
+    assert_eq!(
+        u64::from_le_bytes(b[16..24].try_into().unwrap()),
+        header.generation
+    );
+    assert_eq!(u64::from_le_bytes(b[24..32].try_into().unwrap()), 4_242);
+    assert_eq!(
+        i64::from_le_bytes(b[32..40].try_into().unwrap()),
+        header.first_ts_micros,
+        "first_ts_micros is written, not left at the epoch",
+    );
+    assert_eq!(
+        i64::from_le_bytes(b[40..48].try_into().unwrap()),
+        header.last_ts_micros
+    );
+    assert_eq!(&b[60..64], &[0, 0, 0, 0], "reserved stays zero");
+
+    // Idempotent: the same header always produces the same 64 bytes.
+    assert_eq!(header.commit().expect("v2").bytes, commit.bytes);
+}
+
+#[test]
+fn a_slot_caught_mid_write_fails_its_checksum_rather_than_mixing_two_commits() {
+    // `decode` copies the 64 bytes once and checks the copy, so the checksum
+    // covers exactly the bytes the returned Header carries. Over the
+    // MAP_SHARED mapping the module endorses, with a writer pwriting the same
+    // file, the observable consequence is this: at EVERY split point a
+    // mixture of two images is either one of the two images exactly, or a
+    // refusal. Never a third header that no checksum ever covered.
+    let old = Header::genesis(7, 60, FLAG_CHECKSUMS);
+    let new = old
+        .advance(100, 1_717_386_300_000_000, 1_717_392_240_000_000)
+        .expect("fits")
+        .advance(50, 1_717_392_300_000_000, 1_717_395_240_000_000)
+        .expect("fits");
+    let old_bytes = old.commit().expect("v2").bytes;
+    let new_bytes = new.commit().expect("v2").bytes;
+    assert_eq!(old.generation % 2, new.generation % 2, "the same slot");
+
+    let mut refusals = 0u32;
+    for split in 0..=SLOT_LEN {
+        let mut mixed = new_bytes;
+        for (dst, src) in mixed
+            .iter_mut()
+            .skip(split)
+            .zip(old_bytes.iter().skip(split))
+        {
+            *dst = *src;
+        }
+        match Header::decode(&mixed) {
+            Ok(read) => assert!(
+                read == old || read == new,
+                "split {split} produced a header nobody ever wrote: {read:?}",
+            ),
+            Err(refusal) => {
+                assert!(
+                    matches!(refusal, FormatError::SlotChecksum { .. }),
+                    "split {split}: {refusal}",
+                );
+                refusals += 1;
+            }
+        }
+    }
+    assert!(
+        refusals > 0,
+        "if no mixture is ever refused this test proves nothing",
+    );
+}
+
+#[test]
+fn a_slot_shorter_than_a_slot_is_refused() {
+    assert_eq!(
+        Header::decode(&[]),
+        Err(FormatError::SlotTooShort { len: 0 })
+    );
+    assert_eq!(
+        Header::decode(&[0u8; 63]),
+        Err(FormatError::SlotTooShort { len: 63 }),
+    );
+    // Longer is fine: only the first slot's worth is read.
+    let mut long = vec![0u8; 200];
+    long[..SLOT_LEN].copy_from_slice(&genesis_slot());
+    assert!(Header::decode(&long).is_ok());
+}
+
+#[test]
+fn a_slot_that_is_not_a_bar_file_is_refused_before_its_version_is_read() {
+    let mut slot = genesis_slot();
+    slot[0] = b'X';
+    assert_eq!(Header::decode(&slot), Err(FormatError::NotABarFile));
+    assert_eq!(
+        Header::decode(&[0u8; SLOT_LEN]),
+        Err(FormatError::NotABarFile)
+    );
+}
+
+#[test]
+fn a_slot_naming_an_unknown_version_is_refused_by_number() {
+    let mut slot = genesis_slot();
+    slot[8..10].copy_from_slice(&9u16.to_le_bytes());
+    assert_eq!(Header::decode(&slot), Err(FormatError::UnknownVersion(9)));
+}
+
+#[test]
+fn a_version_one_file_is_named_retired_rather_than_reported_as_destroyed() {
+    // A file written to the geometry docs/02-store-format.md described before
+    // this change: a 64-byte header, magic BRUTEXB1, version 1, stride 56,
+    // n_valid at offset 16, an 8-byte header_crc at 48 over bytes 0..48.
+    let mut v1 = vec![0u8; 64 + 10 * 56];
+    v1[0..8].copy_from_slice(b"BRUTEXB1");
+    v1[8..10].copy_from_slice(&1u16.to_le_bytes());
+    v1[10..12].copy_from_slice(&56u16.to_le_bytes());
+    v1[16..24].copy_from_slice(&10u64.to_le_bytes());
+
+    // The version decides before the checksum is read, so the refusal names
+    // the format rather than the damage. Reading it at version 2's offsets
+    // would lift `generation` out of `n_valid` and hand back plausible
+    // integers, and reporting NoValidHeader would be a false diagnosis of an
+    // intact file.
+    assert_eq!(Header::decode(&v1), Err(FormatError::RetiredVersion(1)));
+    let len = u64::try_from(v1.len()).expect("fits");
+    assert_eq!(
+        Header::read_region(&v1, len),
+        Err(FormatError::RetiredVersion(1)),
+    );
+    assert!(
+        FormatError::RetiredVersion(1)
+            .to_string()
+            .contains("version 1"),
+    );
+}
+
+#[test]
+fn a_magic_that_disagrees_with_the_version_field_is_refused() {
+    // Two independent statements of the same fact. When they differ the file
+    // is not what either of them claims, and reading it at either version's
+    // stride is a guess.
+    let mut slot = genesis_slot();
+    slot[7] = b'9';
+    assert_eq!(
+        Header::decode(&slot),
+        Err(FormatError::MagicVersionMismatch(2)),
+    );
+}
+
+#[test]
+fn a_slot_whose_checksum_does_not_match_its_bytes_is_refused() {
+    let mut slot = genesis_slot();
+    let good = Header::decode(&slot).expect("v2");
+    slot[24] ^= 0x01; // one bit of n_valid
+    let refusal = Header::decode(&slot).expect_err("a flipped counter bit");
+    assert!(matches!(refusal, FormatError::SlotChecksum { .. }));
+    assert!(refusal.to_string().contains("checksum"));
+
+    // Resealing makes it decode again -- which is the point: the checksum is
+    // what stands between a flipped bit and a plausible wrong number.
+    reseal(&mut slot);
+    let tampered = Header::decode(&slot).expect("resealed");
+    assert_ne!(tampered.n_valid, good.n_valid);
+}
+
+#[test]
+fn a_slot_naming_the_wrong_stride_for_its_version_is_refused() {
+    let mut slot = genesis_slot();
+    slot[10..12].copy_from_slice(&64u16.to_le_bytes());
+    reseal(&mut slot);
+    assert_eq!(Header::decode(&slot), Err(FormatError::StrideMismatch(64)));
+}
+
+#[test]
+fn a_header_this_build_cannot_write_is_refused_at_commit() {
+    let unknown = Header {
+        format_version: 9,
+        ..Header::genesis(7, 60, 0)
+    };
+    assert_eq!(unknown.commit(), Err(FormatError::UnknownVersion(9)));
+
+    let retired = Header {
+        format_version: 1,
+        ..Header::genesis(7, 60, 0)
+    };
+    assert_eq!(retired.commit(), Err(FormatError::RetiredVersion(1)));
+
+    let wrong_stride = Header {
+        record_stride: 64,
+        ..Header::genesis(7, 60, 0)
+    };
+    assert_eq!(wrong_stride.commit(), Err(FormatError::StrideMismatch(64)));
+    assert_eq!(
+        wrong_stride.validate(Layout::V2, HEADER_LEN),
+        Err(FormatError::StrideMismatch(64)),
+    );
+}
+
+#[test]
+fn a_genesis_header_describes_an_empty_file() {
+    let header = Header::genesis(7, 60, FLAG_CHECKSUMS);
+    assert_eq!(header.format_version, 2);
+    assert_eq!(header.record_stride, 56);
+    assert_eq!(header.generation, 0);
+    assert_eq!(header.n_valid, 0);
+    assert_eq!(header.symbol_id, 7);
+    assert_eq!(header.timeframe_secs, 60);
+    assert_eq!(header.flags & FLAG_CHECKSUMS, FLAG_CHECKSUMS);
+    assert!(header.checksums_present());
+    assert!(!Header::genesis(7, 60, 0).checksums_present());
+    assert_eq!(header.validate(Layout::V2, HEADER_LEN), Ok(()));
+
+    let commit = header.commit().expect("v2");
+    assert_eq!((commit.slot, commit.offset), (0, 0));
+    assert_eq!(commit.durable_through, HEADER_LEN);
+
+    // The first append to an empty file is what sets first_ts_micros, and
+    // nothing moves it afterwards.
+    let first = header.advance(3, 99, 300).expect("fits");
+    assert_eq!(
+        first,
+        Header {
+            generation: 1,
+            n_valid: 3,
+            first_ts_micros: 99,
+            last_ts_micros: 300,
+            ..header
+        },
+    );
+    let second = first.advance(2, 360, 420).expect("fits");
+    assert_eq!(second.first_ts_micros, 99, "record 0 never moves");
+    assert_eq!(second.last_ts_micros, 420);
+    assert_eq!(second.n_valid, 5);
+}
+
+// ===========================================================================
+// Paths
+// ===========================================================================
+
+fn parts(vendor: Vendor, symbol: &str) -> PathParts<'_> {
+    PathParts {
+        vendor,
+        exchange: "NSE",
+        segment: "INDEX",
+        symbol,
+        timeframe: Timeframe::MINUTE_1,
+        month: YearMonth::new(2024, 6).expect("a real month"),
+        file: FileKind::Bars,
+    }
+}
+
+#[test]
+fn vendor_prefix_isolated() {
+    // X-12, LEXICALLY. Each vendor writes only under its own prefix, and no
+    // vendor can reach another's -- as text. Enforced by construction: the
+    // first segment is a Vendor rather than a string, the renderer writes it
+    // before anything that varies, and no segment can hold a separator.
+    // What this does NOT cover is a symlink; see StorePath::to_path_buf.
+    let mut seen = HashSet::new();
+    for vendor in Vendor::ALL {
+        let path = StorePath::new(parts(vendor, "NIFTY")).expect("a legal path");
+        let rendered = path.to_string();
+        let components: Vec<&str> = rendered.split('/').collect();
+
+        assert_eq!(components[0], STORE_ROOT, "the store root comes first");
+        assert_eq!(
+            components[1],
+            vendor.as_str(),
+            "the vendor is the first segment under the root",
+        );
+        assert_eq!(path.vendor(), vendor);
+        assert_eq!(path.vendor_segment(), vendor.as_str());
+        assert!(
+            components
+                .iter()
+                .all(|c| !c.is_empty() && *c != ".." && *c != "."),
+            "no component can climb: {rendered}",
+        );
+        assert!(seen.insert(rendered), "two vendors produced one path");
+    }
+    assert_eq!(seen.len(), Vendor::ALL.len());
+
+    // The same instrument in two vendors differs only in that one segment, and
+    // neither path is a prefix of the other's vendor directory.
+    let groww = StorePath::new(parts(Vendor::Groww, "NIFTY"))
+        .expect("legal")
+        .to_string();
+    let dhan = StorePath::new(parts(Vendor::Dhan, "NIFTY"))
+        .expect("legal")
+        .to_string();
+    assert_eq!(groww, "bars/groww/NSE/INDEX/NIFTY/1min/2024-06.bin");
+    assert_eq!(dhan, "bars/dhan/NSE/INDEX/NIFTY/1min/2024-06.bin");
+    assert!(!groww.starts_with("bars/dhan/"));
+    assert!(!dhan.starts_with("bars/groww/"));
+
+    // And on a real filesystem path, no component is a parent reference, so
+    // joining onto a root cannot leave it -- lexically.
+    let joined = StorePath::new(parts(Vendor::Groww, "NIFTY"))
+        .expect("legal")
+        .to_path_buf(Path::new("/var/lib/brutex"));
+    assert_eq!(
+        joined,
+        Path::new("/var/lib/brutex/bars/groww/NSE/INDEX/NIFTY/1min/2024-06.bin"),
+    );
+    assert!(joined.starts_with("/var/lib/brutex/bars/groww"));
+    assert!(
+        joined
+            .components()
+            .all(|c| c != std::path::Component::ParentDir),
+    );
+}
+
+#[test]
+fn every_vendor_is_a_legal_segment() {
+    // StorePath::new does not re-check the vendor: it is a closed set of
+    // lower-case literals, and a runtime check would carry a refusal arm no
+    // input could reach, which coverage could never close. This drives the
+    // SAME check_segment every other segment goes through, over the whole
+    // table, so the property is proven rather than assumed.
+    for vendor in Vendor::ALL {
+        assert_eq!(
+            check_segment("vendor", vendor.as_str(), SegmentCase::Lower),
+            Ok(()),
+            "{} is not a legal path segment",
+            vendor.as_str(),
+        );
+        assert!(vendor.as_str().len() <= MAX_VENDOR_LEN);
+    }
+    assert_eq!(MAX_VENDOR_LEN, 5, "groww");
+    const { assert!(MAX_VENDOR_LEN <= MAX_SEGMENT_LEN) }
+
+    // And the check is not vacuous: a vendor segment in the wrong case would
+    // be refused if one ever appeared.
+    assert_eq!(
+        check_segment("vendor", "GROWW", SegmentCase::Lower),
+        Err(PathError::NotCanonicalCase {
+            field: "vendor",
+            byte: b'G',
+        }),
+    );
+}
+
+#[test]
+fn the_segment_cap_is_cores_symbol_capacity() {
+    // A const assertion carries this; the numbers are written out so the
+    // invariant table has a named test. Raising SYMBOL_CAPACITY without
+    // raising MAX_SEGMENT_LEN would make the store path a second, quieter
+    // limit on what can be stored -- and crates/core is not this crate's to
+    // watch.
+    assert_eq!(MAX_SEGMENT_LEN, SYMBOL_CAPACITY);
+    let longest = "A".repeat(SYMBOL_CAPACITY);
+    let symbol = Symbol::new(&longest).expect("core admits a symbol at its cap");
+    assert!(
+        StorePath::new(parts(Vendor::Groww, symbol.as_str())).is_ok(),
+        "so must the path that has to hold it",
+    );
+}
+
+#[test]
+fn a_case_variant_is_refused_not_a_second_prefix() {
+    // Measured: on this machine (APFS, case-insensitive) bars/groww/... and
+    // bars/GROWW/... are ONE file, so writing the second destroys the first.
+    // On the CI runner (ext4) they are TWO trees, which silently splits one
+    // series in half. Same inputs, two different on-disk results chosen by
+    // the host -- so neither variant is allowed to be constructible.
+    assert_eq!(
+        StorePath::new(parts(Vendor::Groww, "nifty")).err(),
+        Some(PathError::NotCanonicalCase {
+            field: "symbol",
+            byte: b'n',
+        }),
+    );
+    assert_eq!(
+        StorePath::new(parts(Vendor::Groww, "NiFtY")).err(),
+        Some(PathError::NotCanonicalCase {
+            field: "symbol",
+            byte: b'i',
+        }),
+    );
+    for (field, hostile) in [
+        (
+            "exchange",
+            PathParts {
+                exchange: "nse",
+                ..parts(Vendor::Groww, "NIFTY")
+            },
+        ),
+        (
+            "segment",
+            PathParts {
+                segment: "index",
+                ..parts(Vendor::Groww, "NIFTY")
+            },
+        ),
+    ] {
+        let err = StorePath::new(hostile).expect_err("must refuse");
+        assert!(
+            err.to_string().contains(field) && err.to_string().contains("case"),
+            "the refusal must name the segment and the reason, got {err}",
+        );
+    }
+
+    // The vendor segment cannot be mis-cased at all: there is no field to put
+    // "GROWW" in, because it is a Vendor and not a string. That is the door
+    // X-12 needed closed -- code holding Vendor::Groww could previously write
+    // `vendor: "dhan"` and nothing would refuse it.
+    assert_eq!(
+        StorePath::new(parts(Vendor::Groww, "NIFTY"))
+            .expect("legal")
+            .vendor(),
+        Vendor::Groww,
+    );
+
+    // And core's normalisation is no longer routed around: `for_key` takes a
+    // Symbol, which upper-cases, so one instrument has exactly one path.
+    let month = YearMonth::new(2024, 6).expect("a real month");
+    let lower = InstrumentKey::index(Exchange::Nse, "nifty").expect("core normalises");
+    let upper = InstrumentKey::index(Exchange::Nse, "NIFTY").expect("a real index");
+    assert_eq!(lower, upper);
+    assert_eq!(
+        StorePath::for_key(
+            Vendor::Groww,
+            &lower,
+            Timeframe::MINUTE_1,
+            month,
+            FileKind::Bars
+        )
+        .expect("legal")
+        .to_string(),
+        "bars/groww/NSE/INDEX/NIFTY/1min/2024-06.bin",
+    );
+}
+
+#[test]
+fn a_segment_that_could_escape_the_vendor_prefix_is_refused() {
+    // Each refusal, by name. Nothing is sanitised: silently stripping a
+    // character maps two different instruments onto one path, which is the
+    // exact failure the vendor prefix exists to prevent.
+    let cases: [(&str, PathError); 9] = [
+        ("", PathError::EmptySegment { field: "symbol" }),
+        ("..", PathError::Traversal { field: "symbol" }),
+        (".", PathError::Traversal { field: "symbol" }),
+        (
+            "a/b",
+            PathError::IllegalByte {
+                field: "symbol",
+                byte: b'/',
+            },
+        ),
+        (
+            "/etc",
+            PathError::IllegalByte {
+                field: "symbol",
+                byte: b'/',
+            },
+        ),
+        (
+            "..\\..",
+            PathError::IllegalByte {
+                field: "symbol",
+                byte: b'.',
+            },
+        ),
+        (
+            "a\0b",
+            PathError::IllegalByte {
+                field: "symbol",
+                byte: 0,
+            },
+        ),
+        (
+            "NIFTY 50",
+            PathError::IllegalByte {
+                field: "symbol",
+                byte: b' ',
+            },
+        ),
+        (
+            "2024-06.bin",
+            PathError::IllegalByte {
+                field: "symbol",
+                byte: b'.',
+            },
+        ),
+    ];
+    for (symbol, expected) in cases {
+        assert_eq!(
+            StorePath::new(parts(Vendor::Groww, symbol)).err(),
+            Some(expected),
+            "symbol {symbol:?} was not refused as expected",
+        );
+    }
+
+    // Over-long, on the field whose cap is load-bearing.
+    let long = "A".repeat(MAX_SEGMENT_LEN + 1);
+    assert_eq!(
+        StorePath::new(parts(Vendor::Groww, &long)).err(),
+        Some(PathError::SegmentTooLong {
+            field: "symbol",
+            len: MAX_SEGMENT_LEN + 1,
+        }),
+    );
+    assert!(StorePath::new(parts(Vendor::Groww, &"A".repeat(MAX_SEGMENT_LEN))).is_ok());
+
+    // Every caller-supplied segment is checked, not only the symbol.
+    for (field, hostile) in [
+        (
+            "exchange",
+            PathParts {
+                exchange: "..",
+                ..parts(Vendor::Groww, "NIFTY")
+            },
+        ),
+        (
+            "segment",
+            PathParts {
+                segment: "",
+                ..parts(Vendor::Groww, "NIFTY")
+            },
+        ),
+        (
+            "symbol",
+            PathParts {
+                symbol: "../DHAN",
+                ..parts(Vendor::Groww, "NIFTY")
+            },
+        ),
+    ] {
+        let err = StorePath::new(hostile).expect_err("must refuse");
+        assert!(
+            err.to_string().contains(field),
+            "the refusal must name the segment, got {err}",
+        );
+    }
+}
+
+#[test]
+fn a_timeframe_and_a_month_are_values_not_strings() {
+    assert_eq!(Timeframe::from_secs(60), Ok(Timeframe::MINUTE_1));
+    assert_eq!(Timeframe::MINUTE_1.secs(), 60);
+    assert_eq!(Timeframe::MINUTE_1.as_str(), "1min");
+    assert_eq!(Timeframe::KNOWN, &[Timeframe::MINUTE_1]);
+    // D-0015: minute bars only, until a minute-level result earns the upgrade.
+    assert_eq!(
+        Timeframe::from_secs(300),
+        Err(PathError::UnknownTimeframe { secs: 300 }),
+    );
+    assert_eq!(
+        Timeframe::from_secs(0),
+        Err(PathError::UnknownTimeframe { secs: 0 }),
+    );
+
+    let june = YearMonth::new(2024, 6).expect("a real month");
+    assert_eq!((june.year(), june.month()), (2024, 6));
+    assert_eq!(june.to_string(), "2024-06");
+    assert_eq!(
+        YearMonth::new(1999, 12).expect("a real month").to_string(),
+        "1999-12",
+    );
+    assert_eq!(
+        YearMonth::new(2024, 0),
+        Err(PathError::MonthOutOfRange { month: 0 }),
+    );
+    assert_eq!(
+        YearMonth::new(2024, 13),
+        Err(PathError::MonthOutOfRange { month: 13 }),
+    );
+    // No bar can predate the epoch its timestamp counts from.
+    assert_eq!(
+        YearMonth::new(1969, 1),
+        Err(PathError::YearOutOfRange { year: 1969 }),
+    );
+    assert_eq!(
+        YearMonth::new(10_000, 1),
+        Err(PathError::YearOutOfRange { year: 10_000 }),
+    );
+    assert!(YearMonth::new(1970, 1).is_ok());
+    assert!(YearMonth::new(9999, 12).is_ok());
+}
+
+#[test]
+fn the_sibling_files_of_a_month_share_every_segment_but_the_extension() {
+    let base = parts(Vendor::Groww, "NIFTY");
+    let mut rendered = Vec::new();
+    for file in FileKind::ALL {
+        let path = StorePath::new(PathParts { file, ..base }).expect("legal");
+        assert_eq!(path.file(), file);
+        rendered.push(path.to_string());
+    }
+    assert_eq!(
+        rendered,
+        vec![
+            "bars/groww/NSE/INDEX/NIFTY/1min/2024-06.bin".to_owned(),
+            "bars/groww/NSE/INDEX/NIFTY/1min/2024-06.crc".to_owned(),
+            "bars/groww/NSE/INDEX/NIFTY/1min/2024-06.ovl".to_owned(),
+            "bars/groww/NSE/INDEX/NIFTY/1min/2024-06.lock".to_owned(),
+        ],
+    );
+
+    // The lock is a sibling formed by the one renderer, not a string a caller
+    // concatenates -- docs/02 §9's "one writer per file, enforced by an
+    // advisory lock" needs a name that cannot drift from the file it guards.
+    assert_eq!(FileKind::Lock.extension(), ".lock");
+    assert_eq!(FileKind::ALL.len(), 4);
+
+    let bars = StorePath::new(base).expect("legal");
+    assert_eq!(bars.timeframe(), Timeframe::MINUTE_1);
+    assert_eq!(bars.month(), YearMonth::new(2024, 6).expect("a real month"));
+}
+
+#[test]
+fn a_path_is_built_from_the_canonical_identity_not_from_loose_strings() {
+    let month = YearMonth::new(2024, 6).expect("a real month");
+    let nifty = InstrumentKey::index(Exchange::Nse, "NIFTY").expect("a real index");
+    let path = StorePath::for_key(
+        Vendor::Groww,
+        &nifty,
+        Timeframe::MINUTE_1,
+        month,
+        FileKind::Bars,
+    )
+    .expect("a legal path");
+    assert_eq!(
+        path.to_string(),
+        "bars/groww/NSE/INDEX/NIFTY/1min/2024-06.bin"
+    );
+
+    let equity = InstrumentKey {
+        exchange: Exchange::Nse,
+        segment: Segment::Cash,
+        underlying: Symbol::new("RELIANCE").expect("a real symbol"),
+        kind: Kind::Equity,
+    };
+    assert_eq!(
+        StorePath::for_key(
+            Vendor::Dhan,
+            &equity,
+            Timeframe::MINUTE_1,
+            month,
+            FileKind::Bars
+        )
+        .expect("a legal path")
+        .to_string(),
+        "bars/dhan/NSE/CASH/RELIANCE/1min/2024-06.bin",
+    );
+
+    // A future and an option are filed under their CONTRACT, which this
+    // builder does not form -- so it refuses by name rather than filing every
+    // expiry under the underlying and silently merging distinct series.
+    let expiry = Expiry::new(2024, 6, 27).expect("a real expiry");
+    for kind in [
+        Kind::Future { expiry },
+        Kind::Option {
+            expiry,
+            strike: Paisa::from_raw(2_500_000),
+            side: OptionSide::Call,
+        },
+    ] {
+        let contract = InstrumentKey {
+            exchange: Exchange::Nse,
+            segment: Segment::Fno,
+            underlying: Symbol::new("NIFTY").expect("a real symbol"),
+            kind,
+        };
+        assert_eq!(
+            StorePath::for_key(
+                Vendor::Groww,
+                &contract,
+                Timeframe::MINUTE_1,
+                month,
+                FileKind::Bars,
+            ),
+            Err(PathError::ContractPathUnsupported),
+        );
+    }
+}
+
+#[test]
+fn a_maximal_path_fits_the_declared_bound() {
+    let longest = "A".repeat(MAX_SEGMENT_LEN);
+    // The widest vendor and the longest extension, found in their tables
+    // rather than written down, so the bound cannot drift away from them.
+    let widest = Vendor::ALL
+        .into_iter()
+        .max_by_key(|v| v.as_str().len())
+        .expect("a non-empty table");
+    assert_eq!(widest.as_str().len(), MAX_VENDOR_LEN);
+    let fattest = FileKind::ALL
+        .into_iter()
+        .max_by_key(|f| f.extension().len())
+        .expect("a non-empty table");
+    assert_eq!(fattest.extension().len(), MAX_EXTENSION_LEN);
+
+    let path = StorePath::new(PathParts {
+        vendor: widest,
+        exchange: &longest,
+        segment: &longest,
+        symbol: &longest,
+        timeframe: Timeframe::MINUTE_1,
+        month: YearMonth::new(9999, 12).expect("a real month"),
+        file: fattest,
+    })
+    .expect("every segment is at the cap");
+
+    // Exactly, not merely within: the bound is the length of the longest legal
+    // path, so a bound that drifted in either direction fails here.
+    assert_eq!(path.to_string().len(), MAX_LEN);
+    assert_eq!(MAX_LEN, 103);
+    assert_eq!(
+        path.to_string(),
+        format!(
+            "bars/{}/{longest}/{longest}/{longest}/1min/9999-12{}",
+            widest.as_str(),
+            fattest.extension(),
+        ),
+    );
+
+    // The timeframe bound is the table's, not the segment cap's.
+    assert!(
+        Timeframe::KNOWN
+            .iter()
+            .all(|tf| tf.as_str().len() <= MAX_TIMEFRAME_LEN),
+    );
+    assert!(
+        Timeframe::KNOWN
+            .iter()
+            .any(|tf| tf.as_str().len() == MAX_TIMEFRAME_LEN),
+        "the bound must be reached by something, or it is not a bound",
+    );
+
+    // Every shorter path is shorter, so the bound really is the maximum.
+    assert!(
+        StorePath::new(parts(Vendor::Groww, "NIFTY"))
+            .expect("legal")
+            .to_string()
+            .len()
+            < MAX_LEN,
+    );
+}
+
+// ===========================================================================
+// Every refusal says something different
+// ===========================================================================
+
+#[test]
+fn every_format_error_renders_a_distinct_reason() {
+    let all = [
+        FormatError::OffsetOverflow,
+        FormatError::SlotTooShort { len: 63 },
+        FormatError::HeaderRegionTooShort { slots: 1, need: 2 },
+        FormatError::NotABarFile,
+        FormatError::UnknownVersion(7),
+        FormatError::RetiredVersion(7),
+        FormatError::MagicVersionMismatch(3),
+        FormatError::StrideMismatch(64),
+        FormatError::TooShortForHeader,
+        FormatError::CounterExceedsFile,
+        FormatError::CounterOverflow,
+        FormatError::GenerationExhausted,
+        FormatError::TimestampsOutOfOrder {
+            previous: 9,
+            next: 8,
+        },
+        FormatError::SlotChecksum {
+            stored: 1,
+            computed: 2,
+        },
+        FormatError::BlockChecksum {
+            block: 4,
+            stored: 1,
+            computed: 2,
+        },
+        FormatError::BlockNotCommitted {
+            block: 4,
+            blocks: 3,
+        },
+        FormatError::BlockLengthMismatch {
+            block: 4,
+            len: 55,
+            need: 56,
+        },
+        FormatError::ChecksumsAbsent,
+        FormatError::SlotPositionMismatch {
+            expected: 1,
+            found: 0,
+        },
+        FormatError::DegenerateLayout { field: "magic" },
+        FormatError::NoValidHeader,
+    ];
+    assert_distinct(&all);
+    assert!(all[1].to_string().contains("63"), "the length is visible");
+    assert!(all[4].to_string().contains('7'), "the version is visible");
+    assert!(all[5].to_string().contains('7'), "the version is visible");
+    assert!(all[7].to_string().contains("64"), "the stride is visible");
+    assert!(all[14].to_string().contains('4'), "the block is visible");
+    assert!(
+        all[19].to_string().contains("magic"),
+        "the field is visible"
+    );
+    let as_error: &dyn std::error::Error = &FormatError::NotABarFile;
+    assert!(as_error.source().is_none());
+}
+
+#[test]
+fn every_path_error_renders_a_distinct_reason() {
+    let all = [
+        PathError::EmptySegment { field: "vendor" },
+        PathError::Traversal { field: "vendor" },
+        PathError::IllegalByte {
+            field: "vendor",
+            byte: b'/',
+        },
+        PathError::NotCanonicalCase {
+            field: "vendor",
+            byte: b'G',
+        },
+        PathError::SegmentTooLong {
+            field: "vendor",
+            len: 99,
+        },
+        PathError::UnknownTimeframe { secs: 300 },
+        PathError::MonthOutOfRange { month: 13 },
+        PathError::YearOutOfRange { year: 1969 },
+        PathError::ContractPathUnsupported,
+    ];
+    assert_distinct(&all);
+    assert!(all[4].to_string().contains("99"), "the length is visible");
+    assert!(
+        all[5].to_string().contains("300"),
+        "the seconds are visible"
+    );
+    assert!(all[3].to_string().contains("case"), "the reason is visible");
+    let as_error: &dyn std::error::Error = &PathError::ContractPathUnsupported;
+    assert!(as_error.source().is_none());
+}
+
+/// Every rendering differs from every other, and none is empty.
+fn assert_distinct<E: std::fmt::Display + std::fmt::Debug>(all: &[E]) {
+    let rendered: Vec<String> = all.iter().map(ToString::to_string).collect();
+    for (i, a) in rendered.iter().enumerate() {
+        assert!(!a.is_empty(), "variant {i} renders as nothing");
+        assert!(
+            !format!("{:?}", all[i]).is_empty(),
+            "variant {i} has no Debug",
+        );
+        for (j, b) in rendered.iter().enumerate() {
+            if i != j {
+                assert_ne!(a, b, "variants {i} and {j} render identically");
+            }
+        }
+    }
+}

--- a/docs/00-charter.md
+++ b/docs/00-charter.md
@@ -149,6 +149,22 @@ Evidence lane is recorded per row and is never promoted while copying.
 | Security ids | NIFTY = 13 (verified from the SDK's own example). BANKNIFTY 25, SENSEX 51, INDIA VIX 21 — **community sources only, unverified.** | mixed |
 | India VIX candle availability | **UNVERIFIED.** No documentation states it. Treat as a hard gate before relying on it. | unverified |
 
+### 4a. Instrument facts transcribed into source
+
+Golden rule 1: every claim about an instrument names the route that produced
+it. These are the instrument-level facts compiled into this repository as Rust
+data rather than fetched, so the route has to be recorded here.
+
+| Fact | Where it lives | Route | Lane |
+|---|---|---|---|
+| **NIFTY Total Market — 750 constituents** | `core::universe::NIFTY_TOTAL_MARKET` | niftyindices.com states the index holds 750 stocks: "all stocks that are part of Nifty 500 and Nifty Microcap 250". The names were transcribed from the local lake's NSE/CASH directories and matched the primary broker's equity list 750/750 with zero misses. Re-checked against both real masters 2026-08-01: 750/750 resolve as a kept equity in **both** vendors, ISINs agreeing. | derived + cross-checked; **UNVERIFIED against an NSE constituent circular** |
+| **F&O underlyings — 213 names** | `core::universe::FNO_UNDERLYINGS` | Derived from the derivative rows of both vendor masters, excluding `*NSETEST`. The two brokers agree exactly: 213 each, zero on either side only. | derived + cross-checked; **UNVERIFIED against an NSE circular** |
+| **NSE board series — 128 codes** | `core::vendor::EQUITY_BOARD_SERIES`, `SME_BOARD_SERIES`, `NON_EQUITY_SERIES` | The measured union of every distinct `series` on a Groww `NSE/CASH/EQ` row and every distinct `SERIES` on a Dhan `NSE/E/EQUITY` row, 2026-08-01. 6 equity-board, 2 SME, 120 debt and fund. Board verdicts agree on 4,080 of 4,080 shared ISINs. | measured from both masters; **UNVERIFIED against an NSE series circular** |
+
+Both index lists are **snapshots** of rebalanced indices, and none of the three
+has been checked against an exchange publication. `docs/06-limits.md` §11
+carries what that costs. D-0025 and D-0029.
+
 ---
 
 ## 5. Run identity

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -143,7 +143,7 @@ observe mid-flight.** Results accumulate per shard and merge once at the end.
 | Operation | Cost | Mechanism |
 |---|---|---|
 | Locate a slice | O(1) | path join |
-| Read bar *i* | O(1) | `base + 64 + i·56` |
+| Read bar *i* | O(1) | `base + 32768 + i·56` — see `docs/02-store-format.md` §1 |
 | Read condition bits for bar *i* | O(1) | index into a `Vec<u128>` |
 | Test one candidate against one bar | O(1) | `(bits & mask) == mask` |
 | Reject a duplicate candidate | O(1) | filter probe, then a sharded exact confirm |

--- a/docs/02-store-format.md
+++ b/docs/02-store-format.md
@@ -1,49 +1,89 @@
-# 02 — Store format, version 1
+# 02 — Store format, version 2
 
 Bytes on disk. This document is the authority; the code follows it.
 
 The version number is in the header. A format change mints a **new version**
 and old files stay readable at their own stride. Nothing is ever mutated in
-place.
+place — `CLAUDE.md` §3 rule 8.
+
+**Version 1 is retired.** §10 says what it was and why it is refused rather
+than decoded. Its number is never reused.
 
 ---
 
 ## 1. File layout
 
 ```
-byte 0                    64                                        EOF
-  ├──────── header ────────┼─── record 0 ─┼─── record 1 ─┼── … ──────┤
-           64 bytes            56 bytes       56 bytes
+byte 0                  32768                                       EOF
+  ├──── header region ────┼─── record 0 ─┼─── record 1 ─┼── … ───────┤
+   2 slots × 16384 spacing    56 bytes       56 bytes
 ```
 
 **Address of record *i*:**
 
 ```
-ptr = base + 64 + i * 56
+ptr = base + 32768 + i * 56
 ```
 
 An add, a multiply, a load. No search, no decode, no allocation.
 
+The two numbers in that formula are not constants on the read path. They come
+from `store::layout::Layout`, selected by the file's own `format_version`.
+
 ---
 
-## 2. Header — 64 bytes
+## 2. Header region — two slots, one write each
+
+The header region is `slot_count × 16384` bytes. Each slot carries **64 bytes
+of fields** at the start of its 16384-byte span; the rest of the span is
+reserved and zero.
+
+Commit *g* is written to slot `g % slot_count`, so consecutive commits never
+touch the same slot, and a reader takes the valid slot with the highest
+generation that the file's length supports.
+
+**Why the slots are 16384 bytes apart and not adjacent.** Storage does not fail
+at byte granularity. The smallest unit a device programs or a filesystem
+writes back is a block or a page, and a partially programmed unit takes
+everything in it. Two slots 64 bytes apart share one such unit, which makes the
+redundancy nominal. Measured on the two hosts this repository builds on:
+
+| Host | Device block | Page |
+|---|---|---|
+| Apple Silicon, macOS, APFS | 4096 | 16384 |
+| GitHub CI runner, x86_64 Linux, ext4 | 4096 | 4096 |
+
+16384 is the largest of those. It is a constant rather than a query of the
+host: a geometry that differed between the two would make the same bytes verify
+differently on each (§3 rule 5).
+
+### One slot — 64 bytes
 
 | Offset | Size | Field | Notes |
 |---|---|---|---|
-| 0 | 8 | `magic` | `b"BRUTEXB1"` |
-| 8 | 2 | `format_version` | `1` |
+| 0 | 8 | `magic` | `b"BRUTEXB2"` |
+| 8 | 2 | `format_version` | `2` |
 | 10 | 2 | `record_stride` | `56`. Read it; never assume it. |
-| 12 | 4 | `flags` | bit 0: checksums present |
-| 16 | 8 | `n_valid` | **the commit counter.** See §5. |
-| 24 | 8 | `first_ts_micros` | of record 0, for a cheap range reject |
-| 32 | 8 | `last_ts_micros` | of record `n_valid-1` |
-| 40 | 4 | `symbol_id` | resolved from the path; a cross-check, not the index |
-| 44 | 4 | `timeframe_secs` | 60 for 1-minute |
-| 48 | 8 | `header_crc` | over bytes 0..48 |
-| 56 | 8 | reserved | zero |
+| 12 | 4 | `flags` | bit 0: block checksums present |
+| 16 | 8 | `generation` | which commit this slot holds. Higher wins. |
+| 24 | 8 | `n_valid` | **the commit counter.** See §5. |
+| 32 | 8 | `first_ts_micros` | of record 0. Meaningful only when `n_valid > 0`. |
+| 40 | 8 | `last_ts_micros` | of record `n_valid-1` |
+| 48 | 4 | `symbol_id` | resolved from the path; a cross-check, not the index |
+| 52 | 4 | `timeframe_secs` | 60 for 1-minute |
+| 56 | 4 | `slot_crc` | CRC-32C over bytes 0..56 **and** 60..64 |
+| 60 | 4 | reserved | zero |
+
+The checksum covers every byte of the slot except the four it occupies, so a
+flipped bit anywhere in the 64 is detected — there is no window a corruption
+can land in and be called clean.
 
 Reserved bytes are zero and stay zero. A future field takes reserved space in
-a **new version**, never by reinterpreting version 1.
+a **new version**, never by reinterpreting version 2.
+
+The 64-byte slot size and the 16384-byte slot spacing are **family** constants:
+every version uses them, which is what lets a reader locate the slots before it
+knows which version the file is.
 
 ---
 
@@ -61,8 +101,8 @@ pub struct Bar {
     pub open_interest:  i64,  // 48  paisa-free count; i64::MIN means null
 }
 
-const _: () = assert!(core::mem::size_of::<Bar>() == 56);
-const _: () = assert!(core::mem::align_of::<Bar>() == 8);
+const _: () = assert!(size_of::<Bar>() == 56);
+const _: () = assert!(align_of::<Bar>() == 8);
 ```
 
 **Prices are paisa integers.** Never a float, at any layer, for any reason.
@@ -73,6 +113,11 @@ months later.
 indices carry no open interest and store the sentinel; conflating that with a
 genuine zero would make a derivative series and an index series indistinguish-
 able on a field that matters.
+
+**A record has no structure that a lost write violates.** An all-zero record is
+a legal flat bar whose open interest is a real zero. Nothing about the record
+can tell it apart from an extent that was never written; that is §6's job, and
+it is why the checksum flag is not decoration.
 
 ---
 
@@ -92,43 +137,109 @@ halted correctly on a full disk; a naive port to a writable mapping would have
 been strictly worse, and that is the single most valuable thing the failure
 audit produced.
 
+A header decoder over a shared mapping copies its 64 bytes **once** before it
+checks anything, so the checksum covers exactly the bytes the decoded header
+carries. A copy that caught a concurrent `pwrite` mid-flight fails that
+checksum rather than returning half of each image.
+
 ---
 
 ## 5. Appending — the commit counter
 
 ```
-1. pwrite the new records at offset  64 + n_valid * 56
-2. fsync the data
-3. store n_valid + count into the header with a RELEASE ordering
-4. fsync the header
+1. pwrite the new records at offset  32768 + n_valid * 56
+2. pwrite the affected block checksums into the .crc sidecar
+3. fsync the data, through Commit::durable_through
+4. pwrite the 64-byte header slot for generation g   <- one write
+5. fsync the header
 ```
 
-A reader loads `n_valid` with an **acquire** ordering and treats records
-`0 .. n_valid` as the whole file. Bytes past `n_valid` are, by definition, not
-there yet.
+A reader treats records `0 .. n_valid` as the whole file. Bytes past `n_valid`
+are, by definition, not there yet.
 
-Consequence: **a torn record is unobservable.** A crash between steps 1 and 3
-leaves bytes on disk that no reader will look at; the next append overwrites
-them. A crash between 3 and 4 leaves a counter that may be re-published — the
-same value, idempotently.
+Consequences:
+
+* **A torn record is unobservable.** A crash between steps 1 and 4 leaves bytes
+  on disk that no reader will look at; the next append overwrites them.
+* **A torn header is unobservable.** Step 4 is one write of one self-checked
+  64-byte unit, into the slot that does *not* hold the previous commit. A crash
+  during it leaves a slot that fails its own checksum, and the reader takes the
+  previous generation.
+* **A header that outran its data loses the tail, not the file.** If the slot
+  becomes durable and the records do not, the counter names records the length
+  cannot support; the reader falls back to the previous generation rather than
+  refusing the whole file.
+
+`Commit::durable_through` is the byte offset step 3 must cover. This repository
+performs no I/O yet, so it states the offset rather than issuing the barrier.
+
+**Exactly one writer per file.** Two writers reading the same generation
+produce the same slot, the same offset and the same record range. Nothing in
+the store crate can enforce that — an exclusive lock is I/O — so the writer
+takes one on the `.lock` sibling (§8) before step 1. This is a stated
+precondition, not a guarantee the format provides.
 
 ---
 
-## 6. Integrity — one checksum per 4 KiB block
+## 6. Integrity — one checksum per block of 73 records
 
-A 4 KiB block holds 73 whole records with 8 bytes of slack. Each block carries
-a CRC in a sidecar file laid out at the same block index, so the record stride
-stays clean.
+A block is **73 whole records = 4088 bytes**, counted in records rather than in
+bytes, and anchored at the end of the header region:
 
 ```
-bars/NSE/INDEX/NIFTY/1min/2024-03.bin
-bars/NSE/INDEX/NIFTY/1min/2024-03.crc
+block_of(i)  =  i / 73
+block start  =  32768 + block * 4088
 ```
+
+Because the block length is a whole multiple of the stride, **a record can
+never begin in one block and end in the next**. Verifying a record reads one
+checksum, never two, whatever its index.
+
+The earlier byte-addressed 4096-byte block did not divide 56: 4096/56 = 73.14,
+so 23 of the first 2,000 records straddled a boundary and verifying one of them
+against either block checked part of a record and pronounced the whole of it
+good.
+
+**Why not the padded 4096-byte block** this document used to describe ("73
+whole records with 8 bytes of slack")? It also never straddles — but a block is
+a range of the file, so padding the block pads the record array, and the
+address of record *i* stops being `base + 32768 + i·56` and becomes
+`base + 32768 + (i/73)·4096 + (i%73)·56`: a division and two multiplies instead
+of a multiply and an add. The 8 bytes are wasted either way, so the padded form
+buys nothing for the cost.
+
+### The tail block covers the committed prefix, not the nominal block
+
+The last block of a file holds only the records the commit counter covers. Its
+checksum is taken over
+
+```
+(n_valid mod 73) * 56 bytes  from the block start
+```
+
+and never over the nominal 4088 — which for 72 of every 73 file states would
+name bytes past EOF. The writer recomputes the tail block's checksum on every
+commit that lands in it; the reader verifies against the `n_valid` it read from
+the header. Both sides derive the length from the same counter.
+
+Each block's CRC-32C lives in a sidecar at the same **block index**:
+
+```
+bars/groww/NSE/INDEX/NIFTY/1min/2024-03.bin
+bars/groww/NSE/INDEX/NIFTY/1min/2024-03.crc
+```
+
+The sidecar is indexed by `i / 73`, not by `(32768 + i*56) / 4096`.
 
 **Why this is not optional.** A flipped bit in a raw `i64` price produces a
 different price — a *plausible* one. There is no structure to violate, no
 parse to fail. Without a checksum the corruption is silent and permanent, and
 every downstream result derived from it is wrong in a way nobody can detect.
+It is also the only thing that can tell a lost write from 73 flat bars.
+
+A file whose `flags` bit 0 is clear carries no sidecar, and a verification
+request against it is **refused** rather than answered — "verified" and "there
+was nothing to verify against" are different answers.
 
 Verification is O(1) per read: one block CRC, not a file scan.
 
@@ -137,7 +248,7 @@ Verification is O(1) per read: one block CRC, not a file scan.
 ## 7. Opening — boundary check
 
 ```
-if (len - 64) % 56 != 0 {
+if (len - 32768) % 56 != 0 {
     // truncate to the last whole record, log loudly, continue
 }
 ```
@@ -146,21 +257,35 @@ A file whose length does not divide by the stride was interrupted. The tail is
 truncated to the last whole record and the event is logged with the byte count
 discarded. Never silently, never by ignoring the remainder.
 
+A file shorter than the header region is all tail, and is reported as such.
+
 ---
 
-## 8. Enriched records are a different file
+## 8. Sibling files of a month
 
 Overlay fields — implied volatility, greeks, anything computed — do **not**
 widen this record. They live in a sibling file with their own version, their
 own stride, and their own commit counter, addressed by the same index *i*.
 
+| Extension | Holds |
+|---|---|
+| `.bin` | the bar records |
+| `.crc` | one block checksum per block index (§6) |
+| `.ovl` | computed overlay fields, at their own stride |
+| `.lock` | the advisory lock one writer holds for the month (§5, §9) |
+
 ```
-bars/NSE/FNO/<contract>/1min/2024-03.bin      56-byte stride, version 1
-bars/NSE/FNO/<contract>/1min/2024-03.ovl      its own stride, version 1
+bars/<vendor>/NSE/FNO/<contract>/1min/2024-03.bin      56-byte stride, version 2
+bars/<vendor>/NSE/FNO/<contract>/1min/2024-03.ovl      its own stride, version 1
 ```
 
 This keeps the base stride constant forever. A base file written in year one
 is readable in year ten by arithmetic that has not changed.
+
+Every one of those names is rendered by `store::path::StorePath` and nothing
+else. The vendor is the first segment (D-0019); every segment is
+case-canonical, because two segments differing only in case are two files on
+ext4 and one file on APFS.
 
 ---
 
@@ -169,5 +294,34 @@ is readable in year ten by arithmetic that has not changed.
 | Hazard | Position |
 |---|---|
 | Page fault on a network mount that has gone away | Uninterruptible. Keep the store on local disk. This is an operational rule, not an architectural fix. |
-| Two writers on one file | Not supported. One writer per file, enforced by an advisory lock, and the lock is a leaf — never held while acquiring another. |
+| Two writers on one file | Not supported. One writer per file, enforced by an advisory lock on the `.lock` sibling, and the lock is a leaf — never held while acquiring another. Nothing in `crates/store` can check it. |
+| A failure coarser than 16384 bytes | Takes both header slots. No arrangement inside one file survives a dead device. |
+| A symlink at a path component | Defeats vendor-prefix isolation, which is a **lexical** property of `StorePath`, not a filesystem one. The writer must open with `openat` + `O_NOFOLLOW` per component and halt naming the linked component. |
 | A wrong value that is well-formed | Out of scope here. Range validation happens at the ingest boundary, before a byte is written. |
+
+---
+
+## 10. Version 1 — retired
+
+Version 1 described:
+
+* a **64-byte** header region holding **one** slot,
+* fields at `n_valid` 16, `first_ts_micros` 24, `last_ts_micros` 32,
+  `symbol_id` 40, `timeframe_secs` 44,
+* an **8-byte** `header_crc` at offset 48 covering bytes 0..48,
+* a byte-addressed **4096-byte** checksum block,
+* magic `b"BRUTEXB1"`.
+
+Every one of those numbers is different in version 2, and version 2 inserts a
+`generation` field at offset 16. Decoding a version-1 file with version 2's
+decoder would lift every field from the wrong offset and return plausible
+integers.
+
+So version 1 is **refused by number**, naming the reason
+(`FormatError::RetiredVersion(1)`), never decoded and never reported as a
+damaged header. Its number is not reused: §3 rule 8 makes the version an
+append-only identifier, not a slot to be overwritten.
+
+No version-1 file can exist — version 1 never had a reader or a writer in this
+repository, only constants. The entry costs one comparison and removes the only
+way this build could misread one if that assumption is ever wrong.

--- a/docs/04-invariants.md
+++ b/docs/04-invariants.md
@@ -76,6 +76,65 @@ dedicated hardware before it is believed.
 | P-07 | A missing, unreadable, or incomplete credential configuration halts the pull and names the absent segment; it never defaults | `pull::unit::credential_config_absent_halts` | — |
 | P-08 | The credential configuration supplies path segments only; a secret value found in it is refused | `pull::unit::credential_config_rejects_secret_value` | — |
 
+## Instrument identity and the vendor merge
+
+Added by D-0024. Every row here is proven by a test that runs today.
+
+| # | Must hold | Proven by | |
+|---|---|---|---|
+| I-01 | A row on the equity segment that is not a share is declined, and the share of the same name is kept — whichever order the file lists them in | `core::vendor::the_cholafin_bond_is_declined_and_the_cholafin_share_is_kept` | ✓ |
+| I-02 | Every measured debt and fund class of either vendor is declined by name, not by falling through a default | `core::vendor::every_measured_debt_and_fund_class_is_declined_by_name` | ✓ |
+| I-03 | An index row is never gated on a listing class it does not have, from either vendor | `core::vendor::an_index_row_survives_the_gate_from_both_vendors` | ✓ |
+| I-04 | The listing class is trimmed before it is read, so padding cannot decline every share in a file | `core::vendor::dhans_class_column_is_trimmed_before_it_is_read` | ✓ |
+| I-05 | An SME listing is declined under its **own** reason and never lumped in with debt | `core::vendor::the_equity_board_is_kept_and_the_sme_board_is_declined_separately` | ✓ |
+| I-06 | An ISIN is refused unless its ISO 6166 check digit verifies | `core::isin::the_one_real_row_with_a_bad_check_digit_is_refused` | ✓ |
+| I-07 | The one real ISIN that fails its check digit never reaches the parse, because the equity gate declines it first | `core::vendor::the_sdl_with_the_bad_check_digit_never_reaches_the_isin_parse` | ✓ |
+| I-08 | A kept equity carries a parseable ISIN or the row is an error; it is never a quiet `None` | `core::vendor::a_kept_equity_must_carry_a_parseable_isin` | ✓ |
+| I-09 | An index carries no ISIN, and no sentinel is invented for one | `api::merge::an_index_carries_no_isin_and_still_merges_on_identity` | ✓ |
+| I-10 | Two vendors giving one key two different ISINs is **one** key and one loud line naming both; neither is dropped and neither wins | `api::merge::a_cross_vendor_isin_conflict_is_reported_and_neither_side_is_dropped` | ✓ |
+| I-11 | A series suffix is stripped only when a second vendor confirms the identity by ISIN | `api::merge::a_suffixed_symbol_merges_only_when_the_isin_confirms_it` | ✓ |
+| I-12 | An unconfirmed suffix is left exactly as the vendor wrote it | `api::merge::an_unconfirmed_suffix_is_left_exactly_as_the_vendor_wrote_it` | ✓ |
+| I-13 | A trailing dash that is not the row's own series is never stripped, so `BAJAJ-AUTO` survives | `core::vendor::a_dash_that_is_not_the_rows_own_series_is_never_stripped` | ✓ |
+| I-14 | Every column a vendor's reader needs is required by name, and a missing one is refused and named | `api::master::every_column_a_vendor_needs_is_required_and_named_when_absent` | ✓ |
+| I-15 | The binary's entry point is measured by running it, not exempted from the coverage gate | `api::binary::the_binary_reports_what_it_read_and_exits_zero` | ✓ |
+
+## The equity gate after D-0025, and the refusal after D-0026
+
+Added by D-0025, D-0026 and D-0027. Every row here is proven by a test that
+runs today.
+
+| # | Must hold | Proven by | |
+|---|---|---|---|
+| I-16 | The three measured series tables are sorted, mutually disjoint and non-empty, so `binary_search` cannot return garbage and no code can get two verdicts | `core::vendor::the_measured_series_tables_are_sorted_disjoint_and_complete` | ✓ |
+| I-17 | A cash-equity row whose series this engine has never seen gets its **own** reason, never the one a debenture gets | `core::vendor::an_unrecognised_series_is_its_own_loud_reason_never_a_bond` | ✓ |
+| I-18 | The unrecognised **code itself** reaches the operator, not only a count of it | `api::master::an_unrecognised_series_is_recorded_under_the_code_itself` | ✓ |
+| I-19 | A fund plan is declined from **both** vendors, and a genuine ETF on the equity board is still kept | `core::vendor::a_mutual_fund_plan_is_declined_from_both_vendors_on_one_series_alphabet` | ✓ |
+| I-20 | The surveillance and partly-paid equity series are kept as equity, from both vendors, and never labelled debt | `core::vendor::the_surveillance_and_partly_paid_equity_series_are_kept_not_called_debt` | ✓ |
+| I-21 | A declined row carries its ISIN as evidence, and an unparseable one is neither an error nor a silent substitute | `core::vendor::a_declined_row_carries_its_isin_as_evidence_for_the_cross_check` | ✓ |
+| I-22 | One vendor keeping an ISIN another declined is a named disagreement, and the instrument is not dropped | `api::merge::one_vendor_keeping_what_another_declined_is_a_named_disagreement` | ✓ |
+| I-23 | A decline about the venue is never mistaken for a disagreement about the paper | `api::merge::a_decline_about_the_venue_is_not_a_disagreement_about_the_paper` | ✓ |
+| I-24 | A row with fewer fields than its columns need is unreadable and names the shortfall; it is never a routine decline | `api::master::a_row_with_too_few_fields_is_unreadable_and_names_the_shortfall` | ✓ |
+| I-25 | Every distinct parse failure reaches the operator with its count and the first line that hit it | `api::master::unreadable_rows_are_grouped_by_reason_with_the_first_line_that_hit_it` | ✓ |
+| I-26 | A searched page still says that a vendor was never read | `api::server::a_searched_page_still_says_a_vendor_was_never_read` | ✓ |
+| I-27 | A vendor that was never read makes the status, the exit code and `/health` all say so | `api::binary::the_binary_exits_non_zero_when_a_vendor_was_never_read` · `api::server::health_answers_503_when_a_vendor_was_never_read` | ✓ |
+| I-28 | An ISIN conflict refuses the universe rather than logging it and continuing | `api::server::an_isin_conflict_reaches_the_report_and_the_page` | ✓ |
+| I-29 | An unrecognised listing class degrades the run, while a routine bond does not | `api::server::an_unrecognised_listing_class_names_the_code_and_degrades_the_run` | ✓ |
+| I-30 | A universe member only one vendor named is counted separately from one two vendors confirmed, and named | `api::merge::the_census_separates_what_two_vendors_confirmed_from_what_one_asserted` | ✓ |
+
+## The instrument universes
+
+Added by D-0029. `crates/core/src/universe.rs` shipped with none of these rows;
+CI gate 10 walks rows→tests and never tests→rows, so the build stayed green
+while `CLAUDE.md` §9 was violated.
+
+| # | Must hold | Proven by | |
+|---|---|---|---|
+| U-01 | Both constituent lists are sorted and unique, so `binary_search` is valid | `core::universe::both_lists_are_sorted_and_unique_so_binary_search_is_valid` | ✓ |
+| U-02 | No two universes share a bit, so an append-only bitset stays safe (`CLAUDE.md` §3.8) | `core::universe::bits_are_distinct_powers_of_two` | ✓ |
+| U-03 | The list lengths are the measured ones, and no exchange test instrument is ever a member | `core::universe::the_counts_are_the_measured_ones` | ✓ |
+| U-04 | No SME ticker is in either universe — the claim `Skip::SmeBoard` declines 1,117 real shares on | `core::universe::no_measured_sme_ticker_belongs_to_either_universe` | ✓ |
+| U-05 | An index is its own universe and a live derivative is in none | `core::universe::an_index_is_its_own_universe_and_a_live_derivative_is_in_none` | ✓ |
+
 ## Cross-cutting
 
 | # | Must hold | Proven by | |
@@ -85,7 +144,8 @@ dedicated hardware before it is believed.
 | X-03 | Every tracked file has an allowed extension | CI gate 1 | ✓ |
 | X-04 | No build script invokes an external process | CI gate 2 | ✓ |
 | X-05 | `web` depends on `core` alone | CI gate 7 | ✓ |
-| X-06 | Line and branch coverage is 100% on every crate | CI coverage job | ✓ |
+| X-06 | **Line and region** coverage is 100% on every crate, with no omit list | CI coverage job (`--fail-under-lines 100 --fail-under-regions 100`) | ✓ |
+| X-06b | ~~Branch coverage is 100% on every crate~~ | **NOT MEASURED.** `llvm-cov` instruments zero branches on the pinned stable toolchain and `--branch` cannot run there at all. Narrowed by D-0030; recorded in `docs/06-limits.md` §7. | — |
 | X-07 | No mutant survives on a touched module | `cargo-mutants`, scheduled | — |
 | X-08 | No tracked file contains a literal credential path | CI gate 1c | ✓ |
 | X-09 | `core` declares no dependency at all | CI gate 9 | ✓ |

--- a/docs/05-decisions.md
+++ b/docs/05-decisions.md
@@ -603,6 +603,444 @@ produced it.**
 
 ---
 
+## D-0024 · 2026-08-01 · The equity gate is the series column; the ISIN is a cross-check, not a key
+
+**Decision, part one — what counts as an equity is read from the vendor's own
+class column, per vendor, and everything else on the equity segment is
+declined with a named reason.**
+
+`INSTRUMENT = EQUITY` does not mean "a share". It means "trades on the equity
+segment". Measured on the real masters this session:
+
+| Vendor | Column read | Kept | Declined |
+|---|---|---|---|
+| Groww | `series` | `EQ` 2,407 · `BE` 289 | ~100 debt/fund series codes, plus `SM` 401 and `ST` 157 as SME |
+| Dhan | `INSTRUMENT_TYPE` (**trimmed** — the values are space padded) | `ES` 2,974 · `ETF` 388 | `DBT` 4,416 · `DEB` 1,429 · `Other` 141 · `TB` 81 · `GB` 78 · `CB` 72 · `MF` 66 · `InvITU` 21 · `REIT` 6 · `PTC` 1 · `PS` 1 |
+
+Of Dhan's 9,674 NSE equity-segment rows, **6,312 are not equity at all**.
+
+**Why this is a correctness fix and not tidying.** Those rows do not merely
+inflate a count — they **capture the ticker**. Dhan line 167146 is
+`NSE,E,19257,INE121A08PJ0,EQUITY,,CHOLAFIN,…,DEB,D1,…,5.0`, a 7.5% NCD, and it
+appears **before** line 171414, `…,INE121A01024,EQUITY,,CHOLAFIN,…,ES,EQ,…,10.0`,
+the share. Insert-if-absent therefore resolved `CHOLAFIN` to the bond and took
+its tick size, silently and dependent on nothing but file order. `MOTHERSON`
+(`INE775A08105`, an NCD) and `ELECTCAST` (`INE086A13016`, a warrant) went the
+same way. All three are NIFTY Total Market members; two are F&O underlyings.
+After the gate, duplicate tickers in Dhan's equity segment fall from **4 to 0**,
+and all three resolve to the share's own ISIN.
+
+**The gate is applied only to a row that already decoded as cash equity.** An
+index row has no class — Groww leaves `series` empty on all 24 of its NSE index
+rows and writes the *ticker* in the `isin` column; Dhan writes `NA` in both.
+Gating any earlier declines `NIFTY` and `BANKNIFTY`, which is the entire
+engine surface.
+
+**Rejected — one flat table of accepted codes across both vendors.** The two
+alphabets are disjoint, and a flat table invites one vendor's code to be
+silently accepted for the other. Same reasoning as `Vendor::segment_of`.
+
+**Rejected — erroring on an unrecognised class.** Unlike a segment or an
+instrument type, this alphabet is open-ended: NSE mints a new debt series
+whenever it needs one and a hundred already exist. An unknown code is declined
+and **counted under its reason**; what never happens is an unknown code being
+accepted.
+
+**SME is a separate reason, and the vendors are asymmetric about it.** An SME
+listing IS a share, so filing it with the debentures would hide a real choice
+behind a wrong label. It is declined because the equity universe is F&O
+underlyings plus NIFTY Total Market, and neither contains an SME listing.
+Groww marks the board in `series` (`SM`, `ST`); **Dhan's `INSTRUMENT_TYPE` does
+not distinguish it** — an SME share is `ES` there — so Dhan keeps SME rows that
+Groww declines. That asymmetry is recorded in `docs/06-limits.md` §10 rather
+than papered over by reading a second Dhan column on a guess.
+
+---
+
+**Decision, part two — the ISIN sits BESIDE the instrument key and is never a
+field of it.**
+
+`InstrumentKey` derives `Hash` and `Eq` over every field and is used directly
+as a `HashMap` key; that collision **is** the deduplication (D-0015). If the
+ISIN were a field, two vendors disagreeing about one instrument's ISIN would
+produce **two different keys**, the merge map would hold it twice, and the
+disagreement would never be seen by anyone. Adding the field that was supposed
+to make identity more precise would silently split it.
+
+Beside the key, the same disagreement is one loud line naming the key and both
+ISINs — the shape D-0020 already requires of every vendor disagreement.
+Measured: across the 4,080 ISINs the two masters share there are **zero**
+conflicts today, and all 750 NIFTY Total Market members resolve in both vendors
+with agreeing ISINs. The check costs nothing until the day it does not.
+
+**Rejected — keying on the ISIN instead of the symbol.** Indices have no ISIN
+at all, so the two instruments the engine sweeps could not be keyed. Inventing
+a sentinel ISIN for `NIFTY` was rejected for the reason every sentinel is
+rejected here: it is a fabrication that reads like a fact.
+
+**Rejected — the exchange token as the cross-check.** It is not time-stable.
+NSE issues a token per (symbol, series), so an `EQ`→`BE` migration mints a new
+one — `SICALLOG` went 19434 → 19440 between the two snapshots. Exactly the 22
+of 4,080 rows whose series differ also differ in token, while the ISIN held
+fixed across all 4,080.
+
+**The check digit is verified, not assumed.** Exactly one row in either master
+fails it — `IN1520250085`, a state development loan — and the equity gate
+declines it before an ISIN is ever parsed. The parse therefore happens **after**
+the gate, and that order is itself tested.
+
+---
+
+**Decision, part three — Groww's series suffix is stripped only when two
+independent things agree.**
+
+Groww leaks `internal_trading_symbol` into `trading_symbol` on exactly **209**
+of the 4,080 shared ISINs, and the rule is exact with zero residual:
+`groww.trading_symbol == dhan.UNDERLYING_SYMBOL + "-" + series`. It reaches
+tradeable equity and ETFs — `BLUECHIP-BE`, `CBAZAAR-ST`, `HDFCLIQUID-EQ`,
+`LOWVOL-EQ` — so "only debt is suffixed" is **false**.
+
+The strip requires the trailing segment to be the row's **own series** (decided
+in `core`, where the series is) **and** some vendor to have asserted the
+stripped identity under the **same ISIN** (decided in `api`, where both vendors
+are). Where both do not hold, the symbol stands exactly as the vendor wrote it.
+
+**Rejected — stripping a trailing `-XX` wherever it appears.** `BAJAJ-AUTO`
+and `NAM-INDIA` are real tickers. `crates/core/src/symbol.rs` already argues
+that blind normalisation manufactures the collision it exists to prevent, and
+an unmerged row is a visible duplicate while a wrongly merged one is two
+instruments silently becoming one.
+
+---
+
+**Consequence, measured before and after on the real masters:**
+
+| | kept | declined | unreadable |
+|---|---|---|---|
+| groww, before | 4,104 | 129,274 | 0 |
+| groww, after | **2,720** | 130,658 (+558 SME, +826 not equity) | 0 |
+| dhan, before | 9,667 | 190,689 | 104 |
+| dhan, after | **3,377** | 196,979 (+6,290 not equity) | 104 |
+
+Merged: **3,400** instruments, **0** ISIN conflicts. The unreadable counts are
+unchanged, which is the check that requiring an ISIN on a kept equity added no
+new failures.
+
+> **Superseded in part by D-0025.** The column D-0024 chose for Dhan —
+> `INSTRUMENT_TYPE` — was measurably wrong on 57 rows, and the per-vendor
+> alphabet it argued for stopped being two alphabets once both vendors were
+> pointed at the NSE series. The *shape* of D-0024 stands: gate the equity
+> segment, apply it only to a row already decoded as cash equity, keep SME
+> under its own reason, and hold the ISIN beside the key. Only the column and
+> the catch-all changed. Nothing in this entry is edited; D-0025 records what
+> replaced it and why.
+
+---
+
+## D-0025 · 2026-08-01 · The equity gate reads the NSE board series, from both vendors, against a measured table
+
+**Decision — the gate reads one exchange-issued fact, `series` at Groww and
+`SERIES` at Dhan, and every code it does not recognise is its own loud
+outcome.**
+
+D-0024 read Groww's NSE `series` and Dhan's own `INSTRUMENT_TYPE`. An
+adversarial review found both arms wrong at an edge, and both wrongnesses had
+one cause: `INSTRUMENT_TYPE` is minted by a broker, and the code was trusting
+one vendor column per vendor with nothing to check it against.
+
+**What Dhan's paper class got wrong.** Measured by joining the two masters on
+ISIN:
+
+| Dhan `INSTRUMENT_TYPE` | Dhan's own `SERIES` | Rows | What they really are |
+|---|---|---:|---|
+| `ETF` | `MF` | 54 | Franklin `FISTIP*`/`FICRF*`, PGIM `PGIMCSA*`, Bandhan `BPF0*` — open-ended fund plans, not ETFs. Groww carries 29 of the ISINs under `series=MF` and declines them. |
+| `Other` | `EQ` | 2 | `IVZINNIFTY` (Invesco India Nifty ETF) and `NARMADA` (Narmada Agrobase Ltd) — real listings Groww keeps. |
+| `MF` | `EQ` | 1 | `INFRABEES` (Nippon India ETF Infra BeES) — a genuine ETF. |
+
+Every one of those 57 rows is a case where the two columns on the **same Dhan
+row** disagree, and the series is right on all 57. Under D-0024 the 54 fund
+plans entered the equity universe as `Kind::Equity` — the exact category
+`Skip::NotEquityListing`'s own text says it exists to remove.
+
+**What the Groww arm got wrong.** It accepted `EQ` and `BE` only, so 30 genuine
+equity listings were declined and *counted under the reason "not an equity
+listing"*, which was false about them:
+
+| Series | Rows (g/d) | What it is |
+|---|---:|---|
+| `BZ` | 25 / 38 | trade-for-trade under surveillance — `HDIL`, `RAJESHEXPO`, `IL&FSENGG`, `ANSALAPI`, `FEL`, `ARSHIYA` |
+| `IT` | 2 / 2 | trade-for-trade, illiquid |
+| `SZ` | 1 / 2 | trade-for-trade, surveillance (second list) |
+| `E1` | 2 / 3 | partly-paid equity |
+
+Three independent confirmations that these are equity: the NSDL security-type
+digits of the ISIN are `01` on 27 of the 30 and `IN9…` (partly paid) on the
+other 3, against `08` for the `CHOLAFIN` NCD and `13` for the `ELECTCAST`
+warrant the gate still declines; Dhan classes all 30 as `ES`; and they are
+ordinary listed companies.
+
+**The measurement that made one table legitimate.** `docs/06-limits.md` §10
+said the Dhan/Groww asymmetry could only be closed by "measuring Dhan's
+`SERIES` alphabet first and recording the result — not adding the column
+because the numbers would look tidier". That measurement was taken:
+
+| Dhan `INSTRUMENT_TYPE` | The `SERIES` values on those rows |
+|---|---|
+| `ES` (2,974) | `EQ` 2,079 · `BE` 291 · `SM` 414 · `ST` 145 · `BZ` 38 · `E1` 3 · `IT` 2 · `SZ` 2 — **nothing else** |
+| `ETF` (388) | `EQ` 334 · `MF` 54 |
+| every debt class | only debt series (`SG`, `GS`, `N0`…`NZ`, `Y*`, `Z*`, `D1`, `W1`, `TB`, …) |
+
+Dhan's `SERIES` is the same NSE alphabet as Groww's `series`, and no
+equity-segment row in either file leaves it empty. On the 4,080 ISINs the two
+masters share, the two series columns disagree on **22** rows — all snapshot
+skew inside one board, `EQ`↔`BE` or `SM`↔`ST`, e.g. `SICALLOG` — and the
+**board verdict differs on 0**. One exchange fact, carried by both vendors,
+agreeing everywhere.
+
+**Rejected — keeping the per-vendor table.** D-0024 argued a flat table
+"invites one vendor's code to be silently accepted for the other". True of two
+broker alphabets; false of one exchange alphabet carried twice. Two copies of
+one fact are free to drift, and the drift is exactly what produced the 57
+errors above.
+
+**Rejected — reading both columns and refusing where they disagree.** It would
+decline `INFRABEES`, `IVZINNIFTY` and `NARMADA`, which are real, and it would
+emit 57 conflict lines every run for a column already known to be the wrong
+one. A check against a source measured to be wrong is noise, not evidence.
+
+**Rejected — an `INF` issuer prefix as the fund test.** `HDFCLIQUID`
+(`INF179KC1JG3`) is a genuine ETF with an `INF` prefix. The rule would have
+been wrong in both directions.
+
+**Decision — an unrecognised series is `Skip::UnrecognisedListingClass`, not
+`Skip::NotEquityListing`.**
+
+Both arms of D-0024's gate ended in `_ => NotEquity`, so a code the engine had
+never seen was reported in the identical words a routine debenture gets.
+Demonstrated on the real Dhan master by rewriting `EQ` to `EQX`: **2,438 shares
+vanished**, every F&O underlying among them, the report still printed `ok`, and
+the exit code was still 0. That is the failure `Vendor::segment_of` is
+documented as making unrepeatable, reproduced in a different column.
+
+It stays a *decline* and not an error — NSE mints a debt series whenever it
+needs one, and turning a routine bond listing into a failed ingest would be the
+opposite mistake. But it is its own decline: its own reason string, its own
+counter, **the offending code itself** carried to the operator
+(`api::master::Loaded::unrecognised`), and a non-zero exit (D-0026). The
+120-code `NON_EQUITY_SERIES` table is what makes "unrecognised" meaningful; it
+is the measured union of both masters, so a new NSE debt series is a one-line
+append.
+
+**Rejected — erroring on an unknown code**, as `segment_of` and `type_of` do.
+Those alphabets are closed and tiny; this one is open-ended with 120 members
+already. An error per bond row would make the unreadable count meaningless.
+
+**Consequence, measured on the real masters:**
+
+| | kept | declined | unreadable |
+|---|---|---|---|
+| groww, D-0024 | 2,720 | 130,658 | 0 |
+| groww, D-0025 | **2,750** | 130,628 (SME 558 · not equity 796) | 0 |
+| dhan, D-0024 | 3,377 | 196,979 | 104 |
+| dhan, D-0025 | **2,767** | 197,589 (SME 559 · not equity 6,341) | 104 |
+
+Merged **2,787** instruments · **0** ISIN conflicts · **0** eligibility
+conflicts. Dhan falls by 610 (54 fund plans + 559 SME, less the 3 real
+listings its paper class had wrongly declined); Groww rises by 30 (`BZ`, `IT`,
+`SZ`, `E1`). The SME decline is now symmetric — 558 at Groww and 559 at Dhan,
+the same paper by ISIN — which is what §10 recorded as unclosed.
+
+All **750** NIFTY Total Market members and **208** of the 213 F&O underlyings
+resolve as a kept equity in **both** vendors; the other five are indices. See
+D-0027 for the two that only one vendor names.
+
+---
+
+## D-0026 · 2026-08-01 · A disagreement or a missing vendor refuses the universe, and the exit code says so
+
+**Decision — `report` prints `DEGRADED`, `run` exits 3, and `/health` answers
+503 whenever a vendor was never read, two vendors disagreed, or a listing class
+was not recognised.**
+
+The code and this ledger both claimed a conflict was a refusal — `merge.rs`
+said a non-empty conflicts vector "is a refusal to believe the merge, not a
+warning to be scrolled past"; `isin.rs` called it "a single loud refusal …
+which is what D-0020 already requires"; D-0024 called it "the shape D-0020
+already requires of every vendor disagreement". Nothing refused. `report`
+emitted an unconditional `ok`, `run` returned 0 for every completed report, and
+`/health` answered 200 with that body. A monitor checking the exit code, the
+HTTP status or the first line saw green while one of the two masters had never
+been opened.
+
+D-0020 is titled "A vendor disagreement refuses the window and names it" and
+requires naming **and** refusing. The old behaviour named and continued, which
+is the "primary vendor wins, log the difference" shape D-0020 exists to reject.
+Report-and-continue may well be right for a master merge — but then it is a new
+locked choice needing its own honest text, not an assertion of conformity with
+a decision that says the opposite. This is that text.
+
+**What is refused, and what is not.** The disputed instruments stay in the map
+and on the page. Dropping them would hide the disagreement, which is the
+failure `CLAUDE.md` §4 forbids. What is refused is the *universe as a whole*:
+`merge::Merged::verdict` returns `Disputed`, `server::Read::is_clean` is false,
+and no caller can turn that into a success.
+
+**Exit code 3, not 1.** `FAILED` means "I tried and could not". Here the work
+completed and the output is real; it is the answer that must not be trusted.
+Distinct codes let a monitor tell a crashed process from a half-read universe.
+
+**Rejected — refusing to print anything.** The tallies are exactly what an
+operator needs in order to find out *why* the read is degraded. Refusing to
+emit them would trade one silent failure for another.
+
+**Rejected — degrading on the unchecked index identity of D-0027.** It is a
+permanent structural fact, not a change, so every run would be `DEGRADED` and
+the signal would mean nothing. It is named loudly on every run instead.
+
+---
+
+## D-0027 · 2026-08-01 · Index identity is unchecked, and the report says which members rest on one vendor
+
+**Decision — no alias table is invented for the indices the two vendors spell
+differently; the report names every universe member only one vendor asserted.**
+
+An index carries no ISIN, so the cross-check D-0024 added cannot reach it.
+Measured: of 35 merged NSE index keys, **only four are spelled identically by
+both masters** — `NIFTY`, `BANKNIFTY`, `FINNIFTY`, `NIFTYIT`. Two of the
+mismatches are F&O underlyings:
+
+| Groww | Dhan |
+|---|---|
+| `NIFTYJR` | `NIFTYNXT50` |
+| `NIFTYMIDSELECT` | `MIDCPNIFTY` |
+| `MIDCAP50` | `NIFTYMCAP50` |
+
+The merged universe therefore holds each of these **twice**, as two
+single-vendor instruments. 211 of the 213 F&O underlyings are confirmed by both
+vendors; 2 are not.
+
+**Rejected — an alias table mapping `NIFTYJR` to `NIFTYNXT50`.** The evidence
+is suggestive — both vendors' *derivative* rows use the Dhan spelling — but it
+is an inference, and `crates/core/src/symbol.rs` argues at length that blind
+normalisation manufactures the collision it exists to prevent. Merging two
+instruments on a guess is precisely the failure the ISIN cross-check exists to
+catch; doing it where no cross-check is possible would be worse, not better.
+
+**Rejected — leaving it implied.** The previous behaviour reported `0 isin
+conflicts` and said nothing, so a clean-looking report was the only evidence
+either way. The report now prints, on every run, how many members of each
+universe resolved and how many **two vendors confirmed**, followed by an
+`UNCHECKED IDENTITY` line naming each single-vendor member. `docs/06-limits.md`
+§12 records the limit.
+
+Neither swept instrument is affected: `NSE-NIFTY` and `NSE-BANKNIFTY` are named
+identically by both vendors and carry two vendor tags.
+
+---
+
+## D-0028 · 2026-08-01 · `.claude/` is ignored, not tracked
+
+**Decision — `/.claude/` and `/mutants.out*` are added to `.gitignore`.**
+
+`.claude/launch.json` was in the working tree and matched no ignore rule, so
+`git check-ignore` exited 1 and the next `git add -A` would have tracked it.
+`.json` is not in `CLAUDE.md` §2's allowed extension list at all, and CI gate
+1b confines `.json` and `.yml` to `.github/` and `crates/web/` — so the commit
+would have failed the build at gate 1b, naming the file. Its sibling
+`settings.local.json` was safe only by accident, through a rule in the
+operator's personal `~/.config/git/ignore` that no clone of this repository
+carries.
+
+**Rejected — deleting the directory.** It is working local tooling, and the
+rule is about what this repository *tracks*, not about what sits beside it.
+Ignoring states that intent; deleting would invite it back untracked and
+unignored.
+
+`mutants.out/` is `cargo-mutants` build output and writes `.json` for the same
+reason; both are ignored in the same change.
+
+---
+
+## D-0029 · 2026-08-01 · The instrument universes are transcribed Rust data, and the merge consults them
+
+**Decision — `crates/core/src/universe.rs` holds the NIFTY Total Market and
+F&O underlying lists as sorted `[&str]` literals, membership is a bitset looked
+up *from* the key, and `api::merge` stamps every merged instrument with it.**
+
+This module shipped in the D-0024 change with no entry here, no invariant rows,
+no charter source for its 963 transcribed instrument names, a `See
+docs/06-limits.md` pointer to a section that did not exist, and **no caller
+anywhere in the workspace**. `CLAUDE.md` §9 requires a ledger entry for every
+locked choice and an invariants row beside the test that proves it; golden rule
+1 requires every claim about an instrument to be traceable to a source recorded
+in `docs/00-charter.md`. None of that was done, and CI stayed green because
+gate 10 walks invariant-rows→tests and never tests→rows. This entry, the rows
+`U-01`…`U-04` in `docs/04-invariants.md`, §4a of the charter and §11 of the
+limits are the correction.
+
+**Why Rust literals.** `CLAUDE.md` §2 permits no `.csv`, so a constituent list
+cannot be tracked as a data file. The data is fine; the format is not.
+
+**Why membership is not a field of `InstrumentKey`.** The key derives `Hash`
+and `Eq` over every field and *is* the deduplication (D-0015). The same
+contract carrying different memberships would become two keys and dedup would
+break in silence — the identical argument D-0024 makes about the ISIN.
+
+**Why it must have a caller.** `Skip::SmeBoard` declines 1,117 real shares on
+the ground that "neither list contains an SME listing". That claim was a
+sentence in a comment about a module nothing consulted. It is now (a) checked
+by `core::universe::no_measured_sme_ticker_belongs_to_either_universe` against
+14 SME tickers taken verbatim from the masters, and (b) load-bearing: the merge
+stamps `Entry::universe`, the page renders a Universe column, and the report
+prints a census on every run. Measured on the real masters: **0 of the 559
+Dhan SME tickers** are in either list.
+
+**Rejected — a perfect hash.** Lookup is `binary_search`, O(log n) — at most
+ten comparisons on 750 entries. That is a departure from golden rule 4 and it
+is written down rather than glossed (`docs/06-limits.md` §11). Membership is
+asked once per instrument at merge time and never once per bar, so it is not on
+the constant-cost path the rule protects; a perfect hash would buy nothing at
+this size and would add machinery to maintain.
+
+**UNVERIFIED and carried as such:** neither list has been checked against an
+NSE constituent circular. Both are snapshots of a rebalanced index.
+
+---
+
+## D-0030 · 2026-08-01 · Branch coverage is not measured, and X-06 no longer claims it is
+
+**Decision — `docs/04-invariants.md` X-06 is narrowed to the line and region
+coverage the CI job actually enforces, and the branch half is recorded as
+unmeasured in `docs/06-limits.md` §7.**
+
+X-06 read "Line and branch coverage is 100% on every crate", proven by "CI
+coverage job", status ✓. The coverage job passes `--fail-under-lines 100
+--fail-under-regions 100` and nothing else. `cargo llvm-cov` reports
+`Branches 0 0 -` for every file — zero branches instrumented — so the branch
+half was a green tick over a measurement that had never run.
+
+It is not merely unreported, it is **unrunnable as configured**: branch
+coverage needs `-Z coverage-options=branch`, which is nightly-only, and
+`rust-toolchain.toml` pins stable 1.97.1. `cargo llvm-cov --branch` fails
+outright with `error: 1 nightly option were parsed`.
+
+**Rejected — moving to nightly to satisfy the row.** The pin is itself a
+decision, and trading a reproducible toolchain for a coverage column is the
+wrong trade.
+
+**Rejected — leaving the row as it was.** A gate that claims a measurement
+nobody took is the same shape as the defects this change exists to fix, and
+`docs/06-limits.md` §7 is the table that exists to say what a green build does
+not prove.
+
+Region coverage is the closest thing the stable toolchain measures: it counts
+every distinct execution region, which subsumes most of what branch coverage
+would catch on this code. It is enforced at 100% and it is what the row now
+claims. When branch coverage stabilises, the row widens again and this entry
+records why it was narrow.
+
+---
+
 ## How to add an entry
 
 Next free ID, today's date, the decision in one sentence, the alternative

--- a/docs/06-limits.md
+++ b/docs/06-limits.md
@@ -112,6 +112,8 @@ exactly the mistake the read-only-mapping decision was made to avoid.
 |---|---|
 | Extension allowlist | the design is good — only that it is one language |
 | 100% coverage | the tests assert anything useful; that is what mutation testing is for |
+| 100% coverage | **branches** were covered. `cargo llvm-cov` reports `Branches 0 0 -` for every file: zero branches are instrumented, and the coverage job gates on `--fail-under-lines` and `--fail-under-regions` only. `--branch` needs `-Z coverage-options=branch`, which is nightly, and `rust-toolchain.toml` pins stable 1.97.1 — so `cargo llvm-cov --branch` fails with `error: 1 nightly option were parsed`. Branch coverage is **unmeasured and currently unmeasurable here**. `docs/04-invariants.md` X-06 claimed it for a long time with a ✓ beside it; D-0030 narrowed the row to what is enforced. Region coverage is the closest stable substitute and is the number that is actually 100%. |
+| Gate 10 | the invariants file is complete. It walks **rows → tests** and never tests → rows, so a module can ship with genuine invariants, real tests and no rows at all, and the build stays green. `crates/core/src/universe.rs` did exactly that; D-0029 and rows `U-01`…`U-05` are the correction, and the gap in the gate remains. |
 | Gate 8 ratios | absolute speed is acceptable — only that it did not degrade with input size |
 | `cargo deny` | a dependency is trustworthy — only that it is licensed and un-advised |
 | Property tests | the property is the right one |
@@ -218,3 +220,118 @@ UNVERIFIED and settleable from the predecessor's own audit log.
 assembled from broker and news secondary sources after nineteen attempts to
 fetch the official circular returned HTTP 403. No 2026 date is
 primary-verified, and 2026-01-15 above is the first one the data disputes.
+
+---
+
+## 10. ~~The equity gate is not symmetric between the vendors~~ — CLOSED by D-0025
+
+**This section recorded an asymmetry that no longer exists.** It is kept
+rather than deleted, because it also records what closed it.
+
+It said Dhan's `SERIES` column was "**not** read, because reading a second
+column to make the two vendors agree would be a guess about what that column
+means on every other row, and no measurement was taken of it", and that closing
+the asymmetry meant "measuring Dhan's `SERIES` alphabet first and recording the
+result — not adding the column because the numbers would look tidier".
+
+That measurement was taken. Dhan's `SERIES` is the same NSE board series Groww
+carries; no equity-segment row leaves it empty; and on the 4,080 shared ISINs
+the two vendors' board verdicts differ on **0**. The full table is in D-0025.
+The gate now reads it, and the SME decline is symmetric: **558** rows at Groww
+and **559** at Dhan, the same paper by ISIN.
+
+What the asymmetry had cost, before it was closed: 558 SME shares that Dhan
+kept and Groww declined entered the merged universe on one vendor's word, and
+`docs/06-limits.md` recorded only that half — the 54 mutual-fund plans Dhan's
+paper class called `ETF`, and the 30 surveillance and partly-paid equity series
+the Groww arm called debt, were not recorded anywhere.
+
+**Still unmeasured:** whether Groww's 209 suffixed symbols are stable between
+snapshots. The suffix strip is confirmed per run against the other vendor's
+ISIN, so a change would not corrupt anything — it would show up as instruments
+splitting into two rows, visibly, on the page. That the leak is *stable* is
+not claimed.
+
+---
+
+## 11. The instrument universes are snapshots, and lookup is O(log n)
+
+`crates/core/src/universe.rs`. D-0029.
+
+**Not constant time.** Membership is a `binary_search` over a sorted array —
+O(log n), at most ten comparisons on 750 entries. `CLAUDE.md` golden rule 4
+requires constant per-operation cost, and this is a departure from it, written
+down here rather than glossed. It is defensible because membership is asked
+**once per instrument at merge time and never once per bar**, so it is not on
+the path the rule protects; a perfect hash would make it O(1) and is not worth
+the machinery at this size. If a universe lookup ever moves onto the per-bar
+path, this entry is the reason it must be replaced first.
+
+**UNVERIFIED against any exchange source.** Neither list has been checked
+against an NSE constituent circular:
+
+| List | Size | Where it came from | Lane |
+|---|---:|---|---|
+| `NIFTY_TOTAL_MARKET` | 750 | transcribed from the local lake's NSE/CASH directories; matched the primary broker's equity list 750/750 | derived, unverified |
+| `FNO_UNDERLYINGS` | 213 | derived from both vendor masters, which agree exactly (213 each, zero on either side only) | derived, cross-checked, unverified |
+
+Both are **snapshots**, and index membership is rebalanced. A rebalance is not
+detected by anything here; it shows up as a member failing to resolve, which
+the report's census makes visible but does not explain.
+
+Measured against the real masters on 2026-08-01 under D-0025: 750 of 750 Total
+Market members and 208 of 213 F&O underlyings resolve as a kept equity in
+**both** vendors. The remaining five F&O underlyings are indices — see §12.
+
+---
+
+## 12. Index identity is not cross-checked at all
+
+D-0027. An index carries **no ISIN**, so the cross-check D-0024 added cannot
+reach it, and there is no second field to reconcile two vendors' spellings
+with.
+
+Measured: of the 35 merged NSE index keys, **four** are spelled identically by
+both masters — `NIFTY`, `BANKNIFTY`, `FINNIFTY`, `NIFTYIT`. The other 31 are
+named by one vendor only, and at least three pairs are the same index under two
+names:
+
+| Groww | Dhan | Consequence |
+|---|---|---|
+| `NIFTYJR` | `NIFTYNXT50` | held twice, each tagged with one vendor |
+| `NIFTYMIDSELECT` | `MIDCPNIFTY` | held twice; both are F&O underlyings |
+| `MIDCAP50` | `NIFTYMCAP50` | held twice |
+
+**211 of the 213 F&O underlyings are confirmed by both vendors; 2 rest on
+one.** No alias table is invented — see D-0027 for why — so the report names
+every single-vendor universe member on every run under `UNCHECKED IDENTITY`,
+and the census prints "resolved" and "confirmed by both vendors" as two
+separate numbers.
+
+This does **not** degrade the run. It is a permanent structural fact rather
+than a change, and a status that is `DEGRADED` on every run carries no
+information.
+
+**Neither swept instrument is affected.** `NSE-NIFTY` and `NSE-BANKNIFTY` are
+named identically by both vendors and carry two vendor tags.
+
+---
+
+## 13. Two things the reader still does not do
+
+**A declined row's ISIN is parsed leniently.** On a kept equity a bad ISIN is
+an error; on a declined row it yields no evidence and no complaint. The row is
+declined and counted under its reason either way, and the ISIN there is only
+ever used to notice that *another* vendor kept the same paper. The cost is that
+one specific cross-check is unavailable for a declined row whose ISIN does not
+parse — on the real masters that is exactly one row, `IN1520250085`, a state
+development loan both vendors decline anyway.
+
+**CSV fields are split on every comma, with no quote handling.** Measured: the
+Dhan master has 33 fields on all 200,460 rows and the Groww master has 21 on
+all 133,378, and **neither file contains a single `"` character**. So the naive
+split cannot shift a column on this data. The day a vendor quotes a company
+name containing a comma, the row's field count changes — which the shortfall
+check in `api::master::load` catches when the row gets *shorter*, and does not
+catch when it gets longer. A longer row would misread the columns after the
+quoted field. This is not fixed; it is measured, bounded and written down.


### PR DESCRIPTION
## What this fixes

An instrument the engine cannot name correctly is an instrument every later result is wrong about. Measured against the real vendor masters:

| Bug | Size | Status |
|---|---|---|
| Bonds/T-bills stored as NSE equities | **6,312 rows** | fixed |
| `CHOLAFIN` resolved to a **7.5% NCD**, not the share | 3 NIFTY Total Market members | fixed |
| Cross-vendor ticker disagreements | **209 → 0** | fixed |
| Page re-parsed 200,000 CSV rows per request | **150 ms → 0.6 ms** | fixed |
| Records straddling a CRC block boundary | 23 of first 2,000 | fixed |

`CHOLAFIN` matched two rows, both `SEGMENT=E INSTRUMENT=EQUITY`. The bond row precedes the share row in the file, so insert-if-absent silently won — and took its wrong tick size with it. Same for `MOTHERSON` and `ELECTCAST`.

## Design decisions worth reviewing

**ISIN sits beside `InstrumentKey`, never inside it.** As a key field, a vendor disagreement produces two keys and splits the merge map silently — the failure §4 forbids. Outside it, a disagreement halts loudly and names both.

**The equity gate reads the NSE board series**, the one column both vendors carry. Gating on Dhan's `INSTRUMENT_TYPE` kept 54 mutual funds as equities and dropped 30 genuine shares in `BZ`/`IT`/`SZ`/`E1`.

**Vendor is the first path segment.** Two vendors cannot collide; a symbol that would escape its prefix is unconstructible rather than sanitised. Paths are relative to a root, so the tree moves to another drive without rewriting a byte.

**The page defaults to the tracked universe (785) with an explicit link to every NSE listing (2,787).** A filter with no way past it hides a bug rather than a row.

## Gates

`fmt` clean · `clippy -D warnings` clean · **232 tests** · **11 doc-tests** · `cargo deny` clean

## Known, measured, recorded — not fixed here

All three are in `docs/06-limits.md` with their numbers:

| | Measured |
|---|---|
| `crc32c` is bit-by-bit; its `IntoIterator` signature forbids the fast paths | 15,622 ns/block vs **381.9 ns** for the ARMv8 instruction this CPU has — **41× available** |
| `Header::read_region` walks to exhaustion | 207 ns at 128 B → **10.3 ms at 256 MiB** |
| `TEST_MARKERS` scans unbounded vendor strings before `Symbol::new` bounds them, and **accepts** the row | 56 ns at 8 B → **245,839 ns at 4 MiB** |

The 41× needs a decision about `#![forbid(unsafe_code)]`, so it is not taken silently here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)